### PR TITLE
IODEV-1329: Убрал `data-type` из конфигмапы импортера

### DIFF
--- a/charts/tiles-api/templates/import.configmap.yaml
+++ b/charts/tiles-api/templates/import.configmap.yaml
@@ -14,7 +14,6 @@ data:
   importer.yaml: |
     {{- $serviceName := include "importer.serviceName" $type.kind }}
     service-name: {{ required (printf "Valid .Values.types[%d].kind required" $index) $serviceName }}
-    data-type: {{ $type.kind }}
     cassandra:
       name: local
       num-retries: 2


### PR DESCRIPTION
Начиная с `4.43.0` это поле больше не используется - теперь мы берём тип данных из манифеста