### PR TITLE
Include rules as value or file

### DIFF
--- a/charts/navi-back/templates/_helpers.tpl
+++ b/charts/navi-back/templates/_helpers.tpl
@@ -91,3 +91,20 @@ Usage:
    {{ include "config.taxi" $ }}
 {{- end -}}
 {{- end -}}
+
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Renders a value or file that contains rules.
+Usage:
+{{ include "rules.renderRules" }}
+*/}}
+{{- define "rules.renderRules" -}}
+    {{- $rules_file_content := .Files.Get "rules.conf" }}
+    {{- if .Values.rules -}}
+        {{- .Values.rules | toPrettyJson | nindent 6 }}
+    {{- else if $rules_file_content  }}
+        {{- .Files.Get "rules.conf" |  nindent 6}}
+    {{- else }}
+        {{- fail "Rules value is not set or rules file is empty" }}
+    {{- end -}}
+{{- end -}}

--- a/charts/navi-back/templates/configmap.yaml
+++ b/charts/navi-back/templates/configmap.yaml
@@ -343,4 +343,6 @@ data:
       }
     }
   rules.conf: |-
-{{ .Files.Get "rules.conf" | indent 4 }}
+   {{- include "rules.renderRules" . }}
+
+

--- a/charts/navi-router/templates/_helpers.tpl
+++ b/charts/navi-router/templates/_helpers.tpl
@@ -75,3 +75,20 @@ Usage:
         {{- tpl (.value | toYaml) .context }}
     {{- end }}
 {{- end -}}
+
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Renders a value or file that contains rules.
+Usage:
+{{ include "rules.renderRules" }}
+*/}}
+{{- define "rules.renderRules" -}}
+    {{- $rules_file_content := .Files.Get "rules.conf" }}
+    {{- if .Values.rules -}}
+        {{- .Values.rules | toPrettyJson | nindent 6 }}
+    {{- else if $rules_file_content  }}
+        {{- .Files.Get "rules.conf" |  nindent 6}}
+    {{- else }}
+        {{- fail "Rules value is not set or rules file is empty" }}
+    {{- end -}}
+{{- end -}}

--- a/charts/navi-router/templates/configmap.yaml
+++ b/charts/navi-router/templates/configmap.yaml
@@ -65,5 +65,5 @@ data:
       }
     }
   rules.conf: |-
-{{ .Files.Get "rules.conf" | indent 4 }}
+    {{- include "rules.renderRules" . }}
 


### PR DESCRIPTION
@Fullmetal8ender @dekhtyarev   
Теперь можно подключать правила для navi-back и navi-router как value:
```
rules: 
    [ 
    {
      "name": "dammam_cr",
      "router_projects": [
          "dammam"
      ],
      "moses_projects": [
          "dammam"
      ],
      "projects": [
          "dammam"
      ],
      "queries": [
          "routing",
          "get_hull"
    
      ],
      "routing": [
          "driving"
      ]
    }
    ]
```
Если значение rules не определено, то будут браться значения из файла rules.conf. Если и его нет, то будет ошибка.