### PR TITLE
Floorsserver env for mapgl-js-api

### DIFF
--- a/charts/mapgl-js-api/README.md
+++ b/charts/mapgl-js-api/README.md
@@ -57,6 +57,7 @@ See the [documentation](https://docs.2gis.com/en/on-premise/map) to learn about:
 | `env.MAPGL_TILESET`       | Tileset of the Tiles API service to use.               | `web`                                                                                             |
 | `env.MAPGL_TRAFFICSERVER` | Domain name of the Traffic Proxy service.              | `https://traffic-proxy.ingress.host`                                                              |
 | `env.MAPGL_KEYSERVER`     | Domain name of the API Keys service.                   | `https://keys-api.ingress.host`                                                                   |
+| `env.MAPGL_FLOORSSERVER`  | Domain name of the Floors API service.                 | `https://floors-api.ingress.host`                                                                   |
 | `env.MAPGL_RTLPLUGIN`     | URL of the plugin for right-to-left languages support. | `https://mapgl-api.ingress.host/api/js/plugins/rtl-v1.0.0.js`                                     |
 | `env.MAPGL_RTLPLUGINHASH` | SHA512 hash of the RTL plugin.                         | `sha512-YAPPEl+Atvsm/cMkrfWefmlQLAlKTGaqFjIkI6urAnDgam2uTVEVVnZZEhHCa91JjYYxa5yr4Ndb4Vl3NUovfA==` |
 

--- a/charts/mapgl-js-api/values.yaml
+++ b/charts/mapgl-js-api/values.yaml
@@ -47,7 +47,7 @@ image:
 # @param env.MAPGL_TILES_API Domain name of the Tiles API service.
 # @param env.MAPGL_TILESET Tileset of the Tiles API service to use.
 # @param env.MAPGL_TRAFFICSERVER Domain name of the Traffic Proxy service.
-# @skip env.MAPGL_FLOORSSERVER
+# @param env.MAPGL_FLOORSSERVER Domain name of the Floors API service.
 # @param env.MAPGL_KEYSERVER Domain name of the API Keys service.
 # @param env.MAPGL_RTLPLUGIN URL of the plugin for right-to-left languages support.
 # @param env.MAPGL_RTLPLUGINHASH SHA512 hash of the RTL plugin.
@@ -58,7 +58,7 @@ env:
   MAPGL_TILES_API: https://tiles-api.ingress.host
   MAPGL_TILESET: web
   MAPGL_TRAFFICSERVER: https://traffic-proxy.ingress.host
-  MAPGL_FLOORSSERVER: https://floors.api.2gis.ru
+  MAPGL_FLOORSSERVER: https://floors-api.ingress.host
   MAPGL_KEYSERVER: https://keys-api.ingress.host
   MAPGL_RTLPLUGIN: https://mapgl-api.ingress.host/api/js/plugins/rtl-v1.0.0.js
   MAPGL_RTLPLUGINHASH: sha512-YAPPEl+Atvsm/cMkrfWefmlQLAlKTGaqFjIkI6urAnDgam2uTVEVVnZZEhHCa91JjYYxa5yr4Ndb4Vl3NUovfA==


### PR DESCRIPTION
Правка переменной `MAPGL_FLOORSSERVER` для Mapgl JS API. Нужно слить после https://github.com/2gis/on-premise-helm-charts/pull/262.