### PR TITLE
[tiles-api] Removed PEERS_IGNORE env from deployment

### DIFF
--- a/charts/tiles-api/templates/deployment.yaml
+++ b/charts/tiles-api/templates/deployment.yaml
@@ -143,8 +143,6 @@ spec:
               value: "true"
             - name: JAEGER_SERVICE_NAME
               value: "tiles"
-            - name: PEERS_IGNORE
-              value: "true"
             - name: CONFIG_FILE_PATH
               value: "/config/api.yaml"
             - name: API_PORT


### PR DESCRIPTION
Мы коллективно не смогли понять, зачем нам нужна здесь эта переменная, и она не даёт клиенту кассандры добавлять новые ноды - поэтому убираем