### PR TITLE
IODEV-1469: Добавил liveness пробу для тайлсервера

### DIFF
--- a/charts/tiles-api/templates/deployment.yaml
+++ b/charts/tiles-api/templates/deployment.yaml
@@ -125,6 +125,14 @@ spec:
           image: {{ required "A valid .Values.dgctlDockerRegistry entry required" .Values.dgctlDockerRegistry }}/{{ .Values.api.image.repository }}:{{ .Values.api.image.tag }}
           imagePullPolicy: {{ .Values.api.image.pullPolicy }}
 
+          livenessProbe:
+            httpGet:
+              path: /healthcheck
+              port: {{ .Values.api.containerPort }}
+            initialDelaySeconds: 60
+            timeoutSeconds: 10
+            failureThreshold: 6
+
           volumeMounts:
             - mountPath: "/config"
               name: config-volume


### PR DESCRIPTION
## Описание

* Тайлсервер умеет сообщать о своём состоянии, но это не проверяется - добавил liveness пробу.
* Тайлсервер не смотрит никакими портами наружу, поэтому readiness проба тут бессмысленна - ей добавлять не стал.

## Почему сейчас?

Это нужно для фикса бага с пропадающей после полного рестарта кассандрой.