### PR TITLE
IODEV-1545: Добавил secure флаг в настройки S3

### DIFF
--- a/charts/license/README.md
+++ b/charts/license/README.md
@@ -24,12 +24,13 @@ See the [documentation](https://docs.2gis.com/en/on-premise/architecture/service
 
 ### Deployment Artifacts Storage settings
 
-| Name                     | Description                                  | Value |
-| ------------------------ | -------------------------------------------- | ----- |
-| `dgctlStorage.host`      | S3 endpoint. Format: `[scheme://]host:port`. | `""`  |
-| `dgctlStorage.bucket`    | S3 bucket name.                              | `""`  |
-| `dgctlStorage.accessKey` | S3 access key for accessing the bucket.      | `""`  |
-| `dgctlStorage.secretKey` | S3 secret key for accessing the bucket.      | `""`  |
+| Name                     | Description                             | Value   |
+| ------------------------ | --------------------------------------- | ------- |
+| `dgctlStorage.host`      | S3 endpoint. Format: `host:port`.       | `""`    |
+| `dgctlStorage.secure`    | If S3 uses https.                       | `false` |
+| `dgctlStorage.bucket`    | S3 bucket name.                         | `""`    |
+| `dgctlStorage.accessKey` | S3 access key for accessing the bucket. | `""`    |
+| `dgctlStorage.secretKey` | S3 secret key for accessing the bucket. | `""`    |
 
 ### Common settings
 
@@ -92,18 +93,19 @@ See the [documentation](https://docs.2gis.com/en/on-premise/architecture/service
 
 ### Persistence
 
-| Name                              | Description                                                                                            | Value  |
-| --------------------------------- | ------------------------------------------------------------------------------------------------------ | ------ |
-| `persistence.type`                | Type of storage used for persistence, should be one of: 's3' - for S3 storage, 'fs' - for PVC storage. | `s3`   |
-| `persistence.fs`                  | **PVC setting for the 'fs' persistence type**                                                          |        |
-| `persistence.fs.storage`          | Storage size, should be at least 10Mi.                                                                 | `10Mi` |
-| `persistence.fs.storageClassName` | Storage class name.                                                                                    | `""`   |
-| `persistence.s3`                  | **S3 setting for the 's3' persistence type**                                                           |        |
-| `persistence.s3.host`             | S3 endpoint. Format: `[scheme://]host:port`.                                                           | `""`   |
-| `persistence.s3.bucket`           | S3 bucket name.                                                                                        | `""`   |
-| `persistence.s3.root`             | Root directory in S3 bucket.                                                                           | `""`   |
-| `persistence.s3.accessKey`        | S3 access key for accessing the bucket.                                                                | `""`   |
-| `persistence.s3.secretKey`        | S3 secret key for accessing the bucket.                                                                | `""`   |
+| Name                              | Description                                                                                            | Value   |
+| --------------------------------- | ------------------------------------------------------------------------------------------------------ | ------- |
+| `persistence.type`                | Type of storage used for persistence, should be one of: 's3' - for S3 storage, 'fs' - for PVC storage. | `s3`    |
+| `persistence.fs`                  | **PVC setting for the 'fs' persistence type**                                                          |         |
+| `persistence.fs.storage`          | Storage size, should be at least 10Mi.                                                                 | `10Mi`  |
+| `persistence.fs.storageClassName` | Storage class name.                                                                                    | `""`    |
+| `persistence.s3`                  | **S3 setting for the 's3' persistence type**                                                           |         |
+| `persistence.s3.host`             | S3 endpoint. Format: `host:port`.                                                                      | `""`    |
+| `persistence.s3.secure`           | If S3 uses https.                                                                                      | `false` |
+| `persistence.s3.bucket`           | S3 bucket name.                                                                                        | `""`    |
+| `persistence.s3.root`             | Root directory in S3 bucket.                                                                           | `""`    |
+| `persistence.s3.accessKey`        | S3 access key for accessing the bucket.                                                                | `""`    |
+| `persistence.s3.secretKey`        | S3 secret key for accessing the bucket.                                                                | `""`    |
 
 ### TPM-related settings for license type 2
 

--- a/charts/license/templates/configmap.yaml
+++ b/charts/license/templates/configmap.yaml
@@ -24,6 +24,7 @@ data:
       type: s3
       s3:
         host: {{ required "A valid $.Values.dgctlStorage.host entry is required" .host }}
+        secure: {{ .secure }}
         bucket: {{ required "A valid $.Values.dgctlStorage.bucket entry is required" .bucket }}
     {{- end }}
     {{- with .persistence }}
@@ -35,6 +36,7 @@ data:
       {{- else if eq .type "s3" }}
       s3:
         host: {{ .s3.host }}
+        secure: {{ .s3.secure }}
         bucket: {{ .s3.bucket }}
         root: {{ .s3.root }}
       {{- else }}

--- a/charts/license/values.yaml
+++ b/charts/license/values.yaml
@@ -6,13 +6,15 @@ dgctlDockerRegistry: ''
 
 # @section Deployment Artifacts Storage settings
 
-# @param dgctlStorage.host S3 endpoint. Format: `[scheme://]host:port`.
+# @param dgctlStorage.host S3 endpoint. Format: `host:port`.
+# @param dgctlStorage.secure If S3 uses https.
 # @param dgctlStorage.bucket S3 bucket name.
 # @param dgctlStorage.accessKey S3 access key for accessing the bucket.
 # @param dgctlStorage.secretKey S3 secret key for accessing the bucket.
 
 dgctlStorage:
   host: ''
+  secure: false
   bucket: ''
   accessKey: ''
   secretKey: ''
@@ -130,7 +132,8 @@ resources:
 # @param persistence.fs.storageClassName Storage class name.
 
 # @extra persistence.s3 **S3 setting for the 's3' persistence type**
-# @param persistence.s3.host S3 endpoint. Format: `[scheme://]host:port`.
+# @param persistence.s3.host S3 endpoint. Format: `host:port`.
+# @param persistence.s3.secure If S3 uses https.
 # @param persistence.s3.bucket S3 bucket name.
 # @param persistence.s3.root Root directory in S3 bucket.
 # @param persistence.s3.accessKey S3 access key for accessing the bucket.
@@ -143,6 +146,7 @@ persistence:
     storageClassName: ''
   s3:
     host: ''
+    secure: false
     bucket: ''
     root: ''
     accessKey: ''


### PR DESCRIPTION
## Описание

Теперь вместо схемы в `host` используется флаг `secure`, который определяет, по какому протоколу надо общаться с S3.

## Тестирование

Можно протестировать на этом образе - `docker-hub.2gis.ru/on-premise/license:2.1.2`