### PR TITLE
Release 0.2.1

### DIFF
--- a/charts/catalog-api/Chart.yaml
+++ b/charts/catalog-api/Chart.yaml
@@ -3,7 +3,7 @@ name: catalog-api
 type: application
 description: A Helm chart for Kubernetes to deploy Catalog APIs
 
-version: 0.2.0
+version: 0.2.1
 appVersion: 3.557.4
 
 maintainers:

--- a/charts/gis-platform/Chart.yaml
+++ b/charts/gis-platform/Chart.yaml
@@ -6,7 +6,7 @@ description: GIS Platform
 
 type: application
 
-version: 0.2.0
+version: 0.2.1
 appVersion: 0.0.2
 
 dependencies:

--- a/charts/keys/Chart.yaml
+++ b/charts/keys/Chart.yaml
@@ -3,7 +3,7 @@ name: keys
 type: application
 description: A Helm chart for Kubernetes to deploy API Keys service
 
-version: 0.2.0
+version: 0.2.1
 appVersion: 1.23.5
 
 maintainers:

--- a/charts/mapgl-js-api/Chart.yaml
+++ b/charts/mapgl-js-api/Chart.yaml
@@ -6,7 +6,7 @@ description: Basic WebGL map chart template for 2GIS On-Premise
 
 type: application
 
-version: 0.2.0
+version: 0.2.1
 appVersion: 1.24.1
 
 maintainers:

--- a/charts/navi-back/Chart.yaml
+++ b/charts/navi-back/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
   - navi
   - back
   - backend
-version: 0.2.0
+version: 0.2.1
 appVersion: "6.3.0"
 maintainers:
   - name: 2gis

--- a/charts/navi-castle/Chart.yaml
+++ b/charts/navi-castle/Chart.yaml
@@ -4,7 +4,7 @@ description: Castle Helm chart for Kubernetes
 type: application
 
 
-version: 0.2.0
+version: 0.2.1
 appVersion: "1.0.2"
 
 maintainers:

--- a/charts/navi-front/Chart.yaml
+++ b/charts/navi-front/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 keywords:
   - navi
   - front
-version: 0.2.0
+version: 0.2.1
 appVersion: "1.16.0"
 maintainers:
   - name: 2gis

--- a/charts/navi-router/Chart.yaml
+++ b/charts/navi-router/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 keywords:
   - navi
   - router
-version: 0.2.0
+version: 0.2.1
 appVersion: "6.3.0"
 maintainers:
   - name: 2gis

--- a/charts/proxy-traffic-jams/Chart.yaml
+++ b/charts/proxy-traffic-jams/Chart.yaml
@@ -6,7 +6,7 @@ description: A Helm chart for Kubernetes to deploy Proxy for traffic jams
 
 type: application
 
-version: 0.2.0
+version: 0.2.1
 appVersion: 0.0.1
 
 maintainers:

--- a/charts/search-api/Chart.yaml
+++ b/charts/search-api/Chart.yaml
@@ -6,7 +6,7 @@ description: Search engine for catalog
 
 type: application
 
-version: 0.2.0
+version: 0.2.1
 appVersion: 1.0.0
 
 maintainers:

--- a/charts/tiles-api/Chart.yaml
+++ b/charts/tiles-api/Chart.yaml
@@ -6,7 +6,7 @@ description: Tiles API for getting cartographic data
 
 type: application
 
-version: 0.2.0
+version: 0.2.1
 appVersion: 4.19.2
 
 maintainers:


### PR DESCRIPTION
При подготовке 0.2.0 в datagateway не залились докер-образы, релиз опубликовался пустой. Бамп версии для фикса, т.к. фарш невозможно провернуть назад