### PR TITLE
Add values.schema.json to pro-ui

### DIFF
--- a/charts/pro-ui/values.schema.json
+++ b/charts/pro-ui/values.schema.json
@@ -9,23 +9,19 @@
     "dgctlDockerRegistry": {
       "type": "string",
       "default": "Any docker registry name",
-      "pattern": "^.+:\\d+$",
-      "title": "Docker Registry endpoint where On-Premise services' images reside. Format: `host:port`",
-      "examples": [""]
+      "title": "Docker Registry endpoint where On-Premise services' images reside. Format: `host:port`"
     },
     "imagePullPolicy": {
       "type": "string",
       "pattern": "^(Always|Never|IfNotPresent)$",
       "default": "IfNotPresent",
-      "title": "The imagePullPolicy Schema",
-      "examples": ["IfNotPresent"]
+      "title": "The imagePullPolicy Schema"
     },
     "imagePullSecrets": {
       "type": "array",
       "default": [],
       "title": "The imagePullSecrets Schema",
-      "items": {},
-      "examples": [[]]
+      "items": {}
     },
     "ui": {
       "type": "object",
@@ -58,63 +54,55 @@
         "replicas": {
           "type": "integer",
           "default": 0,
-          "title": "The replicas Schema",
-          "examples": [1]
+          "title": "The replicas Schema"
         },
         "nodeSelector": {
           "type": "object",
           "default": {},
           "title": "The nodeSelector Schema",
           "required": [],
-          "properties": {},
-          "examples": [{}]
+          "properties": {}
         },
         "affinity": {
           "type": "object",
           "default": {},
           "title": "The affinity Schema",
           "required": [],
-          "properties": {},
-          "examples": [{}]
+          "properties": {}
         },
         "tolerations": {
           "type": "array",
           "default": [],
           "title": "The tolerations Schema",
-          "items": {},
-          "examples": [[]]
+          "items": {}
         },
         "podAnnotations": {
           "type": "object",
           "default": {},
           "title": "The podAnnotations Schema",
           "required": [],
-          "properties": {},
-          "examples": [{}]
+          "properties": {}
         },
         "podLabels": {
           "type": "object",
           "default": {},
           "title": "The podLabels Schema",
           "required": [],
-          "properties": {},
-          "examples": [{}]
+          "properties": {}
         },
         "annotations": {
           "type": "object",
           "default": {},
           "title": "The annotations Schema",
           "required": [],
-          "properties": {},
-          "examples": [{}]
+          "properties": {}
         },
         "labels": {
           "type": "object",
           "default": {},
           "title": "The labels Schema",
           "required": [],
-          "properties": {},
-          "examples": [{}]
+          "properties": {}
         },
         "image": {
           "type": "object",
@@ -125,63 +113,49 @@
             "repository": {
               "type": "string",
               "default": "",
-              "title": "The repository Schema",
-              "examples": ["2gis-on-premise/pro-ui"]
+              "title": "The repository Schema"
             },
             "tag": {
               "type": "string",
               "default": "",
-              "title": "The tag Schema",
-              "examples": ["0.1.5"]
+              "title": "The tag Schema"
             }
-          },
-          "examples": [
-            {
-              "repository": "2gis-on-premise/pro-ui",
-              "tag": "0.1.5"
-            }
-          ]
+          }
         },
         "logLevel": {
           "type": "string",
           "pattern": "^error$",
           "default": "error",
-          "title": "The logLevel Schema",
-          "examples": ["error"]
+          "title": "The logLevel Schema"
         },
         "isOnPremise": {
           "type": "string",
           "pattern": "^(false|true)$",
           "default": "true",
-          "title": "The isOnPremise Schema",
-          "examples": ["true", "false"]
+          "title": "The isOnPremise Schema"
         },
         "ssoAuth": {
           "type": "string",
           "pattern": "^(false|true)$",
           "default": "false",
-          "title": "The ssoAuth Schema",
-          "examples": ["false", "true"]
+          "title": "The ssoAuth Schema"
         },
         "appTheme": {
           "type": "string",
           "pattern": "^(urbi|2gis)$",
           "default": "urbi",
-          "title": "The appTheme Schema",
-          "examples": ["urbi", "2gis"]
+          "title": "The appTheme Schema"
         },
         "appLocale": {
           "type": "string",
           "pattern": "^(en_AE|ru_RU)$",
           "default": "en_AE",
-          "title": "The appLocale Schema",
-          "examples": ["en_AE", "ru_RU"]
+          "title": "The appLocale Schema"
         },
         "appInitialMapCenter": {
           "type": "string",
           "default": "[46.71, 24.72]",
-          "title": "The appInitialMapCenter Schema",
-          "examples": ["[46.71, 24.72]", "[37.64, 55.74]"]
+          "title": "The appInitialMapCenter Schema"
         },
         "api": {
           "type": "object",
@@ -191,17 +165,10 @@
           "properties": {
             "url": {
               "type": "string",
-              "pattern": "^.*/$",
               "default": "",
-              "title": "The url Schema",
-              "examples": ["https://pro-back.4geo.info/"]
+              "title": "The url Schema"
             }
-          },
-          "examples": [
-            {
-              "url": "https://pro-back.4geo.info/"
-            }
-          ]
+          }
         },
         "mapgl": {
           "type": "object",
@@ -212,43 +179,29 @@
             "host": {
               "type": "string",
               "default": "",
-              "title": "The host Schema",
-              "examples": ["pro-js.4geo.info"]
+              "title": "The host Schema"
             },
             "key": {
               "type": "string",
               "default": "",
-              "title": "The key Schema",
-              "examples": ["5eea1dd3-8913-4cda-82a0-496108e5794c"]
+              "title": "The key Schema"
             },
             "styleUrl": {
               "type": "string",
               "default": "",
-              "title": "The styleUrl Schema",
-              "examples": [""]
+              "title": "The styleUrl Schema"
             },
             "styleIconsUrl": {
               "type": "string",
               "default": "",
-              "title": "The styleIconsUrl Schema",
-              "examples": [""]
+              "title": "The styleIconsUrl Schema"
             },
             "styleFontsUrl": {
               "type": "string",
               "default": "",
-              "title": "The styleFontsUrl Schema",
-              "examples": [""]
+              "title": "The styleFontsUrl Schema"
             }
-          },
-          "examples": [
-            {
-              "host": "pro-js.4geo.info",
-              "key": "e33e75a9-0818-4bfd-8147-84ca82543865",
-              "styleUrl": "",
-              "styleIconsUrl": "",
-              "styleFontsUrl": ""
-            }
-          ]
+          }
         },
         "strategy": {
           "type": "object",
@@ -259,8 +212,7 @@
             "type": {
               "type": "string",
               "default": "RollingUpdate",
-              "title": "The type Schema",
-              "examples": ["RollingUpdate"]
+              "title": "The type Schema"
             },
             "rollingUpdate": {
               "type": "object",
@@ -271,33 +223,16 @@
                 "maxUnavailable": {
                   "type": "integer",
                   "default": 0,
-                  "title": "The maxUnavailable Schema",
-                  "examples": [0]
+                  "title": "The maxUnavailable Schema"
                 },
                 "maxSurge": {
                   "type": "integer",
                   "default": 0,
-                  "title": "The maxSurge Schema",
-                  "examples": [1]
+                  "title": "The maxSurge Schema"
                 }
-              },
-              "examples": [
-                {
-                  "maxUnavailable": 0,
-                  "maxSurge": 1
-                }
-              ]
-            }
-          },
-          "examples": [
-            {
-              "type": "RollingUpdate",
-              "rollingUpdate": {
-                "maxUnavailable": 0,
-                "maxSurge": 1
               }
             }
-          ]
+          }
         },
         "service": {
           "type": "object",
@@ -310,38 +245,26 @@
               "default": {},
               "title": "The annotations Schema",
               "required": [],
-              "properties": {},
-              "examples": [{}]
+              "properties": {}
             },
             "labels": {
               "type": "object",
               "default": {},
               "title": "The labels Schema",
               "required": [],
-              "properties": {},
-              "examples": [{}]
+              "properties": {}
             },
             "type": {
               "type": "string",
               "default": "",
-              "title": "The type Schema",
-              "examples": ["ClusterIP"]
+              "title": "The type Schema"
             },
             "port": {
               "type": "integer",
               "default": 0,
-              "title": "The port Schema",
-              "examples": [3000]
+              "title": "The port Schema"
             }
