### PR TITLE
[tiles-api] Cassandra cleaning

### DIFF
--- a/charts/tiles-api/Chart.yaml
+++ b/charts/tiles-api/Chart.yaml
@@ -5,7 +5,7 @@ description: Tiles API for getting cartographic data
 type: application
 
 version: 1.1.2
-appVersion: 4.21.1
+appVersion: 4.22.0
 
 maintainers:
 - name: 2gis

--- a/charts/tiles-api/README.md
+++ b/charts/tiles-api/README.md
@@ -92,6 +92,7 @@ helm upgrade testing 2gis-on-premise/tiles-api --atomic --timeout=60m -f ./custo
 | importer.cleaner.resources.limits.memory | string | `"512Mi"` |  |
 | importer.cleaner.resources.requests.cpu | string | `"50m"` |  |
 | importer.cleaner.resources.requests.memory | string | `"128Mi"` |  |
+| importer.clearSnapshots | bool | `false` | In case of removing keyspace also remove its snapshots (using `nodetool clearsnapshot` over JMX) |
 | importer.enabled | bool | `true` |  |
 | importer.forceImport | bool | `false` | Delete existing keyspace and make imports if true, otherwise skip imports |
 | importer.image.pullPolicy | string | `"IfNotPresent"` |  |

--- a/charts/tiles-api/README.md
+++ b/charts/tiles-api/README.md
@@ -75,6 +75,8 @@ helm upgrade testing 2gis-on-premise/tiles-api --atomic --timeout=60m -f ./custo
 | cassandra.consistencyLevelRead | string | `"LOCAL_QUORUM"` | Consistency level for database read queries. All possible values can be viewed by [link](https://docs.datastax.com/en/cassandra-oss/3.0/cassandra/dml/dmlConfigConsistency.html#Readconsistencylevels) |
 | cassandra.consistencyLevelWrite | string | `"LOCAL_QUORUM"` | Consistency level for database write queries. All possible values can be viewed by [link](https://docs.datastax.com/en/cassandra-oss/3.0/cassandra/dml/dmlConfigConsistency.html#Writeconsistencylevels) |
 | cassandra.credentials | object | `{"jmxPassword":"cassandra","jmxUser":"cassandra","password":"cassandra","user":"cassandra"}` | Credentials for Cassandra authentication |
+| cassandra.credentials.jmxUser | string | `"cassandra"` | user / password for JMX queries (like calling nodetool) |
+| cassandra.credentials.user | string | `"cassandra"` | user / password for CQL queries (read/write to database) |
 | cassandra.environment | string | `""` | Environment name (prod, stage, etc) allows creating multiple environments on a single cassandra cluster |
 | cassandra.hosts | list | `[]` | List of available Cassandra database nodes |
 | cassandra.replicaFactor | int | `3` | Replication factor for Cassandra |
@@ -84,14 +86,14 @@ helm upgrade testing 2gis-on-premise/tiles-api --atomic --timeout=60m -f ./custo
 | dgctlStorage.host | string | `""` |  |
 | dgctlStorage.manifest | string | `""` |  |
 | dgctlStorage.secretKey | string | `""` |  |
-| importer.cleaner.enabled | bool | `false` |  |
-| importer.cleaner.limit | int | `3` |  |
+| importer.cleaner.enabled | bool | `false` | Enables cassandra previous tilesets cleaning before making new imports |
+| importer.cleaner.limit | int | `3` | How many old tilesets leave untouched, minimum 1 |
 | importer.cleaner.resources.limits.cpu | string | `"1000m"` |  |
 | importer.cleaner.resources.limits.memory | string | `"512Mi"` |  |
 | importer.cleaner.resources.requests.cpu | string | `"50m"` |  |
 | importer.cleaner.resources.requests.memory | string | `"128Mi"` |  |
 | importer.enabled | bool | `true` |  |
-| importer.forceImport | bool | `false` |  |
+| importer.forceImport | bool | `false` | Delete existing keyspace and make imports if true, otherwise skip imports |
 | importer.image.pullPolicy | string | `"IfNotPresent"` |  |
 | importer.image.repository | string | `"2gis-on-premise/tiles-api-importer"` |  |
 | importer.image.tag | string | `"v4.21.0"` |  |

--- a/charts/tiles-api/README.md
+++ b/charts/tiles-api/README.md
@@ -40,7 +40,7 @@ helm upgrade testing 2gis-on-premise/tiles-api --atomic --timeout=60m -f ./custo
 | api.hpa.targetCPUUtilizationPercentage | int | `50` |  |
 | api.image.pullPolicy | string | `"IfNotPresent"` |  |
 | api.image.repository | string | `"2gis-on-premise/tiles-api"` |  |
-| api.image.tag | string | `"v4.21.0"` |  |
+| api.image.tag | string | `"v4.22.0"` |  |
 | api.imagePullSecrets | list | `[]` |  |
 | api.ingress.className | string | `"nginx"` |  |
 | api.ingress.enabled | bool | `false` |  |
@@ -97,7 +97,7 @@ helm upgrade testing 2gis-on-premise/tiles-api --atomic --timeout=60m -f ./custo
 | importer.forceImport | bool | `false` | Delete existing keyspace and make imports if true, otherwise skip imports |
 | importer.image.pullPolicy | string | `"IfNotPresent"` |  |
 | importer.image.repository | string | `"2gis-on-premise/tiles-api-importer"` |  |
-| importer.image.tag | string | `"v4.21.0"` |  |
+| importer.image.tag | string | `"v4.22.0"` |  |
 | importer.imagePullSecrets | list | `[]` |  |
 | importer.nodeSelector | object | `{}` |  |
 | importer.resources.limits.cpu | string | `"100m"` |  |
@@ -119,7 +119,7 @@ helm upgrade testing 2gis-on-premise/tiles-api --atomic --timeout=60m -f ./custo
 | proxy.containerPort | int | `5000` |  |
 | proxy.image.pullPolicy | string | `"IfNotPresent"` |  |
 | proxy.image.repository | string | `"2gis-on-premise/tiles-api-proxy"` |  |
-| proxy.image.tag | string | `"v4.21.0"` |  |
+| proxy.image.tag | string | `"v4.22.0"` |  |
 | proxy.resources.limits.cpu | int | `1` |  |
 | proxy.resources.limits.memory | string | `"512Mi"` |  |
 | proxy.resources.requests.cpu | string | `"50m"` |  |

--- a/charts/tiles-api/README.md
+++ b/charts/tiles-api/README.md
@@ -40,7 +40,7 @@ helm upgrade testing 2gis-on-premise/tiles-api --atomic --timeout=60m -f ./custo
 | api.hpa.targetCPUUtilizationPercentage | int | `50` |  |
 | api.image.pullPolicy | string | `"IfNotPresent"` |  |
 | api.image.repository | string | `"2gis-on-premise/tiles-api"` |  |
-| api.image.tag | string | `"v4.19.2"` |  |
+| api.image.tag | string | `"v4.21.0"` |  |
 | api.imagePullSecrets | list | `[]` |  |
 | api.ingress.className | string | `"nginx"` |  |
 | api.ingress.enabled | bool | `false` |  |
@@ -74,7 +74,7 @@ helm upgrade testing 2gis-on-premise/tiles-api --atomic --timeout=60m -f ./custo
 | api.vpa.updateMode | string | `"Auto"` |  |
 | cassandra.consistencyLevelRead | string | `"LOCAL_QUORUM"` | Consistency level for database read queries. All possible values can be viewed by [link](https://docs.datastax.com/en/cassandra-oss/3.0/cassandra/dml/dmlConfigConsistency.html#Readconsistencylevels) |
 | cassandra.consistencyLevelWrite | string | `"LOCAL_QUORUM"` | Consistency level for database write queries. All possible values can be viewed by [link](https://docs.datastax.com/en/cassandra-oss/3.0/cassandra/dml/dmlConfigConsistency.html#Writeconsistencylevels) |
-| cassandra.credentials | object | `{"password":"cassandra","user":"cassandra"}` | Credentials for Cassandra authentication |
+| cassandra.credentials | object | `{"jmxPassword":"cassandra","jmxUser":"cassandra","password":"cassandra","user":"cassandra"}` | Credentials for Cassandra authentication |
 | cassandra.environment | string | `""` | Environment name (prod, stage, etc) allows creating multiple environments on a single cassandra cluster |
 | cassandra.hosts | list | `[]` | List of available Cassandra database nodes |
 | cassandra.replicaFactor | int | `3` | Replication factor for Cassandra |
@@ -84,10 +84,17 @@ helm upgrade testing 2gis-on-premise/tiles-api --atomic --timeout=60m -f ./custo
 | dgctlStorage.host | string | `""` |  |
 | dgctlStorage.manifest | string | `""` |  |
 | dgctlStorage.secretKey | string | `""` |  |
+| importer.cleaner.enabled | bool | `false` |  |
+| importer.cleaner.limit | int | `3` |  |
+| importer.cleaner.resources.limits.cpu | string | `"1000m"` |  |
+| importer.cleaner.resources.limits.memory | string | `"512Mi"` |  |
+| importer.cleaner.resources.requests.cpu | string | `"50m"` |  |
+| importer.cleaner.resources.requests.memory | string | `"128Mi"` |  |
 | importer.enabled | bool | `true` |  |
+| importer.forceImport | bool | `false` |  |
 | importer.image.pullPolicy | string | `"IfNotPresent"` |  |
 | importer.image.repository | string | `"2gis-on-premise/tiles-api-importer"` |  |
-| importer.image.tag | string | `"v4.19.2"` |  |
+| importer.image.tag | string | `"v4.21.0"` |  |
 | importer.imagePullSecrets | list | `[]` |  |
 | importer.nodeSelector | object | `{}` |  |
 | importer.resources.limits.cpu | string | `"100m"` |  |
@@ -109,7 +116,7 @@ helm upgrade testing 2gis-on-premise/tiles-api --atomic --timeout=60m -f ./custo
 | proxy.containerPort | int | `5000` |  |
 | proxy.image.pullPolicy | string | `"IfNotPresent"` |  |
 | proxy.image.repository | string | `"2gis-on-premise/tiles-api-proxy"` |  |
-| proxy.image.tag | string | `"v4.19.2"` |  |
+| proxy.image.tag | string | `"v4.21.0"` |  |
 | proxy.resources.limits.cpu | int | `1` |  |
 | proxy.resources.limits.memory | string | `"512Mi"` |  |
 | proxy.resources.requests.cpu | string | `"50m"` |  |

--- a/charts/tiles-api/configs/importer/importer.yaml
+++ b/charts/tiles-api/configs/importer/importer.yaml
@@ -4,6 +4,7 @@ service-name: {{ .Values.serviceName }}
 workers: {{ .Values.importer.workerNum }}
 data-type: {{ .Values.type }}
 force-import: {{ .Values.importer.forceImport }}
+clear-snapshots: {{ .Values.importer.clearSnapshots }}
 
 credentials:
   user: {{ .Values.cassandra.credentials.user }}

--- a/charts/tiles-api/configs/importer/importer.yaml
+++ b/charts/tiles-api/configs/importer/importer.yaml
@@ -3,11 +3,13 @@ migrations-path: "/migrations"
 service-name: {{ .Values.serviceName }}
 workers: {{ .Values.importer.workerNum }}
 data-type: {{ .Values.type }}
-
+force-import: {{ .Values.importer.forceImport }}
 
 credentials:
   user: {{ .Values.cassandra.credentials.user }}
   password: {{ .Values.cassandra.credentials.password }}
+  jmx-user: {{ .Values.cassandra.credentials.jmxUser }}
+  jmx-password: {{ .Values.cassandra.credentials.jmxPassword }}
 
 cassandra:
   name: local
@@ -42,6 +44,9 @@ k8s:
   worker-image: {{ required "A valid .Values.dgctlDockerRegistry entry required" $.Values.dgctlDockerRegistry }}/{{ .image.repository }}:{{ .image.tag }}
   {{- end }}
   namespace: {{ .Release.Namespace }}
+
+cleaner:
+  limit: {{ .Values.importer.cleaner.limit }}
 
 worker:
   temp-dir: /tmp

--- a/charts/tiles-api/templates/cassandra-cleaner-job.yaml
+++ b/charts/tiles-api/templates/cassandra-cleaner-job.yaml
@@ -1,27 +1,27 @@
-{{- if .Values.importer.enabled }}
+{{- if .Values.importer.cleaner.enabled }}
 ---
 
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name:  {{ include "tiles.fullname" . }}-importer-job
+  name: {{ include "tiles.fullname" . }}-cleaner-job
   labels:
     {{- include "tiles.labels" . | nindent 4 }}
   annotations:
     {{- include "importer.removable-hook-annotations" . | nindent 4 }}
-    "helm.sh/hook-weight": "2" # after cleaning
+    "helm.sh/hook-weight": "1" # before imports
 
 spec:
   backoffLimit: 0
   template:
     metadata:
-      name: {{ include "tiles.fullname" . }}-importer
+      name: {{ include "tiles.fullname" . }}-cleaner
     spec:
       serviceAccountName: {{ include "tiles.fullname" . }}
 
       volumes:
         - name: tmp-volume
-          emptyDir: {}
+          emptyDir: { }
 
         - name: config-volume
           configMap:
@@ -43,12 +43,13 @@ spec:
       {{- end }}
 
       containers:
-        - name: importer
+        - name: cleaner-job
 
           {{- with $.Values.importer }}
           image: {{ required "A valid .Values.dgctlDockerRegistry entry required" $.Values.dgctlDockerRegistry }}/{{ .image.repository }}:{{ .image.tag }}
           imagePullPolicy: {{ .image.pullPolicy }}
-          command: ["/selfimporter", "scheduler"]
+          command: [ "/selfimporter", "clear" ]
+          {{- end}}
 
           volumeMounts:
             - name: tmp-volume
@@ -57,7 +58,7 @@ spec:
             - mountPath: "/config"
               name: config-volume
 
-          {{- with .resources }}
+          {{- with .Values.importer.cleaner.resources }}
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
@@ -65,18 +66,5 @@ spec:
           env:
             - name: CONFIG_PATH
               value: /config/importer.yaml
-            - name: STORAGE_ACCESS_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "tiles.fullname" $ }}
-                  key: s3AccessKey
-            - name: STORAGE_SECRET_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "tiles.fullname" $ }}
-                  key: s3SecretKey
-
-          {{- end}}
-
       restartPolicy: Never
 {{- end }}

