### PR TITLE
IODEV-1145: Tiles-importers добавить лейблы

### DIFF
--- a/charts/tiles-api/configs/importer/job.yaml
+++ b/charts/tiles-api/configs/importer/job.yaml
@@ -6,6 +6,7 @@ metadata:
     task-id: {{`{{.task_id}}`}}
     import-id: {{`{{.import_id}}`}}
     {{- include "tiles.labels" . | nindent 4 }}
+    {{- include "tiles.importer.label" . | nindent 4 }}
 
 spec:
   backoffLimit: 0
@@ -15,7 +16,8 @@ spec:
       labels:
         task-id: {{`{{.task_id}}`}}
         import-id: {{`{{.import_id}}`}}
-        {{- include "tiles.labels" . | nindent 8 }}
+        {{- include "tiles.selectorLabels" . | nindent 8 }}
+        {{- include "tiles.importer.label" . | nindent 8 }}
 
     spec:
       volumes:

--- a/charts/tiles-api/templates/_helpers.tpl
+++ b/charts/tiles-api/templates/_helpers.tpl
@@ -14,7 +14,11 @@ app.kubernetes.io/version: {{ $.Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
 helm.sh/chart: {{ include "tiles.chart" . | quote }}
-{{- end }}
+{{- end -}}
+
+{{- define "tiles.api.label" -}}
+app.kubernetes.io/component: api
+{{- end -}}
 
 {{- define "tiles.manifestCode" -}}
 {{- base $.Values.dgctlStorage.manifest | trimSuffix ".json" }}
@@ -49,6 +53,12 @@ dgis_tileserver_{{ .kind }}_{{ required "Valid .Values.cassandra.environment req
 {{ (include (print $.Template.BasePath .path) $ | fromYaml).data | toYaml | sha256sum }}
 {{- end }}
 
+{{/* Importer */}}
+
+{{- define "tiles.importer.label" -}}
+app.kubernetes.io/component: importer
+{{- end -}}
+
 {{- define "importer.serviceName" -}}
 {{- if eq . "web" -}}
 tiles-api-webgl
@@ -76,3 +86,9 @@ tiles-api-mobile-sdk
 {{- $.Values.importer.serviceAccountOverride | trunc 63 | trimSuffix "-" }}
 {{- end }}
 {{- end }}
+
+{{/* Cleaner */}}
+
+{{- define "tiles.cleaner.label" -}}
+app.kubernetes.io/component: cleaner
+{{- end -}}

--- a/charts/tiles-api/templates/cassandra-cleaner-job.yaml
+++ b/charts/tiles-api/templates/cassandra-cleaner-job.yaml
@@ -9,6 +9,7 @@ metadata:
   name: {{ include "tiles.fullname" $ }}-{{ $type.kind }}-cleaner-job
   labels:
     {{- include "tiles.labels" $ | nindent 4 }}
+    {{- include "tiles.cleaner.label" $ | nindent 4 }}
   annotations:
     {{- include "importer.removable-hook-annotations" $ | nindent 4 }}
     "helm.sh/hook-weight": "1" # before imports
@@ -18,6 +19,9 @@ spec:
   template:
     metadata:
       name: {{ include "tiles.fullname" $ }}-{{ $type.kind }}-cleaner
+      labels:
+        {{- include "tiles.selectorLabels" $ | nindent 8 }}
+        {{- include "tiles.cleaner.label" $ | nindent 8 }}
     spec:
       serviceAccountName: {{ include "importer.serviceAccount" $ }}
 

--- a/charts/tiles-api/templates/deployment.yaml
+++ b/charts/tiles-api/templates/deployment.yaml
@@ -6,6 +6,7 @@ metadata:
   name: {{ include "tiles.fullname" . }}
   labels:
     {{- include "tiles.labels" . | nindent 4 }}
+    {{- include "tiles.api.label" $ | nindent 4 }}
     {{- if $.Values.api.labels }}
     {{- toYaml $.Values.api.labels | nindent 4 }}
     {{- end }}
@@ -22,6 +23,7 @@ spec:
   selector:
     matchLabels:
       {{- include "tiles.selectorLabels" . | nindent 6 }}
+      {{- include "tiles.api.label" $ | nindent 6 }}
 
   {{- with .Values.api.strategy }}
   strategy:
@@ -32,6 +34,7 @@ spec:
     metadata:
       labels:
         {{- include "tiles.selectorLabels" . | nindent 8 }}
+        {{- include "tiles.api.label" $ | nindent 8 }}
         {{- with .Values.api.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/tiles-api/templates/hpa.yaml
+++ b/charts/tiles-api/templates/hpa.yaml
@@ -6,6 +6,7 @@ metadata:
   name: {{ include "tiles.fullname" $ }}
   labels:
     {{- include "tiles.labels" $ | nindent 4 }}
+    {{- include "tiles.api.label" $ | nindent 4 }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1

--- a/charts/tiles-api/templates/ingress.yaml
+++ b/charts/tiles-api/templates/ingress.yaml
@@ -8,6 +8,7 @@ metadata:
   name: {{ include "tiles.fullname" $ }}
   labels:
     {{- include "tiles.labels" $ | nindent 4 }}
+    {{- include "tiles.api.label" $ | nindent 4 }}
     {{- if .labels }}
     {{- toYaml .labels | nindent 4 }}
     {{- end }}

--- a/charts/tiles-api/templates/job.yaml
+++ b/charts/tiles-api/templates/job.yaml
@@ -9,6 +9,7 @@ metadata:
   name:  {{ include "tiles.fullname" $ }}-{{ $type.kind }}-importer-job
   labels:
     {{- include "tiles.labels" $ | nindent 4 }}
+    {{- include "tiles.importer.label" $ | nindent 4 }}
   annotations:
     {{- include "importer.removable-hook-annotations" $ | nindent 4 }}
     "helm.sh/hook-weight": "2" # after cleaning
@@ -18,6 +19,9 @@ spec:
   template:
     metadata:
       name: {{ include "tiles.fullname" $ }}-{{ $type.kind }}-importer
+      labels:
+        {{- include "tiles.selectorLabels" $ | nindent 8 }}
+        {{- include "tiles.importer.label" $ | nindent 8 }}
     spec:
       serviceAccountName: {{ include "importer.serviceAccount" $ }}
 

--- a/charts/tiles-api/templates/pdb.yaml
+++ b/charts/tiles-api/templates/pdb.yaml
@@ -13,6 +13,7 @@ metadata:
   name: {{ include "tiles.fullname" $ }}
   labels:
     {{- include "tiles.labels" $ | nindent 4 }}
+    {{- include "tiles.api.label" $ | nindent 4 }}
 spec:
   {{- if .minAvailable }}
   minAvailable: {{ .minAvailable }}
@@ -23,6 +24,7 @@ spec:
   selector:
     matchLabels:
       {{- include "tiles.selectorLabels" $ | nindent 6 }}
+      {{- include "tiles.api.label" $ | nindent 6 }}
 
 {{- end }}
 {{- end }}

--- a/charts/tiles-api/templates/service.yaml
+++ b/charts/tiles-api/templates/service.yaml
@@ -11,6 +11,7 @@ metadata:
   {{- end }}
   labels:
     {{- include "tiles.labels" $ | nindent 4 }}
+    {{- include "tiles.api.label" $ | nindent 4 }}
     {{- if .labels }}
     {{- toYaml .labels | nindent 4 }}
     {{- end }}
@@ -31,5 +32,6 @@ spec:
 
   selector:
     {{- include "tiles.selectorLabels" $ | nindent 4 }}
+    {{- include "tiles.api.label" $ | nindent 4 }}
 
 {{- end }}

--- a/charts/tiles-api/templates/vpa.yaml
+++ b/charts/tiles-api/templates/vpa.yaml
@@ -8,6 +8,7 @@ metadata:
   name: {{ include "tiles.fullname" $ }}
   labels:
     {{- include "tiles.labels" $ | nindent 4 }}
+    {{- include "tiles.api.label" $ | nindent 4 }}
 spec:
   targetRef:
     apiVersion: apps/v1


### PR DESCRIPTION
1. Добавил `app.kubernetes.io/component` лейблы для `api`, `importer`, `cleaner`.
2. Добавил selector лейблы во все поды, чтобы их можно было мониторить через:
```sh
$ kubectl get pods -l app.kubernetes.io/instance=on-prem-tiles-api-vector
```