-          },
-          "examples": [
-            {
-              "annotations": {},
-              "labels": {},
-              "type": "ClusterIP",
-              "port": 3000
-            }
-          ]
+          }
         },
         "ingress": {
           "type": "object",
@@ -352,8 +275,7 @@
             "enabled": {
               "type": "boolean",
               "default": false,
-              "title": "The enabled Schema",
-              "examples": [false, true]
+              "title": "The enabled Schema"
             },
             "hosts": {
               "type": "array",
@@ -368,35 +290,12 @@
                   "host": {
                     "type": "string",
                     "default": "",
-                    "title": "The host Schema",
-                    "examples": ["pro-ui.host"]
+                    "title": "The host Schema"
                   }
-                },
-                "examples": [
-                  {
-                    "host": "pro-ui.host"
-                  }
-                ]
-              },
-              "examples": [
-                [
-                  {
-                    "host": "pro-ui.host"
-                  }
-                ]
-              ]
-            }
-          },
-          "examples": [
-            {
-              "enabled": false,
-              "hosts": [
-                {
-                  "host": "pro-ui.host"
                 }
-              ]
+              }
             }
-          ]
+          }
         },
         "resources": {
           "type": "object",
@@ -412,25 +311,17 @@
               "properties": {
                 "cpu": {
                   "type": "string",
-                  "pattern": "^\\d+m$",
+                  "pattern": "^\\d+\\w?$",
                   "default": "300m",
-                  "title": "The cpu Schema",
-                  "examples": ["300m"]
+                  "title": "The cpu Schema"
                 },
                 "memory": {
                   "type": "string",
-                  "pattern": "^\\d+Mi$",
+                  "pattern": "^\\d+\\w?\\w?$",
                   "default": "256Mi",
-                  "title": "The memory Schema",
-                  "examples": ["256Mi"]
+                  "title": "The memory Schema"
                 }
-              },
-              "examples": [
-                {
-                  "cpu": "300m",
-                  "memory": "256Mi"
-                }
-              ]
+              }
             },
             "limits": {
               "type": "object",
@@ -441,170 +332,19 @@
                 "cpu": {
                   "type": "integer",
                   "default": 0,
-                  "title": "The cpu Schema",
-                  "examples": [1]
+                  "title": "The cpu Schema"
                 },
                 "memory": {
                   "type": "string",
-                  "pattern": "^\\d+Mi$",
+                  "pattern": "^\\d+\\w?\\w?$",
                   "default": "384Mi",
-                  "title": "The memory Schema",
-                  "examples": ["384Mi"]
+                  "title": "The memory Schema"
                 }
-              },
-              "examples": [
-                {
-                  "cpu": 1,
-                  "memory": "384Mi"
-                }
-              ]
-            }
-          },
-          "examples": [
-            {
-              "requests": {
-                "cpu": "300m",
-                "memory": "256Mi"
-              },
-              "limits": {
-                "cpu": 1,
-                "memory": "384Mi"
               }
             }
-          ]
-        }
-      },
-      "examples": [
-        {
-          "replicas": 1,
-          "nodeSelector": {},
-          "affinity": {},
-          "tolerations": [],
-          "podAnnotations": {},
-          "podLabels": {},
-          "annotations": {},
-          "labels": {},
-          "image": {
-            "repository": "2gis-on-premise/pro-ui",
-            "tag": "0.1.5"
-          },
-          "logLevel": "error",
-          "isOnPremise": "true",
-          "ssoAuth": "false",
-          "appTheme": "urbi",
-          "appLocale": "en_AE",
-          "appInitialMapCenter": "[46.71, 24.72]",
-          "api": {
-            "url": "https://pro-back.4geo.info/"
-          },
-          "mapgl": {
-            "host": "pro-js.4geo.info",
-            "key": "e33e75a9-0818-4bfd-8147-84ca82543865",
-            "styleUrl": "",
-            "styleIconsUrl": "",
-            "styleFontsUrl": ""
-          },
-          "strategy": {
-            "type": "RollingUpdate",
-            "rollingUpdate": {
-              "maxUnavailable": 0,
-              "maxSurge": 1
-            }
-          },
-          "service": {
-            "annotations": {},
-            "labels": {},
-            "type": "ClusterIP",
-            "port": 3000
-          },
-          "ingress": {
-            "enabled": false,
-            "hosts": [
-              {
-                "host": "pro-ui.host"
-              }
-            ]
-          },
-          "resources": {
-            "requests": {
-              "cpu": "300m",
-              "memory": "256Mi"
-            },
-            "limits": {
-              "cpu": 1,
-              "memory": "384Mi"
-            }
-          }
-        }
-      ]
-    }
-  },
-  "examples": [
-    {
-      "dgctlDockerRegistry": "",
-      "imagePullPolicy": "IfNotPresent",
-      "imagePullSecrets": [],
-      "ui": {
-        "replicas": 1,
-        "nodeSelector": {},
-        "affinity": {},
-        "tolerations": [],
-        "podAnnotations": {},
-        "podLabels": {},
-        "annotations": {},
-        "labels": {},
-        "image": {
-          "repository": "2gis-on-premise/pro-ui",
-          "tag": "0.1.5"
-        },
-        "logLevel": "error",
-        "isOnPremise": "true",
-        "ssoAuth": "false",
-        "appTheme": "urbi",
-        "appLocale": "en_AE",
-        "appInitialMapCenter": "[46.71, 24.72]",
-        "api": {
-          "url": "https://pro-back.4geo.info/"
-        },
-        "mapgl": {
-          "host": "pro-js.4geo.info",
-          "key": "e33e75a9-0818-4bfd-8147-84ca82543865",
-          "styleUrl": "",
-          "styleIconsUrl": "",
-          "styleFontsUrl": ""
-        },
-        "strategy": {
-          "type": "RollingUpdate",
-          "rollingUpdate": {
-            "maxUnavailable": 0,
-            "maxSurge": 1
-          }
-        },
-        "service": {
-          "annotations": {},
-          "labels": {},
-          "type": "ClusterIP",
-          "port": 3000
-        },
-        "ingress": {
-          "enabled": false,
-          "hosts": [
-            {
-              "host": "pro-ui.host"
-            }
-          ]
-        },
-        "resources": {
-          "requests": {
-            "cpu": "300m",
-            "memory": "256Mi"
-          },
-          "limits": {
-            "cpu": 1,
-            "memory": "384Mi"
           }
         }
       }
     }
-  ]
+  }
 }

