### PR TITLE
IODEV-903 Переименовал сервисы для поиска в манифесте

### DIFF
--- a/charts/navi-castle/templates/configmapbuilder.yaml
+++ b/charts/navi-castle/templates/configmapbuilder.yaml
@@ -44,7 +44,7 @@ data:
     manifest:
     {
         pattern: '{{ default "/manifests/" .Values.dgctlStorage.manifest }}',
-        service: 'routing',
+        service: 'navi',
     }
     # --------------------------------------------
     # DATA PACKAGE

--- a/charts/tiles-api/templates/_helpers.tpl
+++ b/charts/tiles-api/templates/_helpers.tpl
@@ -61,7 +61,7 @@ app.kubernetes.io/component: importer
 
 {{- define "importer.serviceName" -}}
 {{- if eq . "web" -}}
-tiles-api-webgl
+tiles-api-vector
 {{- else if eq . "raster" -}}
 tiles-api-raster
 {{- else if eq . "native" -}}


### PR DESCRIPTION
В Datagateway мы переименовали сервисы:
* routing -> navi
* tiles-api-webgl -> tiles-api-vector

теперь надо смотреть пути до данных в манифесте в этих новых сервисах.

Пока что мы пишем и в старые сервисы, но планируем со временем отказаться от обратной совместимости.

@i-bogomazov посмотри пожалуйста на navi-castle, я правильно у вас поправил? Нигде не пропустил?