### PR TITLE
[tiles-api] Add cassandra env name to keyspace

### DIFF
--- a/charts/tiles-api/README.md
+++ b/charts/tiles-api/README.md
@@ -75,7 +75,7 @@ helm upgrade testing 2gis-on-premise/tiles-api --atomic --timeout=60m -f ./custo
 | cassandra.consistencyLevelRead | string | `"LOCAL_QUORUM"` | Consistency level for database read queries. All possible values can be viewed by [link](https://docs.datastax.com/en/cassandra-oss/3.0/cassandra/dml/dmlConfigConsistency.html#Readconsistencylevels) |
 | cassandra.consistencyLevelWrite | string | `"LOCAL_QUORUM"` | Consistency level for database write queries. All possible values can be viewed by [link](https://docs.datastax.com/en/cassandra-oss/3.0/cassandra/dml/dmlConfigConsistency.html#Writeconsistencylevels) |
 | cassandra.credentials | object | `{"password":"cassandra","user":"cassandra"}` | Credentials for Cassandra authentication |
-| cassandra.environment | string | `"prod"` | Environment name (prod, stage, etc) allows creating multiple environments on a single cassandra cluster |
+| cassandra.environment | string | `""` | Environment name (prod, stage, etc) allows creating multiple environments on a single cassandra cluster |
 | cassandra.hosts | list | `[]` | List of available Cassandra database nodes |
 | cassandra.replicaFactor | int | `3` | Replication factor for Cassandra |
 | dgctlDockerRegistry | string | `""` |  |

--- a/charts/tiles-api/README.md
+++ b/charts/tiles-api/README.md
@@ -31,12 +31,6 @@ helm upgrade testing 2gis-on-premise/tiles-api --atomic --timeout=60m -f ./custo
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| dgctlDockerRegistry | string | `""` | docker registry server name  |
-| dgctlStorage.host | string | `""` | host:port of S3 server  |
-| dgctlStorage.bucket | string | `""` | S3 bucket  |
-| dgctlStorage.accessKey | string | `""` | S3 access key  |
-| dgctlStorage.secretKey | string | `""` | S3 secret key |
-| dgctlStorage.manifest | string | `""` | Path to the manifest in S3-like storage. The manifest is downloaded via the dgctl utility |
 | api.affinity | object | `{}` |  |
 | api.annotations | object | `{}` |  |
 | api.containerPort | int | `8000` |  |
@@ -44,8 +38,10 @@ helm upgrade testing 2gis-on-premise/tiles-api --atomic --timeout=60m -f ./custo
 | api.hpa.maxReplicas | int | `1` |  |
 | api.hpa.minReplicas | int | `1` |  |
 | api.hpa.targetCPUUtilizationPercentage | int | `50` |  |
-| api.image | string | `"on-premise/tiles-api"` | The path to the docker image. Must have a path to your private docker registry |
-| api.imagePullSecrets | object | `{}` |  |
+| api.image.pullPolicy | string | `"IfNotPresent"` |  |
+| api.image.repository | string | `"2gis-on-premise/tiles-api"` |  |
+| api.image.tag | string | `"v4.19.2"` |  |
+| api.imagePullSecrets | list | `[]` |  |
 | api.ingress.className | string | `"nginx"` |  |
 | api.ingress.enabled | bool | `false` |  |
 | api.ingress.hosts[0].host | string | `"tiles-api.loc"` |  |
@@ -57,7 +53,6 @@ helm upgrade testing 2gis-on-premise/tiles-api --atomic --timeout=60m -f ./custo
 | api.pdb.maxUnavailable | int | `1` |  |
 | api.podAnnotations | object | `{}` |  |
 | api.podLabels | object | `{}` |  |
-| api.pullPolicy | string | `"IfNotPresent"` |  |
 | api.replicaCount | int | `3` |  |
 | api.resources.limits.cpu | int | `1` |  |
 | api.resources.limits.memory | string | `"512Mi"` |  |
@@ -70,7 +65,6 @@ helm upgrade testing 2gis-on-premise/tiles-api --atomic --timeout=60m -f ./custo
 | api.service.type | string | `"ClusterIP"` |  |
 | api.strategy.rollingUpdate.maxSurge | int | `1` |  |
 | api.strategy.rollingUpdate.maxUnavailable | int | `0` |  |
-| api.tag | string | `"v4.19.0"` | Tag with application version |
 | api.terminationGracePeriodSeconds | int | `30` |  |
 | api.tolerations | object | `{}` |  |
 | api.vpa.enabled | bool | `false` |  |
@@ -81,18 +75,25 @@ helm upgrade testing 2gis-on-premise/tiles-api --atomic --timeout=60m -f ./custo
 | cassandra.consistencyLevelRead | string | `"LOCAL_QUORUM"` | Consistency level for database read queries. All possible values can be viewed by [link](https://docs.datastax.com/en/cassandra-oss/3.0/cassandra/dml/dmlConfigConsistency.html#Readconsistencylevels) |
 | cassandra.consistencyLevelWrite | string | `"LOCAL_QUORUM"` | Consistency level for database write queries. All possible values can be viewed by [link](https://docs.datastax.com/en/cassandra-oss/3.0/cassandra/dml/dmlConfigConsistency.html#Writeconsistencylevels) |
 | cassandra.credentials | object | `{"password":"cassandra","user":"cassandra"}` | Credentials for Cassandra authentication |
+| cassandra.environment | string | `"prod"` | Environment name (prod, stage, etc) allows creating multiple environments on a single cassandra cluster |
 | cassandra.hosts | list | `[]` | List of available Cassandra database nodes |
 | cassandra.replicaFactor | int | `3` | Replication factor for Cassandra |
+| dgctlDockerRegistry | string | `""` |  |
+| dgctlStorage.accessKey | string | `""` |  |
+| dgctlStorage.bucket | string | `""` |  |
+| dgctlStorage.host | string | `""` |  |
+| dgctlStorage.manifest | string | `""` |  |
+| dgctlStorage.secretKey | string | `""` |  |
 | importer.enabled | bool | `true` |  |
-| importer.image | string | `"on-premise/tiles-api-importer"` | The path to the docker image. Must have a path to your private docker registry |
-| importer.imagePullSecrets | object | `{}` |  |
+| importer.image.pullPolicy | string | `"IfNotPresent"` |  |
+| importer.image.repository | string | `"2gis-on-premise/tiles-api-importer"` |  |
+| importer.image.tag | string | `"v4.19.2"` |  |
+| importer.imagePullSecrets | list | `[]` |  |
 | importer.nodeSelector | object | `{}` |  |
-| importer.pullPolicy | string | `"IfNotPresent"` |  |
 | importer.resources.limits.cpu | string | `"100m"` |  |
 | importer.resources.limits.memory | string | `"256Mi"` |  |
 | importer.resources.requests.cpu | string | `"50m"` |  |
 | importer.resources.requests.memory | string | `"128Mi"` |  |
-| importer.tag | string | `"v4.19.0"` | Tag with application version |
 | importer.tolerations | object | `{}` |  |
 | importer.workerNum | int | `6` | Number of parallel import processes (spawned jobs) |
 | importer.workerResources.limits.cpu | int | `2` |  |
@@ -103,14 +104,16 @@ helm upgrade testing 2gis-on-premise/tiles-api --atomic --timeout=60m -f ./custo
 | name | string | `"tiles-api"` |  |
 | proxy.access.enabled | bool | `false` | Flag to enable verification access key |
 | proxy.access.host | string | `"http://keys-api.localhost"` | Host for Keys API service |
+| proxy.access.syncPeriod | string | `"2m"` |  |
 | proxy.access.token | string | `""` | Service key for Keys API |
 | proxy.containerPort | int | `5000` |  |
-| proxy.image | string | `"on-premise/tiles-api-proxy"` | The path to the docker image. Must have a path to your private docker registry |
+| proxy.image.pullPolicy | string | `"IfNotPresent"` |  |
+| proxy.image.repository | string | `"2gis-on-premise/tiles-api-proxy"` |  |
+| proxy.image.tag | string | `"v4.19.2"` |  |
 | proxy.resources.limits.cpu | int | `1` |  |
 | proxy.resources.limits.memory | string | `"512Mi"` |  |
 | proxy.resources.requests.cpu | string | `"50m"` |  |
 | proxy.resources.requests.memory | string | `"128Mi"` |  |
-| proxy.tag | string | `"v4.19.0"` | Tag with application version |
 | proxy.timeout | string | `"5s"` |  |
 | serviceName | string | `"tiles-api-webgl"` |  |
 | type | string | `"web"` |  |
@@ -119,4 +122,4 @@ helm upgrade testing 2gis-on-premise/tiles-api --atomic --timeout=60m -f ./custo
 
 | Name | Email | Url |
 | ---- | ------ | --- |
-| 2gis | on-premise@2gis.com | https://github.com/2gis |
+| 2gis | <on-premise@2gis.com> | <https://github.com/2gis> |

--- a/charts/tiles-api/configs/api.yaml
+++ b/charts/tiles-api/configs/api.yaml
@@ -19,7 +19,7 @@ cassandra-clusters:
 
     keyspaces:
       - tileset: {{ .Values.type }}
-        keyspace: dgis_tileserver_{{ .Values.type }}_{{ .Values.cassandra.environment }}_{{ include "tiles.manifestCode" . }}
+        keyspace: dgis_tileserver_{{ .Values.type }}_{{ required "Valid .Values.cassandra.environment required" .Values.cassandra.environment }}_{{ include "tiles.manifestCode" . }}
         default: true
         partition-size: 4
 

--- a/charts/tiles-api/configs/api.yaml
+++ b/charts/tiles-api/configs/api.yaml
@@ -19,7 +19,7 @@ cassandra-clusters:
 
     keyspaces:
       - tileset: {{ .Values.type }}
-        keyspace: dgis_tileserver_{{ .Values.type }}_{{ include "tiles.manifestCode" . }}
+        keyspace: dgis_tileserver_{{ .Values.type }}_{{ .Values.cassandra.environment }}_{{ include "tiles.manifestCode" . }}
         default: true
         partition-size: 4
 

--- a/charts/tiles-api/configs/importer/importer.yaml
+++ b/charts/tiles-api/configs/importer/importer.yaml
@@ -17,7 +17,7 @@ cassandra:
 
   keyspaces:
     - tileset: {{ .Values.type }}
-      keyspace: dgis_tileserver_{{ .Values.type }}_{{ .Values.cassandra.environment }}_{{ include "tiles.manifestCode" . }}
+      keyspace: dgis_tileserver_{{ .Values.type }}_{{ required "Valid .Values.cassandra.environment required" .Values.cassandra.environment }}_{{ include "tiles.manifestCode" . }}
       default: true
       partition-size: 4
 

--- a/charts/tiles-api/configs/importer/importer.yaml
+++ b/charts/tiles-api/configs/importer/importer.yaml
@@ -17,7 +17,7 @@ cassandra:
 
   keyspaces:
     - tileset: {{ .Values.type }}
-      keyspace: dgis_tileserver_{{ .Values.type}}_{{ include "tiles.manifestCode" . }}
+      keyspace: dgis_tileserver_{{ .Values.type }}_{{ .Values.cassandra.environment }}_{{ include "tiles.manifestCode" . }}
       default: true
       partition-size: 4
 

--- a/charts/tiles-api/values.yaml
+++ b/charts/tiles-api/values.yaml
@@ -13,7 +13,7 @@ type: web
 
 cassandra:
   # -- Environment name (prod, stage, etc) allows creating multiple environments on a single cassandra cluster
-  environment: prod
+  environment: ''
 
   # -- List of available Cassandra database nodes
   hosts: []

--- a/charts/tiles-api/values.yaml
+++ b/charts/tiles-api/values.yaml
@@ -12,6 +12,9 @@ name: tiles-api
 type: web
 
 cassandra:
+  # -- Environment name (prod, stage, etc) allows creating multiple environments on a single cassandra cluster
+  environment: prod
+
   # -- List of available Cassandra database nodes
   hosts: []
 


### PR DESCRIPTION
Добавил возможность указать название окружения, чтобы сделать несколько окружений на одном кластере кассандры. Теперь название кейспейса зависит от названия окружения