### PR TITLE
IODEV-1350: Чарты для license v2.0

### DIFF
--- a/charts/license/Chart.yaml
+++ b/charts/license/Chart.yaml
@@ -4,7 +4,7 @@ type: application
 description: A Helm chart for Kubernetes to deploy License service
 
 version: 1.8.0
-appVersion: 2.0.0
+appVersion: 2.0.1
 
 maintainers:
 - name: 2gis

--- a/charts/license/Chart.yaml
+++ b/charts/license/Chart.yaml
@@ -4,7 +4,7 @@ type: application
 description: A Helm chart for Kubernetes to deploy License service
 
 version: 1.8.0
-appVersion: 1.0.1
+appVersion: 2.0.0
 
 maintainers:
 - name: 2gis

--- a/charts/license/README.md
+++ b/charts/license/README.md
@@ -6,8 +6,7 @@ Read more about the On-Premise solution [here](https://docs.2gis.com/en/on-premi
 >
 > All On-Premise services are beta, and under development.
 
-<!--- FIXME: add documentation with link --->
-See the [documentation](https://docs.2gis.com/en/on-premise/overview) to learn about:
+See the [documentation](https://docs.2gis.com/en/on-premise/architecture/services/license) to learn about:
 
 - Architecture of the service.
 
@@ -48,12 +47,12 @@ See the [documentation](https://docs.2gis.com/en/on-premise/overview) to learn a
 | `affinity`         | Kubernetes pod [affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity) settings. | `{}`  |
 | `imagePullSecrets` | Kubernetes image pull secrets.                                                                                              | `[]`  |
 
-### Deployment settings
+### StatefulSet settings
 
 | Name               | Description  | Value                     |
 | ------------------ | ------------ | ------------------------- |
 | `image.repository` | Repository.  | `2gis-on-premise/license` |
-| `image.tag`        | Tag.         | `1.0.1`                   |
+| `image.tag`        | Tag.         | `2.0.0`                   |
 | `image.pullPolicy` | Pull Policy. | `IfNotPresent`            |
 
 ### License service application settings
@@ -69,7 +68,8 @@ See the [documentation](https://docs.2gis.com/en/on-premise/overview) to learn a
 | Name                  | Description                                                                                                                    | Value       |
 | --------------------- | ------------------------------------------------------------------------------------------------------------------------------ | ----------- |
 | `service.type`        | Kubernetes [service type](https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types). | `ClusterIP` |
-| `service.port`        | Service port.                                                                                                                  | `80`        |
+| `service.statusPort`  | Service port for status page and api/v1 (HTTP).                                                                                | `80`        |
+| `service.apiPort`     | Service port for api/v2 (HTTPS).                                                                                               | `443`       |
 | `service.annotations` | Kubernetes [service annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/).              | `{}`        |
 | `service.labels`      | Kubernetes [service labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/).                        | `{}`        |
 
@@ -88,4 +88,11 @@ See the [documentation](https://docs.2gis.com/en/on-premise/overview) to learn a
 | `resources.requests.memory` | A memory request. | `128Mi` |
 | `resources.limits.cpu`      | A CPU limit.      | `1`     |
 | `resources.limits.memory`   | A memory limit.   | `512Mi` |
+
+### Persistence
+
+| Name                           | Description                                                                  | Value  |
+| ------------------------------ | ---------------------------------------------------------------------------- | ------ |
+| `persistence.storage`          | Storage size for the persistence PersistentVolumes, should be at least 10Mi. | `10Mi` |
+| `persistence.storageClassName` | Storage class name for the persistence PersistentVolumes.                    | `""`   |
 

--- a/charts/license/README.md
+++ b/charts/license/README.md
@@ -91,8 +91,16 @@ See the [documentation](https://docs.2gis.com/en/on-premise/architecture/service
 
 ### Persistence
 
-| Name                           | Description                                                                  | Value  |
-| ------------------------------ | ---------------------------------------------------------------------------- | ------ |
-| `persistence.storage`          | Storage size for the persistence PersistentVolumes, should be at least 10Mi. | `10Mi` |
-| `persistence.storageClassName` | Storage class name for the persistence PersistentVolumes.                    | `""`   |
+| Name                              | Description                                                                                            | Value  |
+| --------------------------------- | ------------------------------------------------------------------------------------------------------ | ------ |
+| `persistence.type`                | Type of storage used for persistence, should be one of: 's3' - for S3 storage, 'fs' - for PVC storage. | `s3`   |
+| `persistence.fs`                  | **PVC setting for the 'fs' persistence type**                                                          |        |
+| `persistence.fs.storage`          | Storage size, should be at least 10Mi.                                                                 | `10Mi` |
+| `persistence.fs.storageClassName` | Storage class name.                                                                                    | `""`   |
+| `persistence.s3`                  | **S3 setting for the 's3' persistence type**                                                           |        |
+| `persistence.s3.host`             | S3 endpoint. Format: `host:port`.                                                                      | `""`   |
+| `persistence.s3.bucket`           | S3 bucket name.                                                                                        | `""`   |
+| `persistence.s3.root`             | Root directory in S3 bucket.                                                                           | `""`   |
+| `persistence.s3.accessKey`        | S3 access key for accessing the bucket.                                                                | `""`   |
+| `persistence.s3.secretKey`        | S3 secret key for accessing the bucket.                                                                | `""`   |
 

--- a/charts/license/templates/NOTES.txt
+++ b/charts/license/templates/NOTES.txt
@@ -5,9 +5,9 @@ You can check the status of the app using command
 kubectl get pods -n {{ .Release.Namespace}} -l app.kubernetes.io/name={{ include "license.name" . }} -l app.kubernetes.io/instance={{ .Release.Name }}
 
 {{- if .Values.ingress.enabled }}
-You can check service using curl
+You can check service using browser
 {{- range $host := .Values.ingress.hosts }}
-  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}/api/v1/authority/check
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}/status
 {{- end }}
 {{- else }}
 You should publish the service in your preferred way (ingress, balancer, etc).

--- a/charts/license/templates/configmap.yaml
+++ b/charts/license/templates/configmap.yaml
@@ -16,7 +16,8 @@ data:
       retry-period: {{ .retryPeriod }}
       warning-period: {{ .softBlockPeriod }}
     server:
-      port: {{ .appPort }}
+      http-port: {{ .statusPort }}
+      https-port: {{ .apiPort }}
     {{- end }}
     {{- with .dgctlStorage }}
     storage:
@@ -25,5 +26,7 @@ data:
         host: {{ required "A valid $.Values.dgctlStorage.host entry is required" .host }}
         bucket: {{ required "A valid $.Values.dgctlStorage.bucket entry is required" .bucket }}
     {{- end }}
+    persistence:
+      root: /persistence
 
 {{- end -}}

--- a/charts/license/templates/configmap.yaml
+++ b/charts/license/templates/configmap.yaml
@@ -26,7 +26,20 @@ data:
         host: {{ required "A valid $.Values.dgctlStorage.host entry is required" .host }}
         bucket: {{ required "A valid $.Values.dgctlStorage.bucket entry is required" .bucket }}
     {{- end }}
+    {{- with .persistence }}
     persistence:
-      root: /persistence
+      type: {{ .type }}
+      {{- if eq .type "fs" }}
+      fs:
+        root: /persistence
+      {{- else if eq .type "s3" }}
+      s3:
+        host: {{ .s3.host }}
+        bucket: {{ .s3.bucket }}
+        root: {{ .s3.root }}
+      {{- else }}
+      {{- required "$.persistence.type should be one of: ['fs', 's3']" ""}}
+      {{- end }}
+    {{- end }}
 
 {{- end -}}

--- a/charts/license/templates/ingress.yaml
+++ b/charts/license/templates/ingress.yaml
@@ -41,7 +41,7 @@ spec:
               service:
                 name: {{ include "license.fullname" $ }}
                 port:
-                  name: http
+                  name: status
           {{- end }}
     {{- end }}
 

--- a/charts/license/templates/secret.yaml
+++ b/charts/license/templates/secret.yaml
@@ -1,3 +1,5 @@
+{{- with .Values -}}
+
 ---
 apiVersion: v1
 kind: Secret
@@ -7,7 +9,13 @@ metadata:
     {{- include "license.labels" $ | nindent 4 }}
 type: Opaque
 data:
-  {{- with .Values.dgctlStorage }}
+  {{- with .dgctlStorage }}
   s3AccessKey: {{ required "A valid $.Values.dgctlStorage.accessKey entry is required" .accessKey | b64enc }}
   s3SecretKey: {{ required "A valid $.Values.dgctlStorage.secretKey entry is required" .secretKey | b64enc }}
   {{- end }}
+  {{- if eq .persistence.type "s3" }}
+  persistenceS3AccessKey: {{ required "A valid $.Values.persistence.s3.accessKey entry is required" .persistence.s3.accessKey | b64enc }}
+  persistenceS3SecretKey: {{ required "A valid $.Values.persistence.s3.secretKey entry is required" .persistence.s3.secretKey | b64enc }}
+  {{- end }}
+
+{{- end }}

--- a/charts/license/templates/service.yaml
+++ b/charts/license/templates/service.yaml
@@ -19,8 +19,11 @@ spec:
     {{- include "license.selectorLabels" $ | nindent 4 }}
   type: {{ .type }}
   ports:
-    - port: {{ .port }}
-      name: http
-      targetPort: http
+    - port: {{ .statusPort }}
+      name: status
+      targetPort: status
+    - port: {{ .apiPort }}
+      name: api
+      targetPort: api
 
 {{- end -}}

--- a/charts/license/templates/statefulset.yaml
+++ b/charts/license/templates/statefulset.yaml
@@ -67,8 +67,10 @@ spec:
           volumeMounts:
             - mountPath: /config
               name: config
+            {{- if eq .persistence.type "fs" }}
             - mountPath: /persistence
               name: persistence
+            {{- end }}
           env:
             - name: CONFIG_PATH
               value: /config/config.yaml
@@ -76,16 +78,28 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP
-            - name: S3_ACCESS_KEY
+            - name: STORAGE_ACCESS_KEY
               valueFrom:
                 secretKeyRef:
                   name: {{ include "license.fullname" $ }}
                   key: s3AccessKey
-            - name: S3_SECRET_KEY
+            - name: STORAGE_SECRET_KEY
               valueFrom:
                 secretKeyRef:
                   name: {{ include "license.fullname" $ }}
                   key: s3SecretKey
+            {{- if eq .persistence.type "s3"}}
+            - name: PERSISTENCE_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "license.fullname" $ }}
+                  key: persistenceS3AccessKey
+            - name: PERSISTENCE_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "license.fullname" $ }}
+                  key: persistenceS3SecretKey
+            {{- end }}
           resources:
             {{- toYaml .resources | nindent 12 }}
       volumes:
@@ -108,7 +122,8 @@ spec:
       imagePullSecrets:
         {{- toYaml .imagePullSecrets | nindent 8 }}
       {{- end }}
-  {{- with .persistence }}
+  {{- if eq .persistence.type "fs" }}
+  {{- with .persistence.fs }}
   volumeClaimTemplates:
     - metadata:
         name: persistence
@@ -120,9 +135,10 @@ spec:
           requests:
             storage: {{ .storage }}
         storageClassName: {{ .storageClassName }}
-  {{- end }}
   persistentVolumeClaimRetentionPolicy:
     whenDeleted: Delete
     whenScaled: Delete
+  {{- end }}
+  {{- end }}
 
 {{- end -}}

--- a/charts/license/templates/statefulset.yaml
+++ b/charts/license/templates/statefulset.yaml
@@ -16,6 +16,7 @@ metadata:
     {{- end }}
 spec:
   replicas: 1
+  serviceName: {{ include "license.fullname" $ }}
   selector:
     matchLabels:
       {{- include "license.selectorLabels" $ | nindent 6 }}

--- a/charts/license/templates/statefulset.yaml
+++ b/charts/license/templates/statefulset.yaml
@@ -2,7 +2,7 @@
 
 ---
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: {{ include "license.fullname" $ }}
   {{- if not (empty .annotations) }}
@@ -15,7 +15,7 @@ metadata:
     {{- toYaml .labels | nindent 4 }}
     {{- end }}
 spec:
-  replicas: {{ .replicaCount }}
+  replicas: 1
   selector:
     matchLabels:
       {{- include "license.selectorLabels" $ | nindent 6 }}
@@ -39,16 +39,18 @@ spec:
           image: "{{ required "A valid $.Values.dgctlDockerRegistry entry required" $.Values.dgctlDockerRegistry }}/{{ .repository }}:{{ .tag }}"
           imagePullPolicy: {{ .pullPolicy }}
           {{- end }}
-          command: ["/license"]
+          command: ["/bin/license"]
           ports:
-            - containerPort: {{ .license.appPort }}
-              name: http
+            - containerPort: {{ .license.statusPort }}
+              name: status
+            - containerPort: {{ .license.apiPort }}
+              name: api
           startupProbe:
             {{- $startupInitialDelaySeconds := 10 }}
             {{- $startupPeriodSeconds := include "license.durationToSeconds" (dict "duration" $.Values.license.retryPeriod) }}
             {{- $startupFailureThreshold := 3 }}
             httpGet:
-              port: http
+              port: status
               path: /healthcheck
             initialDelaySeconds: {{ $startupInitialDelaySeconds }}
             periodSeconds: {{ $startupPeriodSeconds }}
@@ -56,7 +58,7 @@ spec:
             failureThreshold: {{ $startupFailureThreshold }}
           livenessProbe:
             httpGet:
-              port: http
+              port: status
               path: /healthcheck
             initialDelaySeconds: {{ add $startupInitialDelaySeconds (mul $startupPeriodSeconds $startupFailureThreshold) }}
             periodSeconds: 40
@@ -65,9 +67,15 @@ spec:
           volumeMounts:
             - mountPath: /config
               name: config
+            - mountPath: /persistence
+              name: persistence
           env:
             - name: CONFIG_PATH
               value: /config/config.yaml
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
             - name: S3_ACCESS_KEY
               valueFrom:
                 secretKeyRef:
@@ -100,5 +108,21 @@ spec:
       imagePullSecrets:
         {{- toYaml .imagePullSecrets | nindent 8 }}
       {{- end }}
+  {{- with .persistence }}
+  volumeClaimTemplates:
+    - metadata:
+        name: persistence
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        volumeMode: Filesystem
+        resources:
+          requests:
+            storage: {{ .storage }}
+        storageClassName: {{ .storageClassName }}
+  {{- end }}
+  persistentVolumeClaimRetentionPolicy:
+    whenDeleted: Delete
+    whenScaled: Delete
 
 {{- end -}}

--- a/charts/license/values.yaml
+++ b/charts/license/values.yaml
@@ -51,7 +51,7 @@ affinity: {}
 
 imagePullSecrets: []
 
-# @section Deployment settings
+# @section StatefulSet settings
 
 # @param image.repository Repository.
 # @param image.tag Tag.
@@ -59,7 +59,7 @@ imagePullSecrets: []
 
 image:
   repository: 2gis-on-premise/license
-  tag: 1.0.1
+  tag: 2.0.0
   pullPolicy: IfNotPresent
 
 # @section License service application settings
@@ -67,24 +67,28 @@ image:
 # @param license.updatePeriod Duration how often service should fetch new license from storage. Duration format is any string supported by (time.ParseDuration)[https://pkg.go.dev/time#ParseDuration].
 # @param license.retryPeriod Duration how often service should try to fetch license from storage if previous attempts were failing.
 # @param license.softBlockPeriod Duration until the license expiration time when license service should respond with 'soft' block status. For this duration additional time units 'd' for days and 'w' for weeks are supported.
-# @skip license.appPort
+# @skip license.statusPort
+# @skip license.apiPort
 
 license:
   updatePeriod: 1h
   retryPeriod: 30s
   softBlockPeriod: 2w
-  appPort: 8080
+  statusPort: 8080
+  apiPort: 8443
 
 # @section Service settings
 
 # @param service.type Kubernetes [service type](https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types).
-# @param service.port Service port.
+# @param service.statusPort Service port for status page and api/v1 (HTTP).
+# @param service.apiPort Service port for api/v2 (HTTPS).
 # @param service.annotations Kubernetes [service annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/).
 # @param service.labels Kubernetes [service labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/).
 
 service:
   type: ClusterIP
-  port: 80
+  statusPort: 80
+  apiPort: 443
   annotations: {}
   labels: {}
 
@@ -112,3 +116,12 @@ resources:
   requests:
     cpu: 50m
     memory: 128Mi
+
+# @section Persistence
+
+# @param persistence.storage Storage size for the persistence PersistentVolumes, should be at least 10Mi.
+# @param persistence.storageClassName Storage class name for the persistence PersistentVolumes.
+
+persistence:
+  storage: 10Mi
+  storageClassName: ''

--- a/charts/license/values.yaml
+++ b/charts/license/values.yaml
@@ -119,9 +119,27 @@ resources:
 
 # @section Persistence
 
-# @param persistence.storage Storage size for the persistence PersistentVolumes, should be at least 10Mi.
-# @param persistence.storageClassName Storage class name for the persistence PersistentVolumes.
+# @param persistence.type Type of storage used for persistence, should be one of: 's3' - for S3 storage, 'fs' - for PVC storage.
+
+# @extra persistence.fs **PVC setting for the 'fs' persistence type**
+# @param persistence.fs.storage Storage size, should be at least 10Mi.
+# @param persistence.fs.storageClassName Storage class name.
+
+# @extra persistence.s3 **S3 setting for the 's3' persistence type**
+# @param persistence.s3.host S3 endpoint. Format: `host:port`.
+# @param persistence.s3.bucket S3 bucket name.
+# @param persistence.s3.root Root directory in S3 bucket.
+# @param persistence.s3.accessKey S3 access key for accessing the bucket.
+# @param persistence.s3.secretKey S3 secret key for accessing the bucket.
 
 persistence:
-  storage: 10Mi
-  storageClassName: ''
+  type: s3
+  fs:
+    storage: 10Mi
+    storageClassName: ''
+  s3:
+    host: ''
+    bucket: ''
+    root: ''
+    accessKey: ''
+    secretKey: ''


### PR DESCRIPTION
## Описание

Обновил чарты для license v2.0 (пока что только для TRUSTED).
1. Переделал Deployment на StatefulSet (это будет нужно для TPM, но сразу закладываем это сюда).
2. Переделал порты, теперь есть:
   * `statusPort (80)` - страница статуса + api/v1
   * `apiPort (443)` - api/v2
3. Добавил persistence - пока что он обязательный, когда будем делать RAFT, сделаем его опциональным.

В целом всё пока что работает как прежде, никаких изменений со стороны клиентов / интегрируемых сервисов.

## Ломающие изменения

* `service.port` -> `service.statusPort`

## Как тестировать

В sandbox с такой конфигурацией:
```yaml
dgctlDockerRegistry: docker-hub.2gis.ru

image:
  repository: on-premise/license
  tag: 2.0.1

license:
  path: license

dgctlStorage:
  host: on-prem-minio.default.svc:9000
  bucket: datagateway
  accessKey: testingkey
  secretKey: testingsecret

ingress:
  enabled: true
  hosts:
    - host: 'license.${CLUSTER_DOMAIN}'
      paths:
        - path: "/"

persistence:
  s3:
    host: on-prem-minio.default.svc:9000
    bucket: datagateway
    root: /persistence
    accessKey: testingkey
    secretKey: testingsecret
```