### PR TITLE
gis-platform 2022-09-07

### DIFF
--- a/Breaking-Changes.md
+++ b/Breaking-Changes.md
@@ -9,6 +9,10 @@
 #### keys
 - For the HPA section, switched from `autoscaling/v2beta2` to `autoscaling/v2`
 
+#### gis-platform
+- REMOVED `.Values.spcore.s3.preview_bucket`. Move its contents to `.Values.spcore.s3.bucket`
+- ADDED `.Values.spcore.s3.session_bucket`. Create it before updating
+
 #### mapgl-js-api
 - Rename `podDisruptionBudget` to `pdb`
 - For the HPA section, switched from `autoscaling/v1` to `autoscaling/v2`

--- a/charts/gis-platform/README.md
+++ b/charts/gis-platform/README.md
@@ -46,9 +46,9 @@ See the [documentation](https://docs.2gis.com/en/on-premise/gis-platform) to lea
 | Name                         | Description                         | Value                                 |
 | ---------------------------- | ----------------------------------- | ------------------------------------- |
 | `spcore.image.repository`    | SPCore service image repository.    | `2gis-on-premise/gis_platform_spcore` |
-| `spcore.image.tag`           | SPCore service image tag.           | `2022-09-07`                          |
+| `spcore.image.tag`           | SPCore service image tag.           | `2022.9.7`                            |
 | `portal.image.repository`    | Portal service image repository.    | `2gis-on-premise/gis_platform_portal` |
-| `portal.image.tag`           | Portal service image tag.           | `2022-09-07`                          |
+| `portal.image.tag`           | Portal service image tag.           | `2022.9.7`                            |
 | `zookeeper.image.repository` | ZooKeeper service image repository. | `2gis-on-premise/zookeeper`           |
 | `zookeeper.image.tag`        | ZooKeeper service image tag.        | `3.7.0-debian-10-r265`                |
 

--- a/charts/gis-platform/README.md
+++ b/charts/gis-platform/README.md
@@ -46,9 +46,9 @@ See the [documentation](https://docs.2gis.com/en/on-premise/gis-platform) to lea
 | Name                         | Description                         | Value                                 |
 | ---------------------------- | ----------------------------------- | ------------------------------------- |
 | `spcore.image.repository`    | SPCore service image repository.    | `2gis-on-premise/gis_platform_spcore` |
-| `spcore.image.tag`           | SPCore service image tag.           | `2022-06-10`                          |
+| `spcore.image.tag`           | SPCore service image tag.           | `2022-09-07`                          |
 | `portal.image.repository`    | Portal service image repository.    | `2gis-on-premise/gis_platform_portal` |
-| `portal.image.tag`           | Portal service image tag.           | `2022-06-10`                          |
+| `portal.image.tag`           | Portal service image tag.           | `2022-09-07`                          |
 | `zookeeper.image.repository` | ZooKeeper service image repository. | `2gis-on-premise/zookeeper`           |
 | `zookeeper.image.tag`        | ZooKeeper service image tag.        | `3.7.0-debian-10-r265`                |
 
@@ -76,7 +76,7 @@ See the [documentation](https://docs.2gis.com/en/on-premise/gis-platform) to lea
 | `spcore.s3.host`                            | S3 endpoint. Format: `host:port`.                                                         | `s3.host`                  |
 | `spcore.s3.region`                          | S3 region.                                                                                | `US`                       |
 | `spcore.s3.bucket`                          | S3 bucket name.                                                                           | `spstatic`                 |
-| `spcore.s3.preview_bucket`                  | S3 bucket name for preview.                                                               | `sppreview`                |
+| `spcore.s3.session_bucket`                  | S3 bucket name for temporary session files.                                               | `spsession`                |
 | `spcore.pg`                                 | **Database access settings.**                                                             |                            |
 | `spcore.pg.host`                            | PostgreSQL host.                                                                          | `postgres.host`            |
 | `spcore.pg.port`                            | PostgreSQL port.                                                                          | `5432`                     |

--- a/charts/gis-platform/README.md
+++ b/charts/gis-platform/README.md
@@ -46,9 +46,9 @@ See the [documentation](https://docs.2gis.com/en/on-premise/gis-platform) to lea
 | Name                         | Description                         | Value                                 |
 | ---------------------------- | ----------------------------------- | ------------------------------------- |
 | `spcore.image.repository`    | SPCore service image repository.    | `2gis-on-premise/gis_platform_spcore` |
-| `spcore.image.tag`           | SPCore service image tag.           | `2022.9.7`                            |
+| `spcore.image.tag`           | SPCore service image tag.           | `2022.9.15`                           |
 | `portal.image.repository`    | Portal service image repository.    | `2gis-on-premise/gis_platform_portal` |
-| `portal.image.tag`           | Portal service image tag.           | `2022.9.7`                            |
+| `portal.image.tag`           | Portal service image tag.           | `2022.9.15`                           |
 | `zookeeper.image.repository` | ZooKeeper service image repository. | `2gis-on-premise/zookeeper`           |
 | `zookeeper.image.tag`        | ZooKeeper service image tag.        | `3.7.0-debian-10-r265`                |
 

--- a/charts/gis-platform/configs/portal/default.conf.template
+++ b/charts/gis-platform/configs/portal/default.conf.template
@@ -162,17 +162,6 @@ server {
         proxy_read_timeout {{ .Values.portal.websocket.timeout }};
     }
 
-    location /sp/snapping {
-        proxy_pass http://spcore-upstream/snapping;
-        proxy_http_version 1.1;
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection $connection_upgrade;
-        proxy_set_header Host $host;
-        proxy_connect_timeout {{ .Values.portal.websocket.timeout }};
-        proxy_send_timeout {{ .Values.portal.websocket.timeout }};
-        proxy_read_timeout {{ .Values.portal.websocket.timeout }};
-    }
-
     location /swagger/ {
         proxy_pass http://spcore-upstream/swagger/;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/charts/gis-platform/configs/portal/default.conf.template
+++ b/charts/gis-platform/configs/portal/default.conf.template
@@ -162,6 +162,17 @@ server {
         proxy_read_timeout {{ .Values.portal.websocket.timeout }};
     }
 
+    location /sp/snapping {
+        proxy_pass http://spcore-upstream/snapping;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+        proxy_set_header Host $host;
+        proxy_connect_timeout {{ .Values.portal.websocket.timeout }};
+        proxy_send_timeout {{ .Values.portal.websocket.timeout }};
+        proxy_read_timeout {{ .Values.portal.websocket.timeout }};
+    }
+
     location /swagger/ {
         proxy_pass http://spcore-upstream/swagger/;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/charts/gis-platform/configs/portal/default.conf.template
+++ b/charts/gis-platform/configs/portal/default.conf.template
@@ -71,6 +71,15 @@ server {
         alias /app/client/static/map/;
     }
 
+    location /shared/ {
+        alias /app/client/;
+        try_files $uri /map/index.html;
+    }
+
+    location /static/shared/ {
+        alias /app/client/static/map/;
+    }
+
     location /sp {
         return 302 $scheme://$http_host/sp/;
     }

--- a/charts/gis-platform/configs/spcore/SPCore.json.template
+++ b/charts/gis-platform/configs/spcore/SPCore.json.template
@@ -4,6 +4,7 @@
   "maximumActiveRequests": 20,
   "pluginsPath": "plugins",
   "silentlyApplyMigrations": true,
+  "RequireUniqueEmail": true,
   "maxRenderTargets": {{- .Values.spcore.maxRenderTargets }},
   "staticPath": "/app/static",
   "previewStaticPath": "/app/static",

--- a/charts/gis-platform/configs/spcore/SPCore.json.template
+++ b/charts/gis-platform/configs/spcore/SPCore.json.template
@@ -30,6 +30,13 @@
          "key": "${GIS_PLATFORM_CATALOG_KEY}"
        }
   },
+  "s3Configuration": {
+    "host": "{{ .Values.spcore.s3.host }}",
+    "region": "{{ .Values.spcore.s3.region }}",
+    "bucketName": "{{ .Values.spcore.s3.bucket }}",
+    "sessionStorageBucketName": "{{ .Values.spcore.s3.session_bucket }}",
+    "provider": "aws"
+  },
   "DefaultLimits": {
     "Tables": {{ .Values.spcore.defaultLimits.tables | int | quote }},
     "Layers": {{ .Values.spcore.defaultLimits.layers | int | quote }},

--- a/charts/gis-platform/configs/spcore/spcore-entrypoint.sh
+++ b/charts/gis-platform/configs/spcore/spcore-entrypoint.sh
@@ -15,4 +15,4 @@ done
 
 envsubst < /app/SPCore.json.template > /app/SPCore.json
 
-/usr/bin/dotnet SPCore.App.Public.dll --updateDb=$UPDATE --resetCluster=$RESET --continue=true
+exec /usr/bin/dotnet SPCore.App.Public.dll --updateDb=$UPDATE --resetCluster=$RESET --continue=true

--- a/charts/gis-platform/gis-platform-config/configuration/MapConfig.json
+++ b/charts/gis-platform/gis-platform-config/configuration/MapConfig.json
@@ -264,6 +264,22 @@
       "layoutOptions": {
         "area": "mainControls"
       }
+    },
+    {
+      "name": "snapping",
+      "priority": 5,
+      "modulePath": "MapControls/Snapping",
+      "layoutOptions": {
+        "area": "topControls"
+      }
+    },
+    {
+      "name": "zoom-selection",
+      "priority": 3,
+      "modulePath": "MapControls/ZoomSelection",
+      "layoutOptions": {
+        "area": "mainControls"
+      }
     }
   ],
   "settings": {

--- a/charts/gis-platform/gis-platform-config/configuration/MapConfig.json
+++ b/charts/gis-platform/gis-platform-config/configuration/MapConfig.json
@@ -222,7 +222,16 @@
       },
       "options": {
         "content": "layers",
-        "allowDevView": true
+        "allowDevView": true,
+        "defaultLayersCondition": {
+          "group": "public",
+          "limit": 1000,
+          "filter": "favorite",
+          "orderByFields": [
+            "-changedDate"
+          ],
+          "geometryFilter": []
+        }
       },
       "priority": 1,
       "modulePath": "LayerList/LayerList",

--- a/charts/gis-platform/gis-platform-config/configuration/MapConfig.json
+++ b/charts/gis-platform/gis-platform-config/configuration/MapConfig.json
@@ -269,6 +269,7 @@
   "settings": {
     "help": false,
     "gotoPortal": false,
-    "feedbackForm": false
+    "feedbackForm": false,
+    "uniqueClassesLimit": 300
   }
 }

--- a/charts/gis-platform/gis-platform-config/configuration/MapConfig.json
+++ b/charts/gis-platform/gis-platform-config/configuration/MapConfig.json
@@ -266,14 +266,6 @@
       }
     },
     {
-      "name": "snapping",
-      "priority": 5,
-      "modulePath": "MapControls/Snapping",
-      "layoutOptions": {
-        "area": "topControls"
-      }
-    },
-    {
       "name": "zoom-selection",
       "priority": 3,
       "modulePath": "MapControls/ZoomSelection",

--- a/charts/gis-platform/gis-platform-config/configuration/MapConfig.json
+++ b/charts/gis-platform/gis-platform-config/configuration/MapConfig.json
@@ -279,6 +279,7 @@
     "gotoPortal": false,
     "feedbackForm": false,
     "uniqueClassesLimit": 300,
-    "labelInsidePosition": true
+    "labelInsidePosition": true,
+    "scaleSegmentation": false
   }
 }