--- a/charts/tiles-api/templates/import.configmap.yaml
+++ b/charts/tiles-api/templates/import.configmap.yaml
@@ -8,7 +8,6 @@ metadata:
     {{- include "tiles.labels" . | nindent 4 }}
   annotations:
     {{- include "importer.removable-hook-annotations" . | nindent 4 }}
-    "helm.sh/hook-weight": "-1"
 
 data:
   {{ (tpl (.Files.Glob "configs/importer/*").AsConfig $) | nindent 2 }}

--- a/charts/tiles-api/values.yaml
+++ b/charts/tiles-api/values.yaml
@@ -20,10 +20,10 @@ cassandra:
 
   # -- Credentials for Cassandra authentication
   credentials:
-    # user / password for CQL queries (read/write to database)
+    # -- user / password for CQL queries (read/write to database)
     user: cassandra
     password: cassandra
-    # user / password for JMX queries (like calling nodetool)
+    # -- user / password for JMX queries (like calling nodetool)
     jmxUser: cassandra
     jmxPassword: cassandra
 
@@ -153,7 +153,7 @@ importer:
   # -- Number of write processes per import process
   writerNum: 8
 
-  # Delete existing keyspace and make imports if true, otherwise skip imports
+  # -- Delete existing keyspace and make imports if true, otherwise skip imports
   forceImport: false
 
   tolerations: {}
