### PR TITLE
Added support for dm-async

### DIFF
--- a/charts/navi-back/templates/_helpers.tpl
+++ b/charts/navi-back/templates/_helpers.tpl
@@ -98,6 +98,11 @@ Usage:
 {{- define "config.dm" -}}
 {{ print  "\"simple_network_car\" : true,\"simple_network_pedestrian\": false,\"simple_network_taxi\" : false,\"simple_network_bicycle\" : false,\"simple_network_truck\" : false,\"attractor_car\" : true,\"attractor_pedestrian\": false,\"attractor_bicycle\": false,\"attractor_taxi\": false,\"reduce_edges_optimization_flag\": true," }}
 {{- end -}}
+
+{{- define "config.bicycle" -}}
+{{ print  "\"simple_network_pedestrian\": false,\"simple_network_taxi\" : false,\"simple_network_bicycle\" : true,\"simple_network_truck\" : false,\"attractor_pedestrian\": false,\"attractor_bicycle\": true,\"attractor_taxi\": false," }}
+{{- end -}}
+
 {{- define "config.serversection" -}}
 {{- if eq .Values.naviback.type "carrouting" -}}
    {{ include "config.carrouting" $ }}
@@ -116,6 +121,9 @@ Usage:
 {{- end -}}
 {{- if eq .Values.naviback.type "pairs" -}}
    {{ include "config.pairs" $ }}
+{{- end }}
+{{- if eq .Values.naviback.type "bicycle" -}}
+   {{ include "config.bicycle" $ }}
 {{- end -}}
 {{- end -}}
 
@@ -131,7 +139,6 @@ Usage:
 {{- print $num_threads }}
 {{- end -}}
 