--- a/charts/gis-platform/gis-platform-config/configuration/MapConfig.json
+++ b/charts/gis-platform/gis-platform-config/configuration/MapConfig.json
@@ -268,6 +268,7 @@
   ],
   "settings": {
     "help": false,
-    "gotoPortal": false
+    "gotoPortal": false,
+    "feedbackForm": false
   }
 }

--- a/charts/gis-platform/gis-platform-config/configuration/MapConfig.json
+++ b/charts/gis-platform/gis-platform-config/configuration/MapConfig.json
@@ -286,6 +286,7 @@
     "help": false,
     "gotoPortal": false,
     "feedbackForm": false,
-    "uniqueClassesLimit": 300
+    "uniqueClassesLimit": 300,
+    "labelInsidePosition": true
   }
 }

--- a/charts/gis-platform/gis-platform-config/configuration/MapConfig.json
+++ b/charts/gis-platform/gis-platform-config/configuration/MapConfig.json
@@ -256,6 +256,14 @@
       "layoutOptions": {
         "area": "portal"
       }
+    },
+    {
+      "name": "selection-control",
+      "priority": 2,
+      "modulePath": "MapControls/SelectionControls",
+      "layoutOptions": {
+        "area": "mainControls"
+      }
     }
   ],
   "settings": {

--- a/charts/gis-platform/templates/gis-platform-spcore-sts.yaml
+++ b/charts/gis-platform/templates/gis-platform-spcore-sts.yaml
@@ -104,14 +104,6 @@ spec:
               secretKeyRef:
                 name: {{ include "gis-platform.secret" . }}
                 key: db_connection_string
-          - name: SPCORE_s3Configuration__host
-            value: {{ .Values.spcore.s3.host | quote }}
-          - name: SPCORE_s3Configuration__region
-            value: {{ .Values.spcore.s3.region | quote }}
-          - name: SPCORE_s3Configuration__bucketName
-            value: {{ .Values.spcore.s3.bucket | quote }}
-          - name: SPCORE_s3Configuration__previewStorageBucketName
-            value: {{ .Values.spcore.s3.preview_bucket | quote }}
           - name: SPCORE_s3Configuration__accessKey
             valueFrom:
               secretKeyRef:

--- a/charts/gis-platform/templates/gis-platform-websocket-ingress.yaml
+++ b/charts/gis-platform/templates/gis-platform-websocket-ingress.yaml
@@ -41,12 +41,5 @@ spec:
                 name: {{ $fullName }}
                 port:
                   number: {{ $svcPort }}
-          - path: /sp/snapping
-            pathType: Prefix
-            backend:
-              service:
-                name: {{ $fullName }}
-                port:
-                  number: {{ $svcPort }}
     {{- end }}
 {{- end }}

--- a/charts/gis-platform/templates/gis-platform-websocket-ingress.yaml
+++ b/charts/gis-platform/templates/gis-platform-websocket-ingress.yaml
@@ -41,5 +41,12 @@ spec:
                 name: {{ $fullName }}
                 port:
                   number: {{ $svcPort }}
+          - path: /sp/snapping
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
     {{- end }}
 {{- end }}

--- a/charts/gis-platform/values.yaml
+++ b/charts/gis-platform/values.yaml
@@ -64,7 +64,7 @@ spcore:
 
   image:
     repository: 2gis-on-premise/gis_platform_spcore
-    tag: '2022-09-07'
+    tag: '2022.9.7'
 
   resources:
     requests:
@@ -204,7 +204,7 @@ portal:
 
   image:
     repository: 2gis-on-premise/gis_platform_portal
-    tag: '2022-09-07'
+    tag: '2022.9.7'
 
   resources:
     requests:

--- a/charts/gis-platform/values.yaml
+++ b/charts/gis-platform/values.yaml
@@ -64,7 +64,7 @@ spcore:
 
   image:
     repository: 2gis-on-premise/gis_platform_spcore
-    tag: '2022.9.7'
+    tag: '2022.9.15'
 
   resources:
     requests:
@@ -204,7 +204,7 @@ portal:
 
   image:
     repository: 2gis-on-premise/gis_platform_portal
-    tag: '2022.9.7'
+    tag: '2022.9.15'
 
   resources:
     requests:

--- a/charts/gis-platform/values.yaml
+++ b/charts/gis-platform/values.yaml
@@ -64,7 +64,7 @@ spcore:
 
   image:
     repository: 2gis-on-premise/gis_platform_spcore
-    tag: '2022-06-10'
+    tag: '2022-09-07'
 
   resources:
     requests:
@@ -88,7 +88,7 @@ spcore:
   # @param spcore.s3.host S3 endpoint. Format: `host:port`.
   # @param spcore.s3.region S3 region.
   # @param spcore.s3.bucket S3 bucket name.
-  # @param spcore.s3.preview_bucket S3 bucket name for preview.
+  # @param spcore.s3.session_bucket S3 bucket name for temporary session files.
 
   s3:
     access_key: ''
@@ -96,7 +96,7 @@ spcore:
     host: s3.host
     region: US
     bucket: spstatic
-    preview_bucket: sppreview
+    session_bucket: spsession
 
   # @extra spcore.pg **Database access settings.**
   # @param spcore.pg.host PostgreSQL host.
@@ -204,7 +204,7 @@ portal:
 
   image:
     repository: 2gis-on-premise/gis_platform_portal
-    tag: '2022-06-10'
+    tag: '2022-09-07'
 
   resources:
     requests:


### PR DESCRIPTION
> Теперь бакета с юзерпиками previewStorageBucketName больше нет в конфиге, а сами юзерпики переехали в бакет bucketName. В нем должна появиться папка userimage куда нужно перетащить все юзерпики из старого бакета. Также теперь все временные данные хранятся в sessionStorageBucketName - его необходимо создать до обновления. Ключ "provider": "aws" указывает на то, что теперь используется библиотека aws.
