### PR TITLE
[gis-platform] Better secret/configmap checksum calculation

### DIFF
--- a/charts/gis-platform/templates/gis-platform-portal-dep.yaml
+++ b/charts/gis-platform/templates/gis-platform-portal-dep.yaml
@@ -12,7 +12,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: {{ include (print $.Template.BasePath "/gis-platform-portal-configmap.yaml") . | sha256sum }}
+        checksum/config: {{ (include (print $.Template.BasePath "/gis-platform-portal-configmap.yaml") . | fromYaml).data | toYaml | sha256sum }}
       labels:
         {{- include "gis-platform-portal.selectorLabels" . | nindent 8 }}
     spec:

--- a/charts/gis-platform/templates/gis-platform-spcore-sts.yaml
+++ b/charts/gis-platform/templates/gis-platform-spcore-sts.yaml
@@ -16,8 +16,8 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: {{ include (print $.Template.BasePath "/gis-platform-spcore-configmap.yaml") . | sha256sum }}
-        checksum/secret: {{ include (print $.Template.BasePath "/secret.yml") . | sha256sum }}
+        checksum/config: {{ (include (print $.Template.BasePath "/gis-platform-spcore-configmap.yaml") . | fromYaml).data | toYaml | sha256sum }}
+        checksum/secret: {{ (include (print $.Template.BasePath "/secret.yml") . | fromYaml).data | toYaml | sha256sum }}
       labels:
         {{- include "gis-platform-spcore.selectorLabels" . | nindent 8 }}
     spec:


### PR DESCRIPTION
При новых релизах у конфигмапы/секрета меняется версия хелмчарта в метаданных, из-за этого меняются чексуммы, и сервис перезапускается, даже если в конфиге реально изменений не было. В этом коммите я сделал так, что чексумма считается только от реальных данных, без учёта `metadata:`