-{{/* vim: set filetype=mustache: */}}
 {{/*
 Renders a value or file that contains rules.
 Usage:
@@ -142,7 +149,7 @@ Usage:
     {{- if .Values.rules -}}
         {{- .Values.rules | toPrettyJson | nindent 6 }}
     {{- else if $rules_file_content  }}
-        {{- .Files.Get "rules.conf" |  nindent 6}}
+        {{- $rules_file_content |  nindent 6}}
     {{- else }}
         {{- fail "Rules value is not set or rules file is empty" }}
     {{- end -}}

--- a/charts/navi-back/templates/configmap.yaml
+++ b/charts/navi-back/templates/configmap.yaml
@@ -226,6 +226,7 @@ data:
           }
         },
         {{- if ne .Values.naviback.type "ctx" }}
+
         "smatrix": {
           "update_period": 0,
           "nodes": [
@@ -344,6 +345,37 @@ data:
                 }
               },
         {{- end }}
+        {{- if .Values.s3.enabled }}
+          "s3": {
+            "distance_matrix": {
+              "endpoint": {{ .Values.s3.url | quote }},
+              "bucket": {{ .Values.s3.bucket | quote }},
+              "access_key": {{ .Values.s3.keyId | quote }},
+              "secret_key": {{ .Values.s3.key | quote }}
+            }
+          },
+        {{- end }}
+        {{- if .Values.kafka.enabled }}
+          "kafka": {
+            "server" : {{ .Values.kafka.server | quote }},
+            "port" : {{ .Values.kafka.port | int }},
+            "user": {{ .Values.kafka.user | quote }},
+            "password": {{ .Values.kafka.password | quote }},
+            "sasl_mechanism": {{ .Values.kafka.mechanism | quote }},
+            "security_protocol": {{ .Values.kafka.protocol | quote }},
+            "task_group_id" : {{ .Values.kafka.groupId | quote }},
+            "cancel_group_id": {{ .Values.kafka.groupId | quote }},
+            "distance_matrix": {
+              "task_topic": {{ .Values.kafka.distanceMatrix.taskTopic | quote }},
+              "cancel_topic":  {{ .Values.kafka.distanceMatrix.cancelTopic | quote }},
+              "status_topic":  {{ .Values.kafka.distanceMatrix.statusTopic | quote }},
+              "update_task_status_period_sec": {{ .Values.kafka.distanceMatrix.updateTaskStatusPeriodSec | int }},
+              "message_expired_period_sec" : {{ .Values.kafka.distanceMatrix.messageExpiredPeriodSec | int }},
+              "request_download_timeout_sec" : {{ .Values.kafka.distanceMatrix.requestDownloadTimeoutSec | int }},
+              "response_upload_timeout_sec": {{ .Values.kafka.distanceMatrix.responseUploadTimeoutSec | int }}
+            }
+          },
+        {{- end }}
         {{- if .Values.naviback.additional_sections }}
           {{- include "tplvalues.render" ( dict "value" .Values.naviback.additional_sections "context" $) | nindent 8 }}
         {{- end }}
@@ -362,7 +394,7 @@ data:
           "attractor_taxi" : {{ .Values.naviback.attractor_taxi | default "false" }},
           "reduce_edges_optimization_flag" : {{ .Values.naviback.reduce_edges_optimization_flag | default "false" }},
           {{- end }}
-          {{- if .Values.resources.limits.cpu }}
+          {{- if ((.Values.resources).limits).cpu }}
           "dist_matrix_thread_pool_size" : {{ include "config.setDistMatrixPool" . }},
           {{- end }}
           "simple_network_emergency" : {{ .Values.naviback.simple_network_emergency | default "false" }},
@@ -404,5 +436,3 @@ data:
     }
   rules.conf: |-
    {{- include "rules.renderRules" . }}
-
-

--- a/charts/navi-back/templates/tests/test-connection.yaml
+++ b/charts/navi-back/templates/tests/test-connection.yaml
@@ -11,5 +11,7 @@ spec:
     - name: wget
       image: busybox
       command: ['wget']
+      resources:
+        {{- toYaml .Values.testResources | nindent 8 }}
       args: ['{{ include "naviback.fullname" . }}:{{ .Values.service.port }}']
   restartPolicy: Never

--- a/charts/navi-back/values.yaml
+++ b/charts/navi-back/values.yaml
@@ -65,6 +65,15 @@ resources:
     cpu: 500m
     memory: 1024Mi
 
+# resources for test-connection
+testResources:
+  limits:
+    cpu: 100m
+    memory: 100Mi
+  requests:
+    cpu: 100m
+    memory: 100Mi
+
 autoscaling:
   enabled: false
   minReplicas: 1
@@ -88,3 +97,32 @@ podDisruptionBudget: {}
 
 naviback:
   app_port: 8080
+
+rules: []
+
+kafka:
+  # if kafka and kafka.distance_matrix sections included in config
+  enabled: false
+  server: example.com
+  port: 9092
+  groupId: test_id
+  user: kafkauser
+  password: kafkapassword
+  mechanism: SCRAM-SHA-512
+  protocol: SASL_SSL
+  distanceMatrix:
+    taskTopic: request_topic
+    cancelTopic: cancel_topic
+    statusTopic: service_message_bus
+    updateTaskStatusPeriodSec: 120
+    messageExpiredPeriodSec: 3600
+    requestDownloadTimeoutSec: 20
+    responseUploadTimeoutSec: 40
+
+s3:
+  # if s3.distance_matrix section included in config
+  enabled: false
+  url: "example.com:80"
+  bucket: samplebucket
+  keyId: sampleid
+  key: samplekey


### PR DESCRIPTION
Kafka and D3 sections enable dm-async functionality, these sections added.

The following changes ported from 2GIS version of the chart:

1. bicycle config added

2. support for limits for test-connection job, certain policies might block
   creation of resources otherwise

3. setting resources is optional, indexing nil exception avoided if not
   specified

4. chart name mismatch in README fixed

5. typo and formatting

Backward compatibility checked on available on-prem properties, resulting helm template diff as expected adds nothing but test-connection limits:
```
$ diff -U0 helm.master-main.yaml helm.fb-main.yaml
--- helm.master-main.yaml	2022-07-21 18:56:37.868556068 +0300
+++ helm.fb-main.yaml	2022-07-21 18:56:19.856529621 +0300
@@ -213,0 +214 @@
+
@@ -398 +399 @@
-        checksum/config: e9d93a5b90f136c989731c2a9d5ea44d2bd1b39c97ada7a7aa3b84069ecff0e3
+        checksum/config: 736d353ef555686a9ceb141d1d8b63e2c9d6b35964ca51dd9ee48c8250b6c671
@@ -481,0 +483,7 @@
+      resources:
+        limits:
+          cpu: 100m
+          memory: 100Mi
+        requests:
+          cpu: 100m
+          memory: 100Mi
```