--- a/charts/pro-ui/values.schema.json
+++ b/charts/pro-ui/values.schema.json
@@ -6,37 +6,9 @@
   "title": "Root Schema",
   "required": ["dgctlDockerRegistry", "imagePullPolicy", "imagePullSecrets", "ui"],
   "properties": {
-    "dgctlDockerRegistry": {
-      "type": "string",
-      "default": "Any docker registry name",
-      "title": "Docker Registry endpoint where On-Premise services' images reside. Format: `host:port`"
-    },
-    "imagePullPolicy": {
-      "type": "string",
-      "default": "IfNotPresent",
-      "title": "The imagePullPolicy Schema"
-    },
-    "imagePullSecrets": {
-      "type": "array",
-      "default": [],
-      "title": "The imagePullSecrets Schema",
-      "items": {}
-    },
     "ui": {
       "type": "object",
-      "default": {},
-      "title": "The ui Schema",
-      "additionalProperties": false,
       "required": [
-        "replicas",
-        "nodeSelector",
-        "affinity",
-        "tolerations",
-        "podAnnotations",
-        "podLabels",
-        "annotations",
-        "labels",
-        "image",
         "logLevel",
         "isOnPremise",
         "ssoAuth",
@@ -44,304 +16,62 @@
         "appLocale",
         "appInitialMapCenter",
         "api",
-        "mapgl",
-        "strategy",
-        "service",
-        "ingress",
-        "resources"
+        "mapgl"
       ],
       "properties": {
-        "replicas": {
-          "type": "integer",
-          "default": 0,
-          "title": "The replicas Schema"
-        },
-        "nodeSelector": {
-          "type": "object",
-          "default": {},
-          "title": "The nodeSelector Schema",
-          "required": [],
-          "properties": {}
-        },
-        "affinity": {
-          "type": "object",
-          "default": {},
-          "title": "The affinity Schema",
-          "required": [],
-          "properties": {}
-        },
-        "tolerations": {
-          "type": "array",
-          "default": [],
-          "title": "The tolerations Schema",
-          "items": {}
-        },
-        "podAnnotations": {
-          "type": "object",
-          "default": {},
-          "title": "The podAnnotations Schema",
-          "required": [],
-          "properties": {}
-        },
-        "podLabels": {
-          "type": "object",
-          "default": {},
-          "title": "The podLabels Schema",
-          "required": [],
-          "properties": {}
-        },
-        "annotations": {
-          "type": "object",
-          "default": {},
-          "title": "The annotations Schema",
-          "required": [],
-          "properties": {}
-        },
-        "labels": {
-          "type": "object",
-          "default": {},
-          "title": "The labels Schema",
-          "required": [],
-          "properties": {}
-        },
-        "image": {
-          "type": "object",
-          "default": {},
-          "additionalProperties": false,
-          "title": "The image Schema",
-          "required": ["repository", "tag"],
-          "properties": {
-            "repository": {
-              "type": "string",
-              "default": "",
-              "title": "The repository Schema"
-            },
-            "tag": {
-              "type": "string",
-              "default": "",
-              "title": "The tag Schema"
-            }
-          }
-        },
         "logLevel": {
           "type": "string",
-          "enum": ["error"],
-          "default": "error",
-          "title": "The logLevel Schema"
+          "enum": ["error"]
         },
         "isOnPremise": {
           "type": "string",
-          "enum": ["true", "false"],
-          "default": "true",
-          "title": "The isOnPremise Schema"
+          "enum": ["true", "false"]
         },
         "ssoAuth": {
           "type": "string",
-          "enum": ["true", "false"],
-          "default": "false",
-          "title": "The ssoAuth Schema"
+          "enum": ["true", "false"]
         },
         "appTheme": {
           "type": "string",
-          "enum": ["urbi", "2gis"],
-          "default": "urbi",
-          "title": "The appTheme Schema"
+          "enum": ["urbi", "2gis"]
         },
         "appLocale": {
           "type": "string",
-          "enum": ["en_AE", "ru_RU"],
-          "default": "en_AE",
-          "title": "The appLocale Schema"
+          "enum": ["en_AE", "ru_RU"]
         },
         "appInitialMapCenter": {
-          "type": "string",
-          "default": "[46.71, 24.72]",
-          "title": "The appInitialMapCenter Schema"
+          "type": "string"
         },
         "api": {
           "type": "object",
-          "default": {},
           "additionalProperties": false,
-          "title": "The api Schema",
           "required": ["url"],
           "properties": {
             "url": {
               "type": "string",
-              "pattern": "^(https?://.+/)?$",
-              "default": "",
-              "title": "The url Schema"
+              "pattern": "^(https?://.+/)?$"
             }
           }
         },
         "mapgl": {
           "type": "object",
-          "default": {},
-          "title": "The mapgl Schema",
           "required": ["host", "key"],
           "additionalProperties": false,
           "properties": {
             "host": {
-              "type": "string",
-              "default": "",
-              "title": "The host Schema"
+              "type": "string"
             },
             "key": {
-              "type": "string",
-              "default": "",
-              "title": "The key Schema"
+              "type": "string"
             },
             "styleUrl": {
-              "type": "string",
-              "default": "",
-              "title": "The styleUrl Schema"
+              "type": "string"
             },
             "styleIconsUrl": {
-              "type": "string",
-              "default": "",
-              "title": "The styleIconsUrl Schema"
+              "type": "string"
             },
             "styleFontsUrl": {
-              "type": "string",
-              "default": "",
-              "title": "The styleFontsUrl Schema"
-            }
-          }
-        },
-        "strategy": {
-          "type": "object",
-          "default": {},
-          "title": "The strategy Schema",
-          "properties": {
-            "type": {
-              "type": "string",
-              "default": "RollingUpdate",
-              "title": "The type Schema"
-            },
-            "rollingUpdate": {
-              "type": "object",
-              "default": {},
-              "title": "The rollingUpdate Schema",
-              "required": ["maxUnavailable", "maxSurge"],
-              "properties": {
-                "maxUnavailable": {
-                  "type": "integer",
-                  "default": 0,
-                  "title": "The maxUnavailable Schema"
-                },
-                "maxSurge": {
-                  "type": "integer",
-                  "default": 0,
-                  "title": "The maxSurge Schema"
-                }
-              }
-            }
-          }
-        },
-        "service": {
-          "type": "object",
-          "default": {},
-          "title": "The service Schema",
-          "required": ["annotations", "labels", "type", "port"],
-          "properties": {
-            "annotations": {
-              "type": "object",
-              "default": {},
-              "title": "The annotations Schema",
-              "required": [],
-              "properties": {}
-            },
-            "labels": {
-              "type": "object",
-              "default": {},
-              "title": "The labels Schema",
-              "required": [],
-              "properties": {}
-            },
-            "type": {
-              "type": "string",
-              "default": "",
-              "title": "The type Schema"
-            },
-            "port": {
-              "type": "integer",
-              "default": 0,
-              "title": "The port Schema"
-            }
-          }
-        },
-        "ingress": {
-          "type": "object",
-          "default": {},
-          "title": "The ingress Schema",
-          "required": ["enabled", "hosts"],
-          "properties": {
-            "enabled": {
-              "type": "boolean",
-              "default": false,
-              "title": "The enabled Schema"
-            },
-            "hosts": {
-              "type": "array",
-              "default": [],
-              "title": "The hosts Schema",
-              "items": {
-                "type": "object",
-                "default": {},
-                "title": "A Schema",
-                "required": ["host"],
-                "properties": {
-                  "host": {
-                    "type": "string",
-                    "default": "",
-                    "title": "The host Schema"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "resources": {
-          "type": "object",
-          "default": {},
-          "additionalProperties": false,
-          "title": "The resources Schema",
-          "required": ["requests", "limits"],
-          "properties": {
-            "requests": {
-              "type": "object",
-              "default": {},
-              "title": "The requests Schema",
-              "required": ["cpu", "memory"],
-              "properties": {
-                "cpu": {
-                  "type": "string",
-                  "default": "300m",
-                  "title": "The cpu Schema"
-                },
-                "memory": {
-                  "type": "string",
-                  "default": "256Mi",
-                  "title": "The memory Schema"
-                }
-              }
-            },
-            "limits": {
-              "type": "object",
-              "default": {},
-              "title": "The limits Schema",
-              "required": ["cpu", "memory"],
-              "properties": {
-                "cpu": {
-                  "type": "integer",
-                  "default": 0,
-                  "title": "The cpu Schema"
-                },
-                "memory": {
-                  "type": "string",
-                  "default": "384Mi",
-                  "title": "The memory Schema"
-                }
-              }
+              "type": "string"
             }
           }
         }

--- a/charts/pro-ui/values.schema.json
+++ b/charts/pro-ui/values.schema.json
@@ -13,7 +13,6 @@
     },
     "imagePullPolicy": {
       "type": "string",
-      "pattern": "^(Always|Never|IfNotPresent)$",
       "default": "IfNotPresent",
       "title": "The imagePullPolicy Schema"
     },
@@ -311,13 +310,11 @@
               "properties": {
                 "cpu": {
                   "type": "string",
-                  "pattern": "^\\d+\\w?$",
                   "default": "300m",
                   "title": "The cpu Schema"
                 },
                 "memory": {
                   "type": "string",
-                  "pattern": "^\\d+\\w?\\w?$",
                   "default": "256Mi",
                   "title": "The memory Schema"
                 }
@@ -336,7 +333,6 @@
                 },
                 "memory": {
                   "type": "string",
-                  "pattern": "^\\d+\\w?\\w?$",
                   "default": "384Mi",
                   "title": "The memory Schema"
                 }

--- a/charts/pro-ui/values.schema.json
+++ b/charts/pro-ui/values.schema.json
@@ -1,0 +1,610 @@
+{
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "$id": "http://example.com/example.json",
+  "type": "object",
+  "default": {},
+  "title": "Root Schema",
+  "required": ["dgctlDockerRegistry", "imagePullPolicy", "imagePullSecrets", "ui"],
+  "properties": {
+    "dgctlDockerRegistry": {
+      "type": "string",
+      "default": "Any docker registry name",
+      "pattern": "^.+:\\d+$",
+      "title": "Docker Registry endpoint where On-Premise services' images reside. Format: `host:port`",
+      "examples": [""]
+    },
+    "imagePullPolicy": {
+      "type": "string",
+      "pattern": "^(Always|Never|IfNotPresent)$",
+      "default": "IfNotPresent",
+      "title": "The imagePullPolicy Schema",
+      "examples": ["IfNotPresent"]
+    },
+    "imagePullSecrets": {
+      "type": "array",
+      "default": [],
+      "title": "The imagePullSecrets Schema",
+      "items": {},
+      "examples": [[]]
+    },
+    "ui": {
+      "type": "object",
+      "default": {},
+      "title": "The ui Schema",
+      "required": [
+        "replicas",
+        "nodeSelector",
+        "affinity",
+        "tolerations",
+        "podAnnotations",
+        "podLabels",
+        "annotations",
+        "labels",
+        "image",
+        "logLevel",
+        "isOnPremise",
+        "ssoAuth",
+        "appTheme",
+        "appLocale",
+        "appInitialMapCenter",
+        "api",
+        "mapgl",
+        "strategy",
+        "service",
+        "ingress",
+        "resources"
+      ],
+      "properties": {
+        "replicas": {
+          "type": "integer",
+          "default": 0,
+          "title": "The replicas Schema",
+          "examples": [1]
+        },
+        "nodeSelector": {
+          "type": "object",
+          "default": {},
+          "title": "The nodeSelector Schema",
+          "required": [],
+          "properties": {},
+          "examples": [{}]
+        },
+        "affinity": {
+          "type": "object",
+          "default": {},
+          "title": "The affinity Schema",
+          "required": [],
+          "properties": {},
+          "examples": [{}]
+        },
+        "tolerations": {
+          "type": "array",
+          "default": [],
+          "title": "The tolerations Schema",
+          "items": {},
+          "examples": [[]]
+        },
+        "podAnnotations": {
+          "type": "object",
+          "default": {},
+          "title": "The podAnnotations Schema",
+          "required": [],
+          "properties": {},
+          "examples": [{}]
+        },
+        "podLabels": {
+          "type": "object",
+          "default": {},
+          "title": "The podLabels Schema",
+          "required": [],
+          "properties": {},
+          "examples": [{}]
+        },
+        "annotations": {
+          "type": "object",
+          "default": {},
+          "title": "The annotations Schema",
+          "required": [],
+          "properties": {},
+          "examples": [{}]
+        },
+        "labels": {
+          "type": "object",
+          "default": {},
+          "title": "The labels Schema",
+          "required": [],
+          "properties": {},
+          "examples": [{}]
+        },
+        "image": {
+          "type": "object",
+          "default": {},
+          "title": "The image Schema",
+          "required": ["repository", "tag"],
+          "properties": {
+            "repository": {
+              "type": "string",
+              "default": "",
+              "title": "The repository Schema",
+              "examples": ["2gis-on-premise/pro-ui"]
+            },
+            "tag": {
+              "type": "string",
+              "default": "",
+              "title": "The tag Schema",
+              "examples": ["0.1.5"]
+            }
+          },
+          "examples": [
+            {
+              "repository": "2gis-on-premise/pro-ui",
+              "tag": "0.1.5"
+            }
+          ]
+        },
+        "logLevel": {
+          "type": "string",
+          "pattern": "^error$",
+          "default": "error",
+          "title": "The logLevel Schema",
+          "examples": ["error"]
+        },
+        "isOnPremise": {
+          "type": "string",
+          "pattern": "^(false|true)$",
+          "default": "true",
+          "title": "The isOnPremise Schema",
+          "examples": ["true", "false"]
+        },
+        "ssoAuth": {
+          "type": "string",
+          "pattern": "^(false|true)$",
+          "default": "false",
+          "title": "The ssoAuth Schema",
+          "examples": ["false", "true"]
+        },
+        "appTheme": {
+          "type": "string",
+          "pattern": "^(urbi|2gis)$",
+          "default": "urbi",
+          "title": "The appTheme Schema",
+          "examples": ["urbi", "2gis"]
+        },
+        "appLocale": {
+          "type": "string",
+          "pattern": "^(en_AE|ru_RU)$",
+          "default": "en_AE",
+          "title": "The appLocale Schema",
+          "examples": ["en_AE", "ru_RU"]
+        },
+        "appInitialMapCenter": {
+          "type": "string",
+          "default": "[46.71, 24.72]",
+          "title": "The appInitialMapCenter Schema",
+          "examples": ["[46.71, 24.72]", "[37.64, 55.74]"]
+        },
+        "api": {
+          "type": "object",
+          "default": {},
+          "title": "The api Schema",
+          "required": ["url"],
+          "properties": {
+            "url": {
+              "type": "string",
+              "pattern": "^.*/$",
+              "default": "",
+              "title": "The url Schema",
+              "examples": ["https://pro-back.4geo.info/"]
+            }
+          },
+          "examples": [
+            {
+              "url": "https://pro-back.4geo.info/"
+            }
+          ]
+        },
+        "mapgl": {
+          "type": "object",
+          "default": {},
+          "title": "The mapgl Schema",
+          "required": ["host", "key", "styleUrl", "styleIconsUrl", "styleFontsUrl"],
+          "properties": {
+            "host": {
+              "type": "string",
+              "default": "",
+              "title": "The host Schema",
+              "examples": ["pro-js.4geo.info"]
+            },
+            "key": {
+              "type": "string",
+              "default": "",
+              "title": "The key Schema",
+              "examples": ["5eea1dd3-8913-4cda-82a0-496108e5794c"]
+            },
+            "styleUrl": {
+              "type": "string",
+              "default": "",
+              "title": "The styleUrl Schema",
+              "examples": [""]
+            },
+            "styleIconsUrl": {
+              "type": "string",
+              "default": "",
+              "title": "The styleIconsUrl Schema",
+              "examples": [""]
+            },
+            "styleFontsUrl": {
+              "type": "string",
+              "default": "",
+              "title": "The styleFontsUrl Schema",
+              "examples": [""]
+            }
+          },
+          "examples": [
+            {
+              "host": "pro-js.4geo.info",
+              "key": "e33e75a9-0818-4bfd-8147-84ca82543865",
+              "styleUrl": "",
+              "styleIconsUrl": "",
+              "styleFontsUrl": ""
+            }
+          ]
+        },
+        "strategy": {
+          "type": "object",
+          "default": {},
+          "title": "The strategy Schema",
+          "required": ["type", "rollingUpdate"],
+          "properties": {
+            "type": {
+              "type": "string",
+              "default": "RollingUpdate",
+              "title": "The type Schema",
+              "examples": ["RollingUpdate"]
+            },
+            "rollingUpdate": {
+              "type": "object",
+              "default": {},
+              "title": "The rollingUpdate Schema",
+              "required": ["maxUnavailable", "maxSurge"],
+              "properties": {
+                "maxUnavailable": {
+                  "type": "integer",
+                  "default": 0,
+                  "title": "The maxUnavailable Schema",
+                  "examples": [0]
+                },
+                "maxSurge": {
+                  "type": "integer",
+                  "default": 0,
+                  "title": "The maxSurge Schema",
+                  "examples": [1]
+                }
+              },
+              "examples": [
+                {
+                  "maxUnavailable": 0,
+                  "maxSurge": 1
+                }
+              ]
+            }
+          },
+          "examples": [
+            {
+              "type": "RollingUpdate",
+              "rollingUpdate": {
+                "maxUnavailable": 0,
+                "maxSurge": 1
+              }
+            }
+          ]
+        },
+        "service": {
+          "type": "object",
+          "default": {},
+          "title": "The service Schema",
+          "required": ["annotations", "labels", "type", "port"],
+          "properties": {
+            "annotations": {
+              "type": "object",
+              "default": {},
+              "title": "The annotations Schema",
+              "required": [],
+              "properties": {},
+              "examples": [{}]
+            },
+            "labels": {
+              "type": "object",
+              "default": {},
+              "title": "The labels Schema",
+              "required": [],
+              "properties": {},
+              "examples": [{}]
+            },
+            "type": {
+              "type": "string",
+              "default": "",
+              "title": "The type Schema",
+              "examples": ["ClusterIP"]
+            },
+            "port": {
+              "type": "integer",
+              "default": 0,
+              "title": "The port Schema",
+              "examples": [3000]
+            }
+          },
+          "examples": [
+            {
+              "annotations": {},
+              "labels": {},
+              "type": "ClusterIP",
+              "port": 3000
+            }
+          ]
+        },
+        "ingress": {
+          "type": "object",
+          "default": {},
+          "title": "The ingress Schema",
+          "required": ["enabled", "hosts"],
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "default": false,
+              "title": "The enabled Schema",
+              "examples": [false, true]
+            },
+            "hosts": {
+              "type": "array",
+              "default": [],
+              "title": "The hosts Schema",
+              "items": {
+                "type": "object",
+                "default": {},
+                "title": "A Schema",
+                "required": ["host"],
+                "properties": {
+                  "host": {
+                    "type": "string",
+                    "default": "",
+                    "title": "The host Schema",
+                    "examples": ["pro-ui.host"]
+                  }
+                },
+                "examples": [
+                  {
+                    "host": "pro-ui.host"
+                  }
+                ]
+              },
+              "examples": [
+                [
+                  {
+                    "host": "pro-ui.host"
+                  }
+                ]
+              ]
+            }
+          },
+          "examples": [
+            {
+              "enabled": false,
+              "hosts": [
+                {
+                  "host": "pro-ui.host"
+                }
+              ]
+            }
+          ]
+        },
+        "resources": {
+          "type": "object",
+          "default": {},
+          "title": "The resources Schema",
+          "required": ["requests", "limits"],
+          "properties": {
+            "requests": {
+              "type": "object",
+              "default": {},
+              "title": "The requests Schema",
+              "required": ["cpu", "memory"],
+              "properties": {
+                "cpu": {
+                  "type": "string",
+                  "pattern": "^\\d+m$",
+                  "default": "300m",
+                  "title": "The cpu Schema",
+                  "examples": ["300m"]
+                },
+                "memory": {
+                  "type": "string",
+                  "pattern": "^\\d+Mi$",
+                  "default": "256Mi",
+                  "title": "The memory Schema",
+                  "examples": ["256Mi"]
+                }
+              },
+              "examples": [
+                {
+                  "cpu": "300m",
+                  "memory": "256Mi"
+                }
+              ]
+            },
+            "limits": {
+              "type": "object",
+              "default": {},
+              "title": "The limits Schema",
+              "required": ["cpu", "memory"],
+              "properties": {
+                "cpu": {
+                  "type": "integer",
+                  "default": 0,
+                  "title": "The cpu Schema",
+                  "examples": [1]
+                },
+                "memory": {
+                  "type": "string",
+                  "pattern": "^\\d+Mi$",
+                  "default": "384Mi",
+                  "title": "The memory Schema",
+                  "examples": ["384Mi"]
+                }
+              },
+              "examples": [
+                {
+                  "cpu": 1,
+                  "memory": "384Mi"
+                }
+              ]
+            }
+          },
+          "examples": [
+            {
+              "requests": {
+                "cpu": "300m",
+                "memory": "256Mi"
+              },
+              "limits": {
+                "cpu": 1,
+                "memory": "384Mi"
+              }
+            }
+          ]
+        }
+      },
+      "examples": [
+        {
+          "replicas": 1,
+          "nodeSelector": {},
+          "affinity": {},
+          "tolerations": [],
+          "podAnnotations": {},
+          "podLabels": {},
+          "annotations": {},
+          "labels": {},
+          "image": {
+            "repository": "2gis-on-premise/pro-ui",
+            "tag": "0.1.5"
+          },
+          "logLevel": "error",
+          "isOnPremise": "true",
+          "ssoAuth": "false",
+          "appTheme": "urbi",
+          "appLocale": "en_AE",
+          "appInitialMapCenter": "[46.71, 24.72]",
+          "api": {
+            "url": "https://pro-back.4geo.info/"
+          },
+          "mapgl": {
+            "host": "pro-js.4geo.info",
+            "key": "e33e75a9-0818-4bfd-8147-84ca82543865",
+            "styleUrl": "",
+            "styleIconsUrl": "",
+            "styleFontsUrl": ""
+          },
+          "strategy": {
+            "type": "RollingUpdate",
+            "rollingUpdate": {
+              "maxUnavailable": 0,
+              "maxSurge": 1
+            }
+          },
+          "service": {
+            "annotations": {},
+            "labels": {},
+            "type": "ClusterIP",
+            "port": 3000
+          },
+          "ingress": {
+            "enabled": false,
+            "hosts": [
+              {
+                "host": "pro-ui.host"
+              }
+            ]
+          },
+          "resources": {
+            "requests": {
+              "cpu": "300m",
+              "memory": "256Mi"
+            },
+            "limits": {
+              "cpu": 1,
+              "memory": "384Mi"
+            }
+          }
+        }
+      ]
+    }
+  },
+  "examples": [
+    {
+      "dgctlDockerRegistry": "",
+      "imagePullPolicy": "IfNotPresent",
+      "imagePullSecrets": [],
+      "ui": {
+        "replicas": 1,
+        "nodeSelector": {},
+        "affinity": {},
+        "tolerations": [],
+        "podAnnotations": {},
+        "podLabels": {},
+        "annotations": {},
+        "labels": {},
+        "image": {
+          "repository": "2gis-on-premise/pro-ui",
+          "tag": "0.1.5"
+        },
+        "logLevel": "error",
+        "isOnPremise": "true",
+        "ssoAuth": "false",
+        "appTheme": "urbi",
+        "appLocale": "en_AE",
+        "appInitialMapCenter": "[46.71, 24.72]",
+        "api": {
+          "url": "https://pro-back.4geo.info/"
+        },
+        "mapgl": {
+          "host": "pro-js.4geo.info",
+          "key": "e33e75a9-0818-4bfd-8147-84ca82543865",
+          "styleUrl": "",
+          "styleIconsUrl": "",
+          "styleFontsUrl": ""
+        },
+        "strategy": {
+          "type": "RollingUpdate",
+          "rollingUpdate": {
+            "maxUnavailable": 0,
+            "maxSurge": 1
+          }
+        },
+        "service": {
+          "annotations": {},
+          "labels": {},
+          "type": "ClusterIP",
+          "port": 3000
+        },
+        "ingress": {
+          "enabled": false,
+          "hosts": [
+            {
+              "host": "pro-ui.host"
+            }
+          ]
+        },
+        "resources": {
+          "requests": {
+            "cpu": "300m",
+            "memory": "256Mi"
+          },
+          "limits": {
+            "cpu": 1,
+            "memory": "384Mi"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/charts/pro-ui/values.schema.json
+++ b/charts/pro-ui/values.schema.json
@@ -107,6 +107,7 @@
         "image": {
           "type": "object",
           "default": {},
+          "additionalProperties": false,
           "title": "The image Schema",
           "required": ["repository", "tag"],
           "properties": {
@@ -160,11 +161,13 @@
         "api": {
           "type": "object",
           "default": {},
+          "additionalProperties": false,
           "title": "The api Schema",
           "required": ["url"],
           "properties": {
             "url": {
               "type": "string",
+              "pattern": "^(https?://.+/)?$",
               "default": "",
               "title": "The url Schema"
             }
@@ -174,7 +177,8 @@
           "type": "object",
           "default": {},
           "title": "The mapgl Schema",
-          "required": ["host", "key", "styleUrl", "styleIconsUrl", "styleFontsUrl"],
+          "required": ["host", "key"],
+          "additionalProperties": false,
           "properties": {
             "host": {
               "type": "string",
@@ -207,7 +211,6 @@
           "type": "object",
           "default": {},
           "title": "The strategy Schema",
-          "required": ["type", "rollingUpdate"],
           "properties": {
             "type": {
               "type": "string",
@@ -300,6 +303,7 @@
         "resources": {
           "type": "object",
           "default": {},
+          "additionalProperties": false,
           "title": "The resources Schema",
           "required": ["requests", "limits"],
           "properties": {

--- a/charts/pro-ui/values.schema.json
+++ b/charts/pro-ui/values.schema.json
@@ -124,31 +124,31 @@
         },
         "logLevel": {
           "type": "string",
-          "pattern": "^error$",
+          "enum": ["error"],
           "default": "error",
           "title": "The logLevel Schema"
         },
         "isOnPremise": {
           "type": "string",
-          "pattern": "^(false|true)$",
+          "enum": ["true", "false"],
           "default": "true",
           "title": "The isOnPremise Schema"
         },
         "ssoAuth": {
           "type": "string",
-          "pattern": "^(false|true)$",
+          "enum": ["true", "false"],
           "default": "false",
           "title": "The ssoAuth Schema"
         },
         "appTheme": {
           "type": "string",
-          "pattern": "^(urbi|2gis)$",
+          "enum": ["urbi", "2gis"],
           "default": "urbi",
           "title": "The appTheme Schema"
         },
         "appLocale": {
           "type": "string",
-          "pattern": "^(en_AE|ru_RU)$",
+          "enum": ["en_AE", "ru_RU"],
           "default": "en_AE",
           "title": "The appLocale Schema"
         },

--- a/charts/pro-ui/values.schema.json
+++ b/charts/pro-ui/values.schema.json
@@ -26,6 +26,7 @@
       "type": "object",
       "default": {},
       "title": "The ui Schema",
+      "additionalProperties": false,
       "required": [
         "replicas",
         "nodeSelector",

--- a/charts/pro-ui/values.yaml
+++ b/charts/pro-ui/values.yaml
@@ -60,7 +60,7 @@ ui:
   # @param ui.api.url Base URL for the Pro API with protocol and trailing slash, ex: http://pro-api.ingress.host/.
 
   api:
-    url: 'https://pro-back.4geo.info/'
+    url: 'pro-back.host'
 
   # @section MapGL JS API settings
 

--- a/charts/pro-ui/values.yaml
+++ b/charts/pro-ui/values.yaml
@@ -2,7 +2,7 @@
 
 # @param dgctlDockerRegistry Docker Registry endpoint where On-Premise services' images reside. Format: `host:port`.
 
-dgctlDockerRegistry: ''
+dgctlDockerRegistry: 'host:3000'
 
 imagePullPolicy: IfNotPresent
 imagePullSecrets: []
@@ -60,7 +60,7 @@ ui:
   # @param ui.api.url Base URL for the Pro API with protocol and trailing slash, ex: http://pro-api.ingress.host/.
 
   api:
-    url: ''
+    url: 'https://pro-back.4geo.info/'
 
   # @section MapGL JS API settings
 
@@ -110,7 +110,7 @@ ui:
   ingress:
     enabled: false
     hosts:
-    - host: pro-ui.host
+      - host: pro-ui.host
 
   # @section Limits
 

--- a/charts/pro-ui/values.yaml
+++ b/charts/pro-ui/values.yaml
@@ -2,7 +2,7 @@
 
 # @param dgctlDockerRegistry Docker Registry endpoint where On-Premise services' images reside. Format: `host:port`.
 
-dgctlDockerRegistry: 'host:3000'
+dgctlDockerRegistry: ''
 
 imagePullPolicy: IfNotPresent
 imagePullSecrets: []

--- a/charts/pro-ui/values.yaml
+++ b/charts/pro-ui/values.yaml
@@ -60,7 +60,7 @@ ui:
   # @param ui.api.url Base URL for the Pro API with protocol and trailing slash, ex: http://pro-api.ingress.host/.
 
   api:
-    url: 'pro-back.host'
+    url: ''
 
   # @section MapGL JS API settings
 


### PR DESCRIPTION
Добавил values.schema.json, чтобы можно проверить было values по ней при `helm install|lint`. Схема подтянется автоматом, ничего спецом делать не надо. Главное, чтобы файлик с values назывался `values.yaml` и был рядом со схемой.

@Fullmetal8ender 