### PR TITLE
[gis-platform] Restart spcore on secrets change

### DIFF
--- a/charts/gis-platform/templates/gis-platform-spcore-sts.yaml
+++ b/charts/gis-platform/templates/gis-platform-spcore-sts.yaml
@@ -17,6 +17,7 @@ spec:
     metadata:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/gis-platform-spcore-configmap.yaml") . | sha256sum }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yml") . | sha256sum }}
       labels:
         {{- include "gis-platform-spcore.selectorLabels" . | nindent 8 }}
     spec:


### PR DESCRIPTION
Вдогонку к предыдущему моржу про отслеживание конфигмапа: спкор также зависит от секретов, надо перезапускаться при их изменении