### PR TITLE
hidden proxy config

### DIFF
--- a/charts/proxy-traffic-jams/templates/configmap.yaml
+++ b/charts/proxy-traffic-jams/templates/configmap.yaml
@@ -17,6 +17,15 @@ data:
     }
 
     http {
+
+        {{- if .Values.proxy.upstreams }}
+        upstream backend {
+            {{- range .Values.proxy.upstreams }}
+            server {{ . }} max_fails=5;
+            {{- end }}
+        }
+        {{- end }}
+
         include       /etc/nginx/mime.types;
         default_type  application/octet-stream;
 
@@ -51,7 +60,12 @@ data:
           server_name _;
 
           location / {
+            {{ if .Values.proxy.upstreams }}
+              proxy_pass         {{ .Values.proxy.protocol }}://backend;
+              proxy_set_header   Host {{ .Values.proxy.host }};
+            {{ else }}
               proxy_pass         {{ .Values.proxy.host }};
+            {{ end }}
               proxy_set_header   Upgrade $http_upgrade;
               proxy_set_header   Connection keep-alive;
               proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/charts/proxy-traffic-jams/values.yaml
+++ b/charts/proxy-traffic-jams/values.yaml
@@ -3,6 +3,8 @@ replicaCount: 1
 proxy:
   host: https://traffic-jams.2gis.com
   listen: 8080
+  protocol: https  # don't document
+  upstreams: []  # don't document
   cache:
     enabled: true
     age: 1m


### PR DESCRIPTION
Для нормальных клиентов ничего не меняется. Но для сауди появился способ задать в upstreams список виртуалок с прокси (а через host передается заголовок для разруливания запросов). Документировать это лучше не надо, чтобы нормальных клиентов не сбивать с толку. Вероятно больше нигде не будет использоваться.