### PR TITLE
Rework CI

### DIFF
--- a/.github/actions/release-charts/action.yml
+++ b/.github/actions/release-charts/action.yml
@@ -1,0 +1,13 @@
+---
+
+name: "Release Helm Charts"
+description: "Host 2GIS on-premise Helm charts repo on GitHub Pages"
+author: "2GIS"
+runs:
+  using: composite
+  steps:
+    - run: |
+        export CHART_RELEASER_OWNER=$(cut -d '/' -f 1 <<< "$GITHUB_REPOSITORY")
+        export CHART_RELEASER_REPO=$(cut -d '/' -f 2 <<< "$GITHUB_REPOSITORY")
+        "$GITHUB_ACTION_PATH/release-charts.sh"
+      shell: bash

--- a/.github/actions/release-charts/release-charts.sh
+++ b/.github/actions/release-charts/release-charts.sh
@@ -1,0 +1,67 @@
+#!/bin/sh
+
+CHART_RELEASER_VERSION=v1.3.0
+
+# install chart-releaser
+if ! [ -d "$RUNNER_TOOL_CACHE" ] ; then
+    printf 'Cache directory "%s" does not exist\n' "$RUNNER_TOOL_CACHE"
+    exit 1
+fi
+
+arch="$(uname -m)"
+cache_dir="$RUNNER_TOOL_CACHE/ct/$CHART_RELEASER_VERSION/$arch"
+
+if ! [ -d "$cache_dir" ] ; then
+    mkdir -p "$cache_dir" || exit 1
+    curl -sSLo cr.tar.gz "https://github.com/helm/chart-releaser/releases/download/$CHART_RELEASER_VERSION/chart-releaser_${CHART_RELEASER_VERSION#v}_linux_amd64.tar.gz"
+    tar -xzf cr.tar.gz -C "$cache_dir"
+    rm -f cr.tar.gz
+fi
+
+printf 'Adding cr bin dir to PATH\n'
+export PATH="$cache_dir:$PATH"
+
+# ensure all chart versions match current tag
+exit_code=0
+for chart in ./charts/* ; do
+    if [ -d "$chart" ] ; then
+        chart_version=$(sed -n -e "s|^version: \(.*\)|\1|gp" "$chart/Chart.yaml")
+        if ! [ "$chart_version" = "$GITHUB_REF_NAME" ] ; then
+            printf 'Version (%s) of the chart %s does not match the tag (%s)\n' \
+                "$chart_version" \
+                "$chart" \
+                "$GITHUB_REF_NAME"
+            exit_code=1
+        fi
+    fi
+done
+if [ "$exit_code" -ne 0 ] ; then
+    exit "$exit_code"
+fi
+
+# package charts
+rm -rf .cr-release-packages
+mkdir -p .cr-release-packages || exit 1
+rm -rf .cr-index
+mkdir -p .cr-index || exit 1
+for chart in ./charts/* ; do
+    if [ -d "$chart" ] ; then
+        printf 'Packaging chart %s\n' "$chart"
+        cr package --package-path .cr-release-packages "$chart" || exit 1
+    fi
+done
+
+# upload releases
+cr upload \
+    -o "$CHART_RELEASER_OWNER" \
+    -r "$CHART_RELEASER_REPO" \
+    -c "$(git rev-parse HEAD)" \
+|| exit 1
+
+# update index
+cr index \
+    -o "$CHART_RELEASER_OWNER" \
+    -r "$CHART_RELEASER_REPO" \
+    -c "https://${CHART_RELEASER_OWNER}.github.io/${CHART_RELEASER_REPO}" \
+    --push \
+|| exit 1

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -20,4 +20,4 @@ jobs:
         uses: helm/chart-testing-action@v2.1.0
 
       - name: Run chart-testing (lint)
-        run: ct lint --target-branch master
+        run: ct lint --target-branch master --check-version-increment=false

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,8 +4,8 @@ name: Release Charts
 
 on:
   push:
-    branches:
-      - master
+    tags:
+      - "*"
 
 jobs:
   release:
@@ -21,7 +21,7 @@ jobs:
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
-      - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.2.1
+      - name: Release charts
+        uses: ./.github/actions/release-charts
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Переделываем процесс релиза чартов.

При lint'e не проверяем инкремент версии, тоесть в мастере изменения в чарте не обязательно сопровождаются изменением версии.

Меняем логику релиза чартов:
1. Запускаем job'у только в тэгах.
2. Проверяем что версия всех чартов в репозитории соответствует имени тэга.
3. Упаковываем, создаем релизы, обновляем индекс.