### PR TITLE
[gis-platform] Enable isochrones support

### DIFF
--- a/charts/gis-platform/configs/spcore/SPCore.json.template
+++ b/charts/gis-platform/configs/spcore/SPCore.json.template
@@ -39,16 +39,9 @@
   "routes": {
       "TwoGisProviders": [
          {
-             "name": "2gis",
-             "type": "2gis",
-             "url": "${GIS_PLATFORM_CATALOG_URL}",
-             "token": "${GIS_PLATFORM_CATALOG_KEY}",
-             "mode": "walking"
-         },
-         {
              "name": "2gis-carrouting",
              "type": "2gis",
-             "url": "${GIS_PLATFORM_CATALOG_URL}",
+             "url": "${GIS_PLATFORM_NAVI_URL}",
              "token": "${GIS_PLATFORM_CATALOG_KEY}",
              "mode": "driving"
          }

--- a/charts/gis-platform/gis-platform-config/configuration/MapConfig.json
+++ b/charts/gis-platform/gis-platform-config/configuration/MapConfig.json
@@ -66,6 +66,20 @@
             "description": "Построение окружностей заданного радиуса вокруг объектов слоя"
           },
           {
+            "name": "availabilityArea",
+            "title": "Availability Area",
+            "options": {
+              "solvers": [
+                {
+                  "text": "Driving",
+                  "value": "2gis-carrouting"
+                }
+              ]
+            },
+            "imageName": "access",
+            "description": "Построение изохрон автомобильной доступности"
+          },
+          {
             "name": "geometrySelection",
             "title": "Выборка геометрией",
             "imageName": "geometrySelection",

--- a/charts/gis-platform/templates/gis-platform-spcore-sts.yaml
+++ b/charts/gis-platform/templates/gis-platform-spcore-sts.yaml
@@ -67,6 +67,8 @@ spec:
           env:
           - name: GIS_PLATFORM_CATALOG_URL
             value: {{ .Values.spcore.catalog.url }}
+          - name: GIS_PLATFORM_NAVI_URL
+            value: {{ .Values.spcore.navi.url }}
           - name: GIS_PLATFORM_CATALOG_KEY
             valueFrom:
               secretKeyRef:

--- a/charts/gis-platform/values.yaml
+++ b/charts/gis-platform/values.yaml
@@ -52,6 +52,8 @@ spcore:
   catalog:
     url: https://catalog.api.2gis.com
     key: ''
+  navi:
+    url: https://catalog.api.2gis.com
   cloud_port: 5050
   http_port: 5051
   maxRenderTargets: 1000


### PR DESCRIPTION
Включаем поддержку автомобильных изохрон. Т.к. каталог пока что не умеет проксировать нави, то пришлось добавить отдельную переменную в values.