@@ -169,10 +169,10 @@ importer:
       memory: 2048Mi
 
   cleaner:
-    # Enables cassandra previous tilesets cleaning before making new imports
+    # -- Enables cassandra previous tilesets cleaning before making new imports
     enabled: false
 
-    # How many old tilesets leave untouched, minimum 1
+    # -- How many old tilesets leave untouched, minimum 1
     limit: 3
 
     resources:

--- a/charts/tiles-api/values.yaml
+++ b/charts/tiles-api/values.yaml
@@ -20,8 +20,12 @@ cassandra:
 
   # -- Credentials for Cassandra authentication
   credentials:
+    # user / password for CQL queries (read/write to database)
     user: cassandra
     password: cassandra
+    # user / password for JMX queries (like calling nodetool)
+    jmxUser: cassandra
+    jmxPassword: cassandra
 
   # -- Replication factor for Cassandra
   replicaFactor: 3
@@ -149,6 +153,9 @@ importer:
   # -- Number of write processes per import process
   writerNum: 8
 
+  # Delete existing keyspace and make imports if true, otherwise skip imports
+  forceImport: false
+
   tolerations: {}
   imagePullSecrets: []
 
@@ -160,3 +167,18 @@ importer:
     limits:
       cpu: 2
       memory: 2048Mi
+
+  cleaner:
+    # Enables cassandra previous tilesets cleaning before making new imports
+    enabled: false
+
+    # How many old tilesets leave untouched, minimum 1
+    limit: 3
+
+    resources:
+      requests:
+        cpu: 50m
+        memory: 128Mi
+      limits:
+        cpu: 1000m
+        memory: 512Mi

--- a/charts/tiles-api/values.yaml
+++ b/charts/tiles-api/values.yaml
@@ -156,6 +156,9 @@ importer:
   # -- Delete existing keyspace and make imports if true, otherwise skip imports
   forceImport: false
 
+  # -- In case of removing keyspace also remove its snapshots (using `nodetool clearsnapshot` over JMX)
+  clearSnapshots: false
+
   tolerations: {}
   imagePullSecrets: []
 

--- a/charts/tiles-api/values.yaml
+++ b/charts/tiles-api/values.yaml
@@ -39,7 +39,7 @@ cassandra:
 proxy:
   image:
     repository: 2gis-on-premise/tiles-api-proxy
-    tag: v4.21.1
+    tag: v4.22.0
     pullPolicy: IfNotPresent
 
   containerPort: 5000
@@ -65,7 +65,7 @@ proxy:
 api:
   image:
     repository: 2gis-on-premise/tiles-api
-    tag: v4.21.1
+    tag: v4.22.0
     pullPolicy: IfNotPresent
 
   terminationGracePeriodSeconds: 30
@@ -136,7 +136,7 @@ importer:
 
   image:
     repository: 2gis-on-premise/tiles-api-importer
-    tag: v4.21.1
+    tag: v4.22.0
     pullPolicy: IfNotPresent
 
   resources:


### PR DESCRIPTION
Добавлена джоба чистки старый кейспейсов. По-умолчанию выключена, включается через values.importer.cleaner.enabled = true

Появился параметр forceImport (по-умолчанию выключен), который сносит кейспейс, если он совпадает с тем, куда импорты делаются

Добавлены параметры jmxUser/jmxPassword для обращению к nodetool