### PR TITLE
Add bundilng python code for dmasync + DB schema parameter

### DIFF
--- a/Breaking-Changes.md
+++ b/Breaking-Changes.md
@@ -1,4 +1,16 @@
 # 2GIS On-Premise Breaking-Changes
+## [1.12.0]
+#### navi-async-matrix
+- Remove `hpa.scaleUpStabilizationWindowSeconds` and `.hpa.scaleDownStabilizationWindowSeconds`
+- Add `hpa.behavior`
+```yaml
+hpa:
+  behavior:
+    scaleUp:
+      stabilizationWindowSeconds: 500
+    scaleDown:
+      stabilizationWindowSeconds: 600
+```
 
 ## [1.10.0]
 #### pro-api

--- a/charts/navi-async-matrix/Chart.yaml
+++ b/charts/navi-async-matrix/Chart.yaml
@@ -5,7 +5,7 @@ description: Service implements asynchronous API over Distance Matrix
 type: application
 
 version: 1.11.0
-appVersion: 1.3.3
+appVersion: 1.6.1
 
 maintainers:
 - name: 2gis

--- a/charts/navi-async-matrix/Chart.yaml
+++ b/charts/navi-async-matrix/Chart.yaml
@@ -5,7 +5,7 @@ description: Service implements asynchronous API over Distance Matrix
 type: application
 
 version: 1.11.0
-appVersion: 1.6.1
+appVersion: 1.6.2
 
 maintainers:
 - name: 2gis

--- a/charts/navi-async-matrix/README.md
+++ b/charts/navi-async-matrix/README.md
@@ -138,19 +138,19 @@ See the [documentation](https://docs.2gis.com/en/on-premise/navigation/distance-
 
 ### Database settings
 
-| Name                 | Description                                 | Value         |
-| -------------------- | ------------------------------------------- | ------------- |
-| `db.host`            | PostgreSQL hostname or IP. **Required**     | `""`          |
-| `db.port`            | PostgreSQL port.                            | `5432`        |
-| `db.name`            | PostgreSQL database name. **Required**      | `""`          |
-| `db.user`            | PostgreSQL username. **Required**           | `""`          |
-| `db.password`        | PostgreSQL password. **Required**           | `""`          |
-| `db.schema`          | PostgreSQL schema.                          | `public`      |
-| `db.tls.enabled`     | If tls connection to postgresql is enabled. | `false`       |
-| `db.tls.sslRootCert` | Root certificate file.                      | `""`          |
-| `db.tls.sslCert`     | Certificate of postgresql server.           | `""`          |
-| `db.tls.sslKey`      | Key of postgresql server.                   | `""`          |
-| `db.tls.sslMode`     | Level of protection.                        | `verify-full` |
+| Name              | Description                                 | Value         |
+| ----------------- | ------------------------------------------- | ------------- |
+| `db.host`         | PostgreSQL hostname or IP. **Required**     | `""`          |
+| `db.port`         | PostgreSQL port.                            | `5432`        |
+| `db.name`         | PostgreSQL database name. **Required**      | `""`          |
+| `db.user`         | PostgreSQL username. **Required**           | `""`          |
+| `db.password`     | PostgreSQL password. **Required**           | `""`          |
+| `db.schema`       | PostgreSQL schema.                          | `public`      |
+| `db.tls.enabled`  | If tls connection to postgresql is enabled. | `false`       |
+| `db.tls.rootCert` | Root certificate file.                      | `""`          |
+| `db.tls.cert`     | Certificate of postgresql server.           | `""`          |
+| `db.tls.key`      | Key of postgresql server.                   | `""`          |
+| `db.tls.mode`     | Level of protection.                        | `verify-full` |
 
 ### Kafka settings
 

--- a/charts/navi-async-matrix/README.md
+++ b/charts/navi-async-matrix/README.md
@@ -154,6 +154,7 @@ See the [documentation](https://docs.2gis.com/en/on-premise/navigation/distance-
 | `kafka.groupId`                   | Distance Matrix Async API group identifier.                                                                               | `navi_async_matrix` |
 | `kafka.statusTopic`               | Name of the topic for sending new tasks to.                                                                               | `status_topic`      |
 | `kafka.cancelTopic`               | Name of the topic for canceling or receiving information about finished tasks.                                            | `cancel_topic`      |
+| `kafka.archiveTopic`              | Name of the topic for archiving tasks.                                                                                    | `archive_topic`     |
 | `kafka.properties`                | Properties as supported by kafka-python. Refer to inline comments for details.                                            |                     |
 | `kafka.sensitiveProperties`       | As kafka.properties, but kept in Secrets. Refer to inlines comments for details.                                          | `{}`                |
 | `kafka.fileProperties`            | As kafka.properties, but kept in a file, which passed to application as a filename. Refer to inline comments for details. | `{}`                |

--- a/charts/navi-async-matrix/README.md
+++ b/charts/navi-async-matrix/README.md
@@ -105,15 +105,14 @@ See the [documentation](https://docs.2gis.com/en/on-premise/navigation/distance-
 
 ### Kubernetes [Horizontal Pod Autoscaling](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/) settings
 
-| Name                                      | Description                                                                                                                                                          | Value   |
-| ----------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
-| `hpa.enabled`                             | If HPA is enabled for the service.                                                                                                                                   | `false` |
-| `hpa.minReplicas`                         | Lower limit for the number of replicas to which the autoscaler can scale down.                                                                                       | `1`     |
-| `hpa.maxReplicas`                         | Upper limit for the number of replicas to which the autoscaler can scale up.                                                                                         | `2`     |
-| `hpa.scaleDownStabilizationWindowSeconds` | Scale-down window.                                                                                                                                                   | `""`    |
-| `hpa.scaleUpStabilizationWindowSeconds`   | Scale-up window.                                                                                                                                                     | `""`    |
-| `hpa.targetCPUUtilizationPercentage`      | Target average CPU utilization (represented as a percentage of requested CPU) over all the pods; if not specified the default autoscaling policy will be used.       | `80`    |
-| `hpa.targetMemoryUtilizationPercentage`   | Target average memory utilization (represented as a percentage of requested memory) over all the pods; if not specified the default autoscaling policy will be used. | `""`    |
+| Name                                    | Description                                                                                                                                                          | Value   |
+| --------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| `hpa.enabled`                           | If HPA is enabled for the service.                                                                                                                                   | `false` |
+| `hpa.minReplicas`                       | Lower limit for the number of replicas to which the autoscaler can scale down.                                                                                       | `1`     |
+| `hpa.maxReplicas`                       | Upper limit for the number of replicas to which the autoscaler can scale up.                                                                                         | `2`     |
+| `hpa.targetCPUUtilizationPercentage`    | Target average CPU utilization (represented as a percentage of requested CPU) over all the pods; if not specified the default autoscaling policy will be used.       | `80`    |
+| `hpa.targetMemoryUtilizationPercentage` | Target average memory utilization (represented as a percentage of requested memory) over all the pods; if not specified the default autoscaling policy will be used. | `""`    |
+| `hpa.behavior`                          | HPA Behavior                                                                                                                                                         | `{}`    |
 
 ### Kubernetes [Vertical Pod Autoscaling](https://github.com/kubernetes/autoscaler/blob/master/vertical-pod-autoscaler/README.md) settings
 

--- a/charts/navi-async-matrix/README.md
+++ b/charts/navi-async-matrix/README.md
@@ -138,14 +138,14 @@ See the [documentation](https://docs.2gis.com/en/on-premise/navigation/distance-
 
 ### Database settings
 
-| Name          | Description                             		| Value    |
-| ------------- | ----------------------------------------------------- | -------- |
-| `db.host`     | PostgreSQL hostname or IP. **Required** 		| `""`     |
-| `db.port`     | PostgreSQL port.                        		| `5432`   |
-| `db.name`     | PostgreSQL database name. **Required**  		| `""`     |
-| `db.user`     | PostgreSQL username. **Required**       		| `""`     |
-| `db.password` | PostgreSQL password. **Required**       		| `""`     |
-| `db.schema`   | PostgreSQL schema. Must be specified in overrides.	| `public` |
+| Name          | Description                             																					| Value    |
+| ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
+| `db.host`     | PostgreSQL hostname or IP. **Required** 																					| `""`     |
+| `db.port`     | PostgreSQL port.                        																					| `5432`   |
+| `db.name`     | PostgreSQL database name. **Required**  																					| `""`     |
+| `db.user`     | PostgreSQL username. **Required**       																					| `""`     |
+| `db.password` | PostgreSQL password. **Required**       																					| `""`     |
+| `db.schema`   | PostgreSQL schema. Must be specified in overrides. If the database name changes, a new database with the specified schema will be created. Otherwise, the database will be recreated with a new schema.	| `public` |
 
 ### Kafka settings
 

--- a/charts/navi-async-matrix/README.md
+++ b/charts/navi-async-matrix/README.md
@@ -63,14 +63,6 @@ See the [documentation](https://docs.2gis.com/en/on-premise/navigation/distance-
 | `serviceAccount.annotations` | Annotations to add to the service account.                                                                              | `{}`    |
 | `serviceAccount.name`        | The name of the service account to use. If not set and create is true, a name is generated using the fullname template. | `""`    |
 
-### RBAC parameter
-
-| Name               | Description                                     | Value   |
-| ------------------ | ----------------------------------------------- | ------- |
-| `rbac.create`      | Whether to create and use RBAC resources or not | `false` |
-| `rbac.annotations` | Role and RoleBinding annotations                | `{}`    |
-| `rbac.labels`      | Role and RoleBinding additional labels          | `{}`    |
-
 ### Strategy settings
 
 | Name                  | Description                                                          | Value           |
@@ -136,16 +128,14 @@ See the [documentation](https://docs.2gis.com/en/on-premise/navigation/distance-
 
 ### Distance Matrix Async API settings
 
-| Name                         | Description                                                                                                                   | Value  |
-| ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------- | ------ |
-| `dm.port`                    | Distance Matrix Async API HTTP port.                                                                                          | `8000` |
-| `dm.configType`              | Configuration type. Must always be `env`.                                                                                     | `env`  |
-| `dm.logLevel`                | Logging level, one of: DEBUG, INFO, WARNING, ERROR, CRITICAL.                                                                 | `INFO` |
-| `dm.workerCount`             | Number of Distance Matrix Async workers.                                                                                      | `4`    |
-| `dm.citiesUrl`               | URL of the information about cities provided by the Navi-Castle service, ex: http://navi-castle.svc/cities.conf. **Required** | `""`   |
-| `dm.citiesUpdatePeriod`      | Period (in seconds) between requesting data from `citiesUrl`.                                                                 | `3600` |
-| `dm.taskSplitSize`           | Minimum size of matrix to get split in archiver job.                                                                          | `5000` |
-| `dm.compositeTaskTimeoutSec` | Timeout for executing split tasks.                                                                                            | `3600` |
+| Name                    | Description                                                                                                                   | Value  |
+| ----------------------- | ----------------------------------------------------------------------------------------------------------------------------- | ------ |
+| `dm.port`               | Distance Matrix Async API HTTP port.                                                                                          | `8000` |
+| `dm.configType`         | Configuration type. Must always be `env`.                                                                                     | `env`  |
+| `dm.logLevel`           | Logging level, one of: DEBUG, INFO, WARNING, ERROR, CRITICAL.                                                                 | `INFO` |
+| `dm.workerCount`        | Number of Distance Matrix Async workers.                                                                                      | `4`    |
+| `dm.citiesUrl`          | URL of the information about cities provided by the Navi-Castle service, ex: http://navi-castle.svc/cities.conf. **Required** | `""`   |
+| `dm.citiesUpdatePeriod` | Period (in seconds) between requesting data from `citiesUrl`.                                                                 | `3600` |
 
 ### Database settings
 
@@ -169,7 +159,6 @@ See the [documentation](https://docs.2gis.com/en/on-premise/navigation/distance-
 | `kafka.groupId`                   | Distance Matrix Async API group identifier.                                                                               | `navi_async_matrix` |
 | `kafka.statusTopic`               | Name of the topic for sending new tasks to.                                                                               | `status_topic`      |
 | `kafka.cancelTopic`               | Name of the topic for canceling or receiving information about finished tasks.                                            | `cancel_topic`      |
-| `kafka.archiveTopic`              | Name of the topic for archiving tasks.                                                                                    | `archive_topic`     |
 | `kafka.properties`                | Properties as supported by kafka-python. Refer to inline comments for details.                                            |                     |
 | `kafka.sensitiveProperties`       | As kafka.properties, but kept in Secrets. Refer to inlines comments for details.                                          | `{}`                |
 | `kafka.fileProperties`            | As kafka.properties, but kept in a file, which passed to application as a filename. Refer to inline comments for details. | `{}`                |

--- a/charts/navi-async-matrix/README.md
+++ b/charts/navi-async-matrix/README.md
@@ -128,23 +128,24 @@ See the [documentation](https://docs.2gis.com/en/on-premise/navigation/distance-
 
 ### Distance Matrix Async API settings
 
-| Name                    | Description                                                                                                                   | Value  |
-| ----------------------- | ----------------------------------------------------------------------------------------------------------------------------- | ------ |
-| `dm.port`               | Distance Matrix Async API HTTP port.                                                                                          | `8000` |
-| `dm.configType`         | Configuration type. Must always be `env`.                                                                                     | `env`  |
-| `dm.workerCount`        | Number of Distance Matrix Async workers.                                                                                      | `4`    |
-| `dm.citiesUrl`          | URL of the information about cities provided by the Navi-Castle service, ex: http://navi-castle.svc/cities.conf. **Required** | `""`   |
-| `dm.citiesUpdatePeriod` | Period (in seconds) between requesting data from `citiesUrl`.                                                                 | `3600` |
+| Name                    | Description                                                                                                                   | Value      |
+| ----------------------- | ----------------------------------------------------------------------------------------------------------------------------- | ---------- |
+| `dm.host`               | Distance Matrix Async API HTTP host.                                                                                          | `0.0.0.0`  |
+| `dm.port`               | Distance Matrix Async API HTTP port.                                                                                          | `8000`     |
+| `dm.configType`         | Configuration type. Must always be `env`.                                                                                     | `env`      |
+| `dm.citiesUrl`          | URL of the information about cities provided by the Navi-Castle service, ex: http://navi-castle.svc/cities.conf. **Required** | `""`       |
+| `dm.citiesUpdatePeriod` | Period (in seconds) between requesting data from `citiesUrl`.                                                                 | `3600`     |
 
 ### Database settings
 
-| Name          | Description                             | Value  |
-| ------------- | --------------------------------------- | ------ |
-| `db.host`     | PostgreSQL hostname or IP. **Required** | `""`   |
-| `db.port`     | PostgreSQL port.                        | `5432` |
-| `db.name`     | PostgreSQL database name. **Required**  | `""`   |
-| `db.user`     | PostgreSQL username. **Required**       | `""`   |
-| `db.password` | PostgreSQL password. **Required**       | `""`   |
+| Name          | Description                             		| Value    |
+| ------------- | ----------------------------------------------------- | -------- |
+| `db.host`     | PostgreSQL hostname or IP. **Required** 		| `""`     |
+| `db.port`     | PostgreSQL port.                        		| `5432`   |
+| `db.name`     | PostgreSQL database name. **Required**  		| `""`     |
+| `db.user`     | PostgreSQL username. **Required**       		| `""`     |
+| `db.password` | PostgreSQL password. **Required**       		| `""`     |
+| `db.schema`   | PostgreSQL schema. Must be specified in overrides.	| `public` |
 
 ### Kafka settings
 

--- a/charts/navi-async-matrix/README.md
+++ b/charts/navi-async-matrix/README.md
@@ -30,7 +30,7 @@ See the [documentation](https://docs.2gis.com/en/on-premise/navigation/distance-
 
 | Name                            | Description                                                                                                                 | Value  |
 | ------------------------------- | --------------------------------------------------------------------------------------------------------------------------- | ------ |
-| `replicaCount`                  | A replica count for the pod.                                                                                                | `2`    |
+| `replicaCount`                  | A replica count for the pod.                                                                                                | `1`    |
 | `imagePullSecrets`              | Kubernetes image pull secrets.                                                                                              | `[]`   |
 | `nameOverride`                  | Base name to use in all the Kubernetes entities deployed by this chart.                                                     | `""`   |
 | `fullnameOverride`              | Base fullname to use in all the Kubernetes entities deployed by this chart.                                                 | `""`   |
@@ -52,7 +52,7 @@ See the [documentation](https://docs.2gis.com/en/on-premise/navigation/distance-
 | Name               | Description | Value                               |
 | ------------------ | ----------- | ----------------------------------- |
 | `image.repository` | Repository  | `2gis-on-premise/navi-async-matrix` |
-| `image.tag`        | Tag         | `1.6.0`                             |
+| `image.tag`        | Tag         | `1.6.1`                             |
 | `image.pullPolicy` | Pull Policy | `IfNotPresent`                      |
 
 ### Service account settings
@@ -140,6 +140,7 @@ See the [documentation](https://docs.2gis.com/en/on-premise/navigation/distance-
 | ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------- | ------ |
 | `dm.port`                    | Distance Matrix Async API HTTP port.                                                                                          | `8000` |
 | `dm.configType`              | Configuration type. Must always be `env`.                                                                                     | `env`  |
+| `dm.logLevel`                | Logging level, one of: DEBUG, INFO, WARNING, ERROR, CRITICAL.                                                                 | `INFO` |
 | `dm.workerCount`             | Number of Distance Matrix Async workers.                                                                                      | `4`    |
 | `dm.citiesUrl`               | URL of the information about cities provided by the Navi-Castle service, ex: http://navi-castle.svc/cities.conf. **Required** | `""`   |
 | `dm.citiesUpdatePeriod`      | Period (in seconds) between requesting data from `citiesUrl`.                                                                 | `3600` |
@@ -148,14 +149,18 @@ See the [documentation](https://docs.2gis.com/en/on-premise/navigation/distance-
 
 ### Database settings
 
-| Name          | Description                             | Value    |
-| ------------- | --------------------------------------- | -------- |
-| `db.host`     | PostgreSQL hostname or IP. **Required** | `""`     |
-| `db.port`     | PostgreSQL port.                        | `5432`   |
-| `db.name`     | PostgreSQL database name. **Required**  | `""`     |
-| `db.user`     | PostgreSQL username. **Required**       | `""`     |
-| `db.password` | PostgreSQL password. **Required**       | `""`     |
-| `db.schema`   | PostgreSQL schema.                      | `public` |
+| Name             | Description                             | Value         |
+| ---------------- | --------------------------------------- | ------------- |
+| `db.host`        | PostgreSQL hostname or IP. **Required** | `""`          |
+| `db.port`        | PostgreSQL port.                        | `5432`        |
+| `db.name`        | PostgreSQL database name. **Required**  | `""`          |
+| `db.user`        | PostgreSQL username. **Required**       | `""`          |
+| `db.password`    | PostgreSQL password. **Required**       | `""`          |
+| `db.schema`      | PostgreSQL schema.                      | `public`      |
+| `db.sslRootCert` | Root certificate file.                  | `""`          |
+| `db.sslCert`     | Certificate of postgresql server.       | `""`          |
+| `db.sslKey`      | Key of postgresql server.               | `""`          |
+| `db.sslMode`     | Level of protection.                    | `verify-full` |
 
 ### Kafka settings
 

--- a/charts/navi-async-matrix/README.md
+++ b/charts/navi-async-matrix/README.md
@@ -138,18 +138,19 @@ See the [documentation](https://docs.2gis.com/en/on-premise/navigation/distance-
 
 ### Database settings
 
-| Name             | Description                             | Value         |
-| ---------------- | --------------------------------------- | ------------- |
-| `db.host`        | PostgreSQL hostname or IP. **Required** | `""`          |
-| `db.port`        | PostgreSQL port.                        | `5432`        |
-| `db.name`        | PostgreSQL database name. **Required**  | `""`          |
-| `db.user`        | PostgreSQL username. **Required**       | `""`          |
-| `db.password`    | PostgreSQL password. **Required**       | `""`          |
-| `db.schema`      | PostgreSQL schema.                      | `public`      |
-| `db.sslRootCert` | Root certificate file.                  | `""`          |
-| `db.sslCert`     | Certificate of postgresql server.       | `""`          |
-| `db.sslKey`      | Key of postgresql server.               | `""`          |
-| `db.sslMode`     | Level of protection.                    | `verify-full` |
+| Name                 | Description                                 | Value         |
+| -------------------- | ------------------------------------------- | ------------- |
+| `db.host`            | PostgreSQL hostname or IP. **Required**     | `""`          |
+| `db.port`            | PostgreSQL port.                            | `5432`        |
+| `db.name`            | PostgreSQL database name. **Required**      | `""`          |
+| `db.user`            | PostgreSQL username. **Required**           | `""`          |
+| `db.password`        | PostgreSQL password. **Required**           | `""`          |
+| `db.schema`          | PostgreSQL schema.                          | `public`      |
+| `db.tls.enabled`     | If tls connection to postgresql is enabled. | `false`       |
+| `db.tls.sslRootCert` | Root certificate file.                      | `""`          |
+| `db.tls.sslCert`     | Certificate of postgresql server.           | `""`          |
+| `db.tls.sslKey`      | Key of postgresql server.                   | `""`          |
+| `db.tls.sslMode`     | Level of protection.                        | `verify-full` |
 
 ### Kafka settings
 

--- a/charts/navi-async-matrix/README.md
+++ b/charts/navi-async-matrix/README.md
@@ -52,7 +52,7 @@ See the [documentation](https://docs.2gis.com/en/on-premise/navigation/distance-
 | Name               | Description | Value                               |
 | ------------------ | ----------- | ----------------------------------- |
 | `image.repository` | Repository  | `2gis-on-premise/navi-async-matrix` |
-| `image.tag`        | Tag         | `1.6.1`                             |
+| `image.tag`        | Tag         | `1.6.2`                             |
 | `image.pullPolicy` | Pull Policy | `IfNotPresent`                      |
 
 ### Service account settings

--- a/charts/navi-async-matrix/README.md
+++ b/charts/navi-async-matrix/README.md
@@ -30,7 +30,7 @@ See the [documentation](https://docs.2gis.com/en/on-premise/navigation/distance-
 
 | Name                            | Description                                                                                                                 | Value  |
 | ------------------------------- | --------------------------------------------------------------------------------------------------------------------------- | ------ |
-| `replicaCount`                  | A replica count for the pod.                                                                                                | `1`    |
+| `replicaCount`                  | A replica count for the pod.                                                                                                | `2`    |
 | `imagePullSecrets`              | Kubernetes image pull secrets.                                                                                              | `[]`   |
 | `nameOverride`                  | Base name to use in all the Kubernetes entities deployed by this chart.                                                     | `""`   |
 | `fullnameOverride`              | Base fullname to use in all the Kubernetes entities deployed by this chart.                                                 | `""`   |
@@ -52,7 +52,7 @@ See the [documentation](https://docs.2gis.com/en/on-premise/navigation/distance-
 | Name               | Description | Value                               |
 | ------------------ | ----------- | ----------------------------------- |
 | `image.repository` | Repository  | `2gis-on-premise/navi-async-matrix` |
-| `image.tag`        | Tag         | `1.3.3`                             |
+| `image.tag`        | Tag         | `1.6.0`                             |
 | `image.pullPolicy` | Pull Policy | `IfNotPresent`                      |
 
 ### Service account settings
@@ -62,6 +62,14 @@ See the [documentation](https://docs.2gis.com/en/on-premise/navigation/distance-
 | `serviceAccount.create`      | Specifies whether a service account should be created.                                                                  | `false` |
 | `serviceAccount.annotations` | Annotations to add to the service account.                                                                              | `{}`    |
 | `serviceAccount.name`        | The name of the service account to use. If not set and create is true, a name is generated using the fullname template. | `""`    |
+
+### RBAC parameter
+
+| Name               | Description                                     | Value   |
+| ------------------ | ----------------------------------------------- | ------- |
+| `rbac.create`      | Whether to create and use RBAC resources or not | `false` |
+| `rbac.annotations` | Role and RoleBinding annotations                | `{}`    |
+| `rbac.labels`      | Role and RoleBinding additional labels          | `{}`    |
 
 ### Strategy settings
 
@@ -128,24 +136,26 @@ See the [documentation](https://docs.2gis.com/en/on-premise/navigation/distance-
 
 ### Distance Matrix Async API settings
 
-| Name                    | Description                                                                                                                   | Value      |
-| ----------------------- | ----------------------------------------------------------------------------------------------------------------------------- | ---------- |
-| `dm.host`               | Distance Matrix Async API HTTP host.                                                                                          | `0.0.0.0`  |
-| `dm.port`               | Distance Matrix Async API HTTP port.                                                                                          | `8000`     |
-| `dm.configType`         | Configuration type. Must always be `env`.                                                                                     | `env`      |
-| `dm.citiesUrl`          | URL of the information about cities provided by the Navi-Castle service, ex: http://navi-castle.svc/cities.conf. **Required** | `""`       |
-| `dm.citiesUpdatePeriod` | Period (in seconds) between requesting data from `citiesUrl`.                                                                 | `3600`     |
+| Name                         | Description                                                                                                                   | Value  |
+| ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------- | ------ |
+| `dm.port`                    | Distance Matrix Async API HTTP port.                                                                                          | `8000` |
+| `dm.configType`              | Configuration type. Must always be `env`.                                                                                     | `env`  |
+| `dm.workerCount`             | Number of Distance Matrix Async workers.                                                                                      | `4`    |
+| `dm.citiesUrl`               | URL of the information about cities provided by the Navi-Castle service, ex: http://navi-castle.svc/cities.conf. **Required** | `""`   |
+| `dm.citiesUpdatePeriod`      | Period (in seconds) between requesting data from `citiesUrl`.                                                                 | `3600` |
+| `dm.taskSplitSize`           | Minimum size of matrix to get split in archiver job.                                                                          | `5000` |
+| `dm.compositeTaskTimeoutSec` | Timeout for executing split tasks.                                                                                            | `3600` |
 
 ### Database settings
 
-| Name          | Description                             																					| Value    |
-| ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
-| `db.host`     | PostgreSQL hostname or IP. **Required** 																					| `""`     |
-| `db.port`     | PostgreSQL port.                        																					| `5432`   |
-| `db.name`     | PostgreSQL database name. **Required**  																					| `""`     |
-| `db.user`     | PostgreSQL username. **Required**       																					| `""`     |
-| `db.password` | PostgreSQL password. **Required**       																					| `""`     |
-| `db.schema`   | PostgreSQL schema. Must be specified in overrides. If the database name changes, a new database with the specified schema will be created. Otherwise, the database will be recreated with a new schema.	| `public` |
+| Name          | Description                             | Value    |
+| ------------- | --------------------------------------- | -------- |
+| `db.host`     | PostgreSQL hostname or IP. **Required** | `""`     |
+| `db.port`     | PostgreSQL port.                        | `5432`   |
+| `db.name`     | PostgreSQL database name. **Required**  | `""`     |
+| `db.user`     | PostgreSQL username. **Required**       | `""`     |
+| `db.password` | PostgreSQL password. **Required**       | `""`     |
+| `db.schema`   | PostgreSQL schema.                      | `public` |
 
 ### Kafka settings
 

--- a/charts/navi-async-matrix/templates/_helpers.tpl
+++ b/charts/navi-async-matrix/templates/_helpers.tpl
@@ -44,6 +44,109 @@ Create the name of the service account to use
 {{- end }}
 {{- end }}
 
+{{- /*
+     Collect merged Kafka properties from these dictionaries:
+       - kafka.properties: this is a simple key/value dictionary
+       - kafka.fileProperties: this is a key/content dictionary given in values,
+         content is sensitive and stored in Secret resource, they get
+         mounted as files sonamed after key. While actual secret values are
+         hidden this way, what actually goes here in environment properties is
+         file names. This value substitution is implemented down here.
+     */ -}}
+
+{{- /* Merge .kafka.properties and .kafka.fileProperties dictionaries.
+
+       Context:
+         .kafka.properties
+         .kafka.fileProperties
+         .mountpoint
+
+       File properties values (file contents) replaced with keys (file names).
+       File names prepended with the supposed directory from .mountpoint.
+       Returns {"ret": that-merged-dict}.
+       Folding result in "ret" needed for marshalling.
+     */ -}}
+{{- define "navi-async-matrix.kafkaProperties" -}}
+  {{- $ctx := . -}}
+  {{- $kafkaProperties := dict -}}
+  {{- range $key, $_ := $ctx.kafka.fileProperties -}}
+    {{- $_ := set $kafkaProperties $key (printf "%s/%s" $ctx.mountpoint $key) -}}
+  {{- end -}}
+  {{- $kafkaProperties = mustMerge $kafkaProperties $ctx.kafka.properties -}}
+  {{- dict "ret" $kafkaProperties | toYaml }}
+{{- end }}
+
+{{- /* Translate properties into `env` construction as in containers:
+
+       Context:
+         .kafka.properties
+         .kafka.fileProperties
+         .kafka.sensitiveProperties
+         .mountpoint
+         .secretname
+         .prefix
+
+       .kafka.properties and .kafka.fileProperties merged with kafkaProperties (defined above)
+       each entry translated into {"name":..., "value":...}
+         where name is in form <PREFIX><PROPERTY_NAME>
+         prefix is from .prefix
+         property name with '.' replaced with '_' and in upper-case
+         e.g.:
+            prefix=PRODUCER_CONFIG_
+            property-name=security.protocol
+            result: PRODUCER_CONFIG_SECURITY_PROTOCOL
+       merged with .sensitiveProperties where entries are in format:
+         { "name": ...,
+           "valueFrom": {
+             "secretKeyRef": {
+               "name": ...,
+               "key": ...
+             }
+           }
+         }
+       where secretKeyRef.name is from .secretname
+       Resulting object folded in {"ret":...} for marshalling.
+     */ -}}
+{{- define "navi-async-matrix.kafkaPropertiesEnv" -}}
+  {{- $ctx := . -}}
+  {{- $kafkaProperties := get (fromYaml (include "navi-async-matrix.kafkaProperties" $ctx)) "ret" -}}
+  {{- $env := list -}}
+  {{- range $prop, $val := $kafkaProperties -}}
+    {{- $env = append $env (dict
+          "name" (print $ctx.prefix ($prop | upper | replace "." "_"))
+          "value" $val
+        ) -}}
+  {{- end -}}
+  {{- range $prop, $val := $ctx.kafka.sensitiveProperties -}}
+    {{- $env = append $env (dict
+          "name" (print $ctx.prefix ($prop | upper | replace "." "_"))
+          "valueFrom" (dict
+            "secretKeyRef" (dict
+              "name" $ctx.secretname
+              "key" $prop
+            )
+          )
+        ) -}}
+  {{- end -}}
+  {{- dict "ret" $env | toYaml }}
+{{- end }}
+
+{{- /* Encodes to "invalid" JSON representing comma separated list entries.
+
+       Context:
+         .ret - list to encode
+
+       Example:
+         .ret=[1, 2, 3]
+         result: "1, 2, 3,"
+     */ -}}
+{{- define "navi-async-matrix.partialListToJson" -}}
+  {{- range .ret }}
+    {{- . | mustToPrettyJson }},
+    {{- println }}
+  {{- end }}
+{{- end }}
+
 {{/*
 Return the target Kubernetes version
 */}}

--- a/charts/navi-async-matrix/templates/_helpers.tpl
+++ b/charts/navi-async-matrix/templates/_helpers.tpl
@@ -44,6 +44,14 @@ Create the name of the service account to use
 {{- end }}
 {{- end }}
 
+{{- define "navi-async-matrix.dbDsnParams" -}}
+{{- if and .Values.db.sslRootCert .Values.db.sslCert .Values.db.sslKey .Values.db.sslMode }}
+{{- printf "?sslcert=/etc/2gis/secret/psql/client.crt&sslkey=/etc/2gis/secret/psql/client.key&sslrootcert=/etc/2gis/secret/psql/ca.crt&sslmode=%s"
+               .Values.db.sslMode -}}
+{{- end }}
+{{- end }}
+
+
 {{- /*
      Collect merged Kafka properties from these dictionaries:
        - kafka.properties: this is a simple key/value dictionary
@@ -176,3 +184,19 @@ Return the appropriate apiVersion for Horizontal Pod Autoscaler.
 {{- print "autoscaling/v2" -}}
 {{- end -}}
 {{- end -}}
+
+{{- /*
+Name for psql intermediate volume for copy secrets and change permissions
+*/ -}}
+
+{{- define "navi-async-matrix.fullname-psql-raw" -}}
+{{- printf "%s-psql-raw" (include "navi-async-matrix.fullname" .) -}}
+{{- end }}
+
+{{- /*
+Name for psql secret and volume
+*/ -}}
+
+{{- define "navi-async-matrix.fullname-psql" -}}
+{{- printf "%s-psql" (include "navi-async-matrix.fullname" .) -}}
+{{- end }}

--- a/charts/navi-async-matrix/templates/_helpers.tpl
+++ b/charts/navi-async-matrix/templates/_helpers.tpl
@@ -45,9 +45,9 @@ Create the name of the service account to use
 {{- end }}
 
 {{- define "navi-async-matrix.dbDsnParams" -}}
-{{- if and .Values.db.tls.enabled }}
+{{- if .Values.db.tls.enabled }}
 {{- printf "?sslcert=/etc/2gis/secret/psql/client.crt&sslkey=/etc/2gis/secret/psql/client.key&sslrootcert=/etc/2gis/secret/psql/ca.crt&sslmode=%s"
-               ( required "A valid db.tls.sslMode entry required" .Values.db.tls.sslMode) -}}
+               ( required "A valid db.tls.mode entry required" .Values.db.tls.mode) -}}
 {{- end }}
 {{- end }}
 

--- a/charts/navi-async-matrix/templates/_helpers.tpl
+++ b/charts/navi-async-matrix/templates/_helpers.tpl
@@ -45,9 +45,9 @@ Create the name of the service account to use
 {{- end }}
 
 {{- define "navi-async-matrix.dbDsnParams" -}}
-{{- if and .Values.db.sslRootCert .Values.db.sslCert .Values.db.sslKey .Values.db.sslMode }}
+{{- if and .Values.db.tls.enabled }}
 {{- printf "?sslcert=/etc/2gis/secret/psql/client.crt&sslkey=/etc/2gis/secret/psql/client.key&sslrootcert=/etc/2gis/secret/psql/ca.crt&sslmode=%s"
-               .Values.db.sslMode -}}
+               ( required "A valid db.tls.sslMode entry required" .Values.db.tls.sslMode) -}}
 {{- end }}
 {{- end }}
 

--- a/charts/navi-async-matrix/templates/configmap.yaml
+++ b/charts/navi-async-matrix/templates/configmap.yaml
@@ -1,0 +1,90 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "navi-async-matrix.fullname" . }}-configmap
+data:
+  archive_pod_manifest.json: |
+    {
+      "apiVersion": "v1",
+      "kind": "Pod",
+      "metadata": {
+        "name": null,
+        "labels": {{ mustToJson .Values.dm.archiver.labels }},
+        "annotations": {{ mustToJson .Values.dm.archiver.annotations }}
+      },
+      "spec": {
+        {{- if .Values.kafka.fileProperties }}
+        "volumes": [
+          {
+            "name": {{ printf "%s-kafka" (include "navi-async-matrix.fullname" .) | mustToJson }},
+            "secret": {
+              "secretName": {{ printf "%s-kafka" (include "navi-async-matrix.fullname" .) | mustToJson }}
+            }
+          }
+        ],
+        {{- end }}
+        "serviceAccountName": {{ include "navi-async-matrix.serviceAccountName" . | mustToJson }},
+        "containers": [
+          {
+            "name": null,
+            "image": "{{ .Values.dgctlDockerRegistry }}/{{ .Values.dm.archiver.image.repository }}:{{ .Values.dm.archiver.image.tag }}",
+            "resources": {{ .Values.dm.archiver.resources | mustToJson }},
+            {{- if .Values.kafka.fileProperties }}
+            "volumeMounts": [
+              {
+                "name": {{ printf "%s-kafka" (include "navi-async-matrix.fullname" .) | mustToJson }},
+                "mountPath": "/app/secret/"
+              }
+            ],
+            {{- end }}
+            "env": [
+              {
+                "name": "CONFIG_TYPE",
+                "value" :"env"
+              },
+              {
+                "name": "KAFKA_PRODUCER_SETTING__TOPIC",
+                "value": {{ .Values.kafka.archiveTopic | mustToJson }}
+              },
+            {{- $kafkaPropertiesEnv := include "navi-async-matrix.kafkaPropertiesEnv" (dict
+                  "kafka" .Values.kafka
+                  "secretname" (print
+                      (include "navi-async-matrix.fullname" .)
+                      "-kafka"
+                    )
+                  "mountpoint" "/app/secret"
+                  "prefix" "KAFKA_PRODUCER_SETTING__CONFIG__"
+                ) | fromYaml -}}
+            {{- include "navi-async-matrix.partialListToJson" $kafkaPropertiesEnv | nindent 14 -}}
+              {
+                "name": "S3_ENDPOINT_URL",
+                "value": {{ .Values.s3.host | mustToJson }}
+              },
+              {
+                "name": "S3_BUCKET",
+                "value": {{ .Values.s3.bucket | mustToJson }}
+              },
+              {
+                "name": "S3_ACCESS_KEY",
+                "value": {{ .Values.s3.accessKey | mustToJson }}
+              },
+              {
+                "name": "S3_SECRET_KEY",
+                "valueFrom": {
+                  "secretKeyRef": {
+                    "name": {{ include "navi-async-matrix.fullname" . | mustToJson }},
+                    "key": "s3key"
+                  }
+                }
+              },
+              {
+                "name": "S3_USE_MINIO",
+                "value" :"true"
+              }
+            ]
+          }
+        ],
+        "restartPolicy": "Never"
+      }
+    }

--- a/charts/navi-async-matrix/templates/configmap.yaml
+++ b/charts/navi-async-matrix/templates/configmap.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.dm.archiver.enabled }}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -88,3 +89,4 @@ data:
         "restartPolicy": "Never"
       }
     }
+{{- end }}

--- a/charts/navi-async-matrix/templates/hpa.yaml
+++ b/charts/navi-async-matrix/templates/hpa.yaml
@@ -13,9 +13,9 @@ spec:
     name: {{ include "navi-async-matrix.fullname" $ }}
   minReplicas: {{ .minReplicas }}
   maxReplicas: {{ .maxReplicas }}
-  {{- if .Values.hpa.behavior }}
+  {{- if .behavior }}
   behavior:
-    {{- toYaml .Values.hpa.behavior | nindent 4 }}
+    {{- toYaml .behavior | nindent 4 }}
   {{- end }}
   metrics:
   {{- with .targetCPUUtilizationPercentage }}

--- a/charts/navi-async-matrix/templates/hpa.yaml
+++ b/charts/navi-async-matrix/templates/hpa.yaml
@@ -13,11 +13,10 @@ spec:
     name: {{ include "navi-async-matrix.fullname" $ }}
   minReplicas: {{ .minReplicas }}
   maxReplicas: {{ .maxReplicas }}
+  {{- if .Values.hpa.behavior }}
   behavior:
-    scaleUp:
-        stabilizationWindowSeconds: {{ .scaleUpStabilizationWindowSeconds }}
-    scaleDown:
-        stabilizationWindowSeconds: {{ .scaleDownStabilizationWindowSeconds }}
+    {{- toYaml .Values.hpa.behavior | nindent 4 }}
+  {{- end }}
   metrics:
   {{- with .targetCPUUtilizationPercentage }}
     - type: Resource

--- a/charts/navi-async-matrix/templates/role.yaml
+++ b/charts/navi-async-matrix/templates/role.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.create }}
+{{- if .Values.dm.archiver.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -31,4 +31,4 @@ rules:
   - patch
   - update
   - watch
-{{- end }}{{- /* .Values.rbac.create */}}
+{{- end }}{{- /* .Values.dm.archiver.enabled */}}

--- a/charts/navi-async-matrix/templates/role.yaml
+++ b/charts/navi-async-matrix/templates/role.yaml
@@ -1,0 +1,34 @@
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "navi-async-matrix.fullname" . }}
+  labels:
+    {{- include "navi-async-matrix.labels" . | nindent 4 }}
+    {{- with .Values.rbac.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.rbac.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+rules:
+- apiGroups: [""]
+  resources:
+  - pods/log
+  verbs:
+  - get
+  - list
+- apiGroups: [""]
+  resources:
+  - pods
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
+{{- end }}{{- /* .Values.rbac.create */}}

--- a/charts/navi-async-matrix/templates/rolebinding.yaml
+++ b/charts/navi-async-matrix/templates/rolebinding.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "navi-async-matrix.fullname" . }}
+  labels:
+    {{- include "navi-async-matrix.labels" . | nindent 4 }}
+    {{- with .Values.rbac.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.rbac.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "navi-async-matrix.serviceAccountName" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "navi-async-matrix.fullname" . }}
+{{- end -}}{{- /* .Values.rbac.create */ -}}

--- a/charts/navi-async-matrix/templates/rolebinding.yaml
+++ b/charts/navi-async-matrix/templates/rolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.create -}}
+{{- if .Values.dm.archiver.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -19,4 +19,4 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: {{ include "navi-async-matrix.fullname" . }}
-{{- end -}}{{- /* .Values.rbac.create */ -}}
+{{- end }}{{- /* .Values.dm.archiver.enabled */}}

--- a/charts/navi-async-matrix/templates/secret.yaml
+++ b/charts/navi-async-matrix/templates/secret.yaml
@@ -49,7 +49,7 @@ metadata:
     {{- end }}
 type: Opaque
 data:
-  client.crt: {{ required "A valid db.tls.sslCert entry required" .Values.db.tls.sslCert | b64enc | quote }}
-  client.key: {{ required "A valid db.tls.sslKeyentry required" .Values.db.tls.sslKey | b64enc | quote }}
-  ca.crt: {{ required "A valid db.tls.sslRootCert entry required" .Values.db.tls.sslRootCert | b64enc | quote }}
+  client.crt: {{ required "A valid db.tls.cert entry required" .Values.db.tls.cert | b64enc | quote }}
+  client.key: {{ required "A valid db.tls.key entry required" .Values.db.tls.key | b64enc | quote }}
+  ca.crt: {{ required "A valid db.tls.rootCert entry required" .Values.db.tls.rootCert | b64enc | quote }}
 {{- end }}

--- a/charts/navi-async-matrix/templates/secret.yaml
+++ b/charts/navi-async-matrix/templates/secret.yaml
@@ -36,7 +36,7 @@ data:
   {{ $prop | quote }}: {{ $val | b64enc | quote }}
   {{- end }}
 {{- end }}
-{{- if and .Values.db.sslRootCert .Values.db.sslCert .Values.db.sslKey .Values.db.sslMode }}
+{{- if .Values.db.tls.enabled }}
 ---
 apiVersion: v1
 kind: Secret
@@ -49,7 +49,7 @@ metadata:
     {{- end }}
 type: Opaque
 data:
-  client.crt: {{ .Values.db.sslCert | b64enc | quote }}
-  client.key: {{ .Values.db.sslKey | b64enc | quote }}
-  ca.crt: {{ .Values.db.sslRootCert | b64enc | quote }}
+  client.crt: {{ required "A valid db.tls.sslCert entry required" .Values.db.tls.sslCert | b64enc | quote }}
+  client.key: {{ required "A valid db.tls.sslKeyentry required" .Values.db.tls.sslKey | b64enc | quote }}
+  ca.crt: {{ required "A valid db.tls.sslRootCert entry required" .Values.db.tls.sslRootCert | b64enc | quote }}
 {{- end }}

--- a/charts/navi-async-matrix/templates/secret.yaml
+++ b/charts/navi-async-matrix/templates/secret.yaml
@@ -9,7 +9,14 @@ metadata:
     {{- end }}
 type: Opaque
 data:
-  dbDsn: {{ printf "postgresql://%s:%s@%s:%d/%s" .Values.db.user .Values.db.password .Values.db.host (.Values.db.port | int) .Values.db.name | b64enc | quote }}
+  dbDsn: {{ printf "postgresql://%s:%s@%s:%d/%s%s"
+              .Values.db.user
+              .Values.db.password
+              .Values.db.host
+              (.Values.db.port | int)
+              .Values.db.name
+              (include "navi-async-matrix.dbDsnParams" .)
+              | b64enc | quote }}
   s3key: {{ required "A valid .Values.s3.secretKey entry required" .Values.s3.secretKey | b64enc | quote }}
   dmApiKey: {{ .Values.keys.token | b64enc | quote }}
 {{- if or .Values.kafka.sensitiveProperties .Values.kafka.fileProperties }}
@@ -28,4 +35,21 @@ data:
   {{- range $prop, $val := merge (deepCopy .Values.kafka.sensitiveProperties) (deepCopy .Values.kafka.fileProperties) }}
   {{ $prop | quote }}: {{ $val | b64enc | quote }}
   {{- end }}
+{{- end }}
+{{- if and .Values.db.sslRootCert .Values.db.sslCert .Values.db.sslKey .Values.db.sslMode }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "navi-async-matrix.fullname-psql" . | quote }}
+  labels:
+    {{- include "navi-async-matrix.labels" . | nindent 4 }}
+    {{- if .Values.labels }}
+    {{- toYaml .Values.labels | nindent 4 }}
+    {{- end }}
+type: Opaque
+data:
+  client.crt: {{ .Values.db.sslCert | b64enc | quote }}
+  client.key: {{ .Values.db.sslKey | b64enc | quote }}
+  ca.crt: {{ .Values.db.sslRootCert | b64enc | quote }}
 {{- end }}

--- a/charts/navi-async-matrix/templates/statefulset.yaml
+++ b/charts/navi-async-matrix/templates/statefulset.yaml
@@ -69,7 +69,7 @@ spec:
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       volumes:
       {{- if .Values.dm.archiver.enabled }}
-        - name: {{ printf "%s-manifest" (include "navi-async-matrix.fullname" .) | quote }}
+        - name: {{ printf "%s-configmap" (include "navi-async-matrix.fullname" .) | quote }}
           configMap:
             name: {{ printf "%s-configmap" (include "navi-async-matrix.fullname" .) | quote }}
       {{- end }}
@@ -133,7 +133,7 @@ spec:
           readinessProbe: *healthProbe
           volumeMounts:
           {{- if .Values.dm.archiver.enabled }}
-          - name: {{ printf "%s-manifest" (include "navi-async-matrix.fullname" .) | quote }}
+          - name: {{ printf "%s-configmap" (include "navi-async-matrix.fullname" .) | quote }}
             mountPath: /app/src/composite_task_result_archiver/manifests/archive_pod_manifest.json
             subPath: archive_pod_manifest.json
           {{- end }}

--- a/charts/navi-async-matrix/templates/statefulset.yaml
+++ b/charts/navi-async-matrix/templates/statefulset.yaml
@@ -134,6 +134,25 @@ spec:
               value: {{ .Values.kafka.groupId | quote }}
             - name: DM_ASYNC_SERVICE_TOPIC_RULES
               value: {{ .Values.kafka.taskTopicRules | mustToJson | quote }}
+            - name: DM_ASYNC_SERVICE_KAFKA_CONSUMER_SETTING__KAFKA_CONSUMER_ARCHIVE_RESPONSE_TOPIC
+              value: {{ .Values.kafka.archiveTopic | quote }}
+            {{- if .Values.dm.archiver.enabled }}
+            - name: DM_ASYNC_SERVICE_DEBUG_MODE
+              value: {{ .Values.dm.archiver.fetchLogs | ternary "true" "false" | quote }}
+            - name: DM_ASYNC_SERVICE_ARCHIVER_K8S_SETTING__NAMESPACE
+              value: {{ .Release.Namespace | quote }}
+            - name: DM_ASYNC_SERVICE_ARCHIVER_K8S_SETTING__CONFIG_TYPE
+              value: cluster
+            {{- /* master-uri and token used in local runs only */}}
+            - name: DM_ASYNC_SERVICE_ARCHIVER_K8S_SETTING__MASTER_URI
+              value: ""
+            - name: DM_ASYNC_SERVICE_ARCHIVER_K8S_SETTING__TOKEN
+              value: ""
+            - name: DM_ASYNC_SERVICE_TASK_SPLIT_SIZE
+              value: {{ .Values.dm.taskSplitSize | quote }}
+            - name: DM_ASYNC_SERVICE_COMPOSITE_TASK_TIMEOUT_IN_SECONDS
+              value: {{ .Values.dm.compositeTaskTimeoutSec | quote }}
+            {{- end }}{{- /* .Values.dm.archiver.enabled */}}
             {{- /*
                  Collect merged Kafka properties from these dictionaries:
                    - kafka.properties: this is a simple key/value dictionary
@@ -166,6 +185,21 @@ spec:
             - name: DM_ASYNC_SERVICE_BSS__VERSION
               value: {{ .Values.bss.version | quote }}
             {{- end }}
+            {{- range (list
+                "DM_ASYNC_SERVICE_KAFKA_PRODUCER_SETTING__KAFKA_PRODUCER_CONFIG__"
+                "DM_ASYNC_SERVICE_KAFKA_CONSUMER_SETTING__KAFKA_CONSUMER_CONFIG__"
+              ) }}
+            {{- $kafkaPropertiesEnv := include "navi-async-matrix.kafkaPropertiesEnv" (dict
+                  "kafka" $.Values.kafka
+                  "secretname" (print
+                      (include "navi-async-matrix.fullname" $)
+                      "-kafka"
+                    )
+                  "mountpoint" "/etc/2gis/secret"
+                  "prefix" .
+                ) | fromYaml }}
+            {{- get $kafkaPropertiesEnv "ret" | toYaml | nindent 12 }}
+            {{- end }}{{- /* range */}}
             # sensitive data
             - name: DM_ASYNC_SERVICE_DB_SCHEMA
               value: {{ .Values.db.schema | quote }}

--- a/charts/navi-async-matrix/templates/statefulset.yaml
+++ b/charts/navi-async-matrix/templates/statefulset.yaml
@@ -68,6 +68,10 @@ spec:
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       {{- if .Values.kafka.fileProperties }}
       volumes:
+        - name: {{ printf "%s-manifest" (include "navi-async-matrix.fullname" .) | quote }}
+          configMap:
+            name: {{ printf "%s-configmap" (include "navi-async-matrix.fullname" .) | quote }}
+      {{- if .Values.kafka.fileProperties }}
         - name: {{ printf "%s-kafka" (include "navi-async-matrix.fullname" .) | quote }}
           secret:
             secretName: {{ printf "%s-kafka" (include "navi-async-matrix.fullname" .) | quote }}
@@ -100,6 +104,9 @@ spec:
           # here is a workaround for that
           {{- if .Values.kafka.fileProperties }}
           volumeMounts:
+          - name: {{ printf "%s-manifest" (include "navi-async-matrix.fullname" .) | quote }}
+            mountPath: /app/src/composite_task_result_archiver/manifests/archive_pod_manifest.json
+            subPath: archive_pod_manifest.json
           - name: {{ printf "%s-kafka" (include "navi-async-matrix.fullname" .) | quote }}
             mountPath: /etc/2gis/secret/
           {{- end }}

--- a/charts/navi-async-matrix/templates/statefulset.yaml
+++ b/charts/navi-async-matrix/templates/statefulset.yaml
@@ -179,9 +179,9 @@ spec:
             - name: DM_ASYNC_SERVICE_TOPIC_RULES
               {{- /* topicRules is a structure, hence mustToJson */}}
               value: {{ .Values.kafka.taskTopicRules | mustToJson | quote }}
+            {{- if .Values.dm.archiver.enabled }}
             - name: DM_ASYNC_SERVICE_KAFKA_CONSUMER_SETTING__KAFKA_CONSUMER_ARCHIVE_RESPONSE_TOPIC
               value: {{ .Values.kafka.archiveTopic | quote }}
-            {{- if .Values.dm.archiver.enabled }}
             - name: DM_ASYNC_SERVICE_DEBUG_MODE
               value: {{ .Values.dm.archiver.fetchLogs | ternary "true" "false" | quote }}
             - name: DM_ASYNC_SERVICE_ARCHIVER_K8S_SETTING__NAMESPACE

--- a/charts/navi-async-matrix/templates/statefulset.yaml
+++ b/charts/navi-async-matrix/templates/statefulset.yaml
@@ -26,13 +26,13 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
-        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
         prometheus.io/path: "/metrics"
         prometheus.io/port: {{ .Values.dm.port | quote }}
         {{- if .Values.prometheusEnabled }}
         prometheus.io/scrape: "true"
         {{- end }}
+        checksum/config: {{ (include (print $.Template.BasePath "/configmap.yaml") . | fromYaml).data | toYaml | sha256sum }}
+        checksum/secret: {{ (include (print $.Template.BasePath "/secret.yaml") . | fromYaml).data | toYaml | sha256sum }}
       {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -68,14 +68,46 @@ spec:
       {{- end }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       volumes:
+      {{- if .Values.dm.archiver.enabled }}
         - name: {{ printf "%s-manifest" (include "navi-async-matrix.fullname" .) | quote }}
           configMap:
             name: {{ printf "%s-configmap" (include "navi-async-matrix.fullname" .) | quote }}
+      {{- end }}
       {{- if .Values.kafka.fileProperties }}
         - name: {{ printf "%s-kafka" (include "navi-async-matrix.fullname" .) | quote }}
           secret:
             secretName: {{ printf "%s-kafka" (include "navi-async-matrix.fullname" .) | quote }}
       {{- end }}
+      {{- if and .Values.db.sslRootCert .Values.db.sslCert .Values.db.sslKey .Values.db.sslMode }}
+        - name: {{ include "navi-async-matrix.fullname-psql-raw" . | quote }}
+          secret:
+            secretName: {{ include "navi-async-matrix.fullname-psql" . | quote }}
+        - name: {{ include "navi-async-matrix.fullname-psql" . | quote }}
+          emptyDir: {}
+      {{- end }}
+      initContainers:
+        {{- if and .Values.db.sslRootCert .Values.db.sslCert .Values.db.sslKey .Values.db.sslMode }}
+        - name: copy-certs
+          image: '{{ required "A valid .Values.dgctlDockerRegistry entry required" .Values.dgctlDockerRegistry }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}'
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          command:
+            - /bin/sh
+            - -ec
+            - |
+              cp /tmp/certs/* /etc/2gis/secret/psql/
+              chmod 600 /etc/2gis/secret/psql/client.key
+          volumeMounts:
+            - name: {{ include "navi-async-matrix.fullname-psql-raw" . | quote }}
+              mountPath: /tmp/certs
+            - name: {{ include "navi-async-matrix.fullname-psql" . | quote }}
+              mountPath: /etc/2gis/secret/psql
+        {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: '{{ required "A valid .Values.dgctlDockerRegistry entry required" .Values.dgctlDockerRegistry }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}'
@@ -99,16 +131,19 @@ spec:
             periodSeconds: 15
             timeoutSeconds: 5
           readinessProbe: *healthProbe
-          # exposing Pod's ordinal is not yet achieved:
-          # https://github.com/kubernetes/kubernetes/issues/30427
-          # here is a workaround for that
-          {{- if .Values.kafka.fileProperties }}
           volumeMounts:
+          {{- if .Values.dm.archiver.enabled }}
           - name: {{ printf "%s-manifest" (include "navi-async-matrix.fullname" .) | quote }}
             mountPath: /app/src/composite_task_result_archiver/manifests/archive_pod_manifest.json
             subPath: archive_pod_manifest.json
+          {{- end }}
+          {{- if .Values.kafka.fileProperties }}
           - name: {{ printf "%s-kafka" (include "navi-async-matrix.fullname" .) | quote }}
             mountPath: /etc/2gis/secret/
+          {{- end }}
+          {{- if and .Values.db.sslRootCert .Values.db.sslCert .Values.db.sslKey .Values.db.sslMode }}
+          - name: {{ printf "%s-psql" (include "navi-async-matrix.fullname" .) | quote }}
+            mountPath: /etc/2gis/secret/psql
           {{- end }}
           env:
             - name: DM_ASYNC_SERVICE_HOST
@@ -129,6 +164,8 @@ spec:
               value: {{ required "A valid .Values.s3.host entry required" .Values.s3.host | quote }}
             - name: DM_ASYNC_SERVICE_STORAGE_SETTING__S3_STORAGE_CONNECTION__S3_BUCKET
               value: {{ required "A valid .Values.s3.bucket entry required" .Values.s3.bucket | quote }}
+            - name: DM_ASYNC_SERVICE_LOGGER_SETTING__LEVEL
+              value: {{ .Values.dm.logLevel | quote }}
             {{- if .Values.s3.publicNetloc }}
             - name: DM_ASYNC_SERVICE_STORAGE_SETTING__S3_PUBLIC_NETLOC
               value: {{ .Values.s3.publicNetloc | quote }}
@@ -140,6 +177,7 @@ spec:
             - name: DM_ASYNC_SERVICE_KAFKA_CONSUMER_SETTING__KAFKA_CONSUMER_CONFIG__GROUP_ID
               value: {{ .Values.kafka.groupId | quote }}
             - name: DM_ASYNC_SERVICE_TOPIC_RULES
+              {{- /* topicRules is a structure, hence mustToJson */}}
               value: {{ .Values.kafka.taskTopicRules | mustToJson | quote }}
             - name: DM_ASYNC_SERVICE_KAFKA_CONSUMER_SETTING__KAFKA_CONSUMER_ARCHIVE_RESPONSE_TOPIC
               value: {{ .Values.kafka.archiveTopic | quote }}

--- a/charts/navi-async-matrix/templates/statefulset.yaml
+++ b/charts/navi-async-matrix/templates/statefulset.yaml
@@ -198,26 +198,6 @@ spec:
             - name: DM_ASYNC_SERVICE_COMPOSITE_TASK_TIMEOUT_IN_SECONDS
               value: {{ .Values.dm.compositeTaskTimeoutSec | quote }}
             {{- end }}{{- /* .Values.dm.archiver.enabled */}}
-            {{- /*
-                 Collect merged Kafka properties from these dictionaries:
-                   - kafka.properties: this is a simple key/value dictionary
-                   - kafka.fileProperties: this is a key/content dictionary given in values,
-                     content is sensitive and stored in Secret resource, they get
-                     mounted as files sonamed after key. While actual secret values are
-                     hidden this way, what actually goes here in environment properties is
-                     file names. This value substitution is implemented down here.
-                 */ -}}
-            {{- $kafkaProperties := dict -}}
-            {{- range $key, $_ := .Values.kafka.fileProperties -}}
-            {{- $_ := set $kafkaProperties $key (printf "/etc/2gis/secret/%s" $key) -}}
-            {{- end -}}
-            {{- $kafkaProperties := mustMerge $kafkaProperties .Values.kafka.properties -}}
-            {{- range $prop, $val := $kafkaProperties }}
-            - name: DM_ASYNC_SERVICE_KAFKA_CONSUMER_SETTING__KAFKA_CONSUMER_CONFIG__{{ $prop | upper | replace "." "_" }}
-              value: {{ $val | quote }}
-            - name: DM_ASYNC_SERVICE_KAFKA_PRODUCER_SETTING__KAFKA_PRODUCER_CONFIG__{{ $prop | upper | replace "." "_" }}
-              value: {{ $val | quote }}
-            {{- end }}
             - name: DM_ASYNC_SERVICE_NODE_ID
               valueFrom:
                 fieldRef:
@@ -258,18 +238,6 @@ spec:
                 secretKeyRef:
                   name: {{ include "navi-async-matrix.fullname" . | quote }}
                   key: s3key
-            {{- range $prop, $val := .Values.kafka.sensitiveProperties }}
-            - name: DM_ASYNC_SERVICE_KAFKA_CONSUMER_SETTING__KAFKA_CONSUMER_CONFIG__{{ $prop | upper | replace "." "_" }}
-              valueFrom:
-                secretKeyRef:
-                  name: {{ printf "%s-kafka" (include "navi-async-matrix.fullname" $) | quote }}
-                  key: {{ $prop | quote }}
-            - name: DM_ASYNC_SERVICE_KAFKA_PRODUCER_SETTING__KAFKA_PRODUCER_CONFIG__{{ $prop | upper | replace "." "_" }}
-              valueFrom:
-                secretKeyRef:
-                  name: {{ printf "%s-kafka" (include "navi-async-matrix.fullname" $) | quote }}
-                  key: {{ $prop | quote }}
-            {{- end }}
             - name: DM_ASYNC_SERVICE_KMS__DM_ASYNC_TOKEN
               valueFrom:
                 secretKeyRef:

--- a/charts/navi-async-matrix/templates/statefulset.yaml
+++ b/charts/navi-async-matrix/templates/statefulset.yaml
@@ -78,7 +78,7 @@ spec:
           secret:
             secretName: {{ printf "%s-kafka" (include "navi-async-matrix.fullname" .) | quote }}
       {{- end }}
-      {{- if and .Values.db.sslRootCert .Values.db.sslCert .Values.db.sslKey .Values.db.sslMode }}
+      {{- if .Values.db.tls.enabled }}
         - name: {{ include "navi-async-matrix.fullname-psql-raw" . | quote }}
           secret:
             secretName: {{ include "navi-async-matrix.fullname-psql" . | quote }}
@@ -86,7 +86,7 @@ spec:
           emptyDir: {}
       {{- end }}
       initContainers:
-        {{- if and .Values.db.sslRootCert .Values.db.sslCert .Values.db.sslKey .Values.db.sslMode }}
+        {{- if .Values.db.tls.enabled }}
         - name: copy-certs
           image: '{{ required "A valid .Values.dgctlDockerRegistry entry required" .Values.dgctlDockerRegistry }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}'
           imagePullPolicy: {{ .Values.image.pullPolicy }}
@@ -141,7 +141,7 @@ spec:
           - name: {{ printf "%s-kafka" (include "navi-async-matrix.fullname" .) | quote }}
             mountPath: /etc/2gis/secret/
           {{- end }}
-          {{- if and .Values.db.sslRootCert .Values.db.sslCert .Values.db.sslKey .Values.db.sslMode }}
+          {{- if .Values.db.tls.enabled }}
           - name: {{ printf "%s-psql" (include "navi-async-matrix.fullname" .) | quote }}
             mountPath: /etc/2gis/secret/psql
           {{- end }}

--- a/charts/navi-async-matrix/templates/statefulset.yaml
+++ b/charts/navi-async-matrix/templates/statefulset.yaml
@@ -98,21 +98,16 @@ spec:
           # exposing Pod's ordinal is not yet achieved:
           # https://github.com/kubernetes/kubernetes/issues/30427
           # here is a workaround for that
-          command:
-            - uvicorn
-            - src.main:app
-            - '--host'
-            - '0.0.0.0'
-            - '--port'
-            - '{{ .Values.dm.port | int }}'
-            - '--workers'
-            - '{{ .Values.dm.workerCount | int }}'
           {{- if .Values.kafka.fileProperties }}
           volumeMounts:
           - name: {{ printf "%s-kafka" (include "navi-async-matrix.fullname" .) | quote }}
             mountPath: /etc/2gis/secret/
           {{- end }}
           env:
+            - name: DM_ASYNC_SERVICE_HOST
+              value: {{ .Values.dm.host | quote }}
+            - name: DM_ASYNC_SERVICE_PORT
+              value: {{ .Values.dm.port | quote }}
             - name: CONFIG_TYPE
               value: {{ .Values.dm.configType | quote }}
             - name: DM_ASYNC_SERVICE_CITIES_SETTING__LINK_TO_CITIES_FILE
@@ -172,6 +167,8 @@ spec:
               value: {{ .Values.bss.version | quote }}
             {{- end }}
             # sensitive data
+            - name: DM_ASYNC_SERVICE_DB_SCHEMA
+              value: {{ .Values.db.schema | quote }}
             - name: DM_ASYNC_SERVICE_DB_DSN
               valueFrom:
                 secretKeyRef:

--- a/charts/navi-async-matrix/templates/statefulset.yaml
+++ b/charts/navi-async-matrix/templates/statefulset.yaml
@@ -66,7 +66,6 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
-      {{- if .Values.kafka.fileProperties }}
       volumes:
         - name: {{ printf "%s-manifest" (include "navi-async-matrix.fullname" .) | quote }}
           configMap:

--- a/charts/navi-async-matrix/templates/statefulset.yaml
+++ b/charts/navi-async-matrix/templates/statefulset.yaml
@@ -26,6 +26,7 @@ spec:
   template:
     metadata:
       annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
         prometheus.io/path: "/metrics"
         prometheus.io/port: {{ .Values.dm.port | quote }}

--- a/charts/navi-async-matrix/templates/vpa.yaml
+++ b/charts/navi-async-matrix/templates/vpa.yaml
@@ -17,7 +17,7 @@ spec:
     updateMode: {{ .updateMode }}
   resourcePolicy:
     containerPolicies:
-      - containerName: {{ include "navi-async-matrix.name" }}
+      - containerName: {{ include "navi-async-matrix.name" $ }}
         mode: Auto
         {{- with .minAllowed }}
         minAllowed:

--- a/charts/navi-async-matrix/values.yaml
+++ b/charts/navi-async-matrix/values.yaml
@@ -51,7 +51,7 @@ prometheusEnabled: true
 image:
   repository: 2gis-on-premise/navi-async-matrix
   pullPolicy: IfNotPresent
-  tag: 1.6.1
+  tag: 1.6.2
 
 
 # @section Service account settings

--- a/charts/navi-async-matrix/values.yaml
+++ b/charts/navi-async-matrix/values.yaml
@@ -177,6 +177,7 @@ dm:
   configType: env
   citiesUrl: ''
   citiesUpdatePeriod: 3600
+  taskSplitSize: 5000
   archiver:
     enabled: true
     fetchLogs: false

--- a/charts/navi-async-matrix/values.yaml
+++ b/charts/navi-async-matrix/values.yaml
@@ -199,10 +199,11 @@ dm:
 # @param db.user PostgreSQL username. **Required**
 # @param db.password PostgreSQL password. **Required**
 # @param db.schema PostgreSQL schema.
-# @param db.sslRootCert Root certificate file.
-# @param db.sslCert Certificate of postgresql server.
-# @param db.sslKey Key of postgresql server.
-# @param db.sslMode Level of protection.
+# @param db.tls.enabled If tls connection to postgresql is enabled.
+# @param db.tls.sslRootCert Root certificate file.
+# @param db.tls.sslCert Certificate of postgresql server.
+# @param db.tls.sslKey Key of postgresql server.
+# @param db.tls.sslMode Level of protection.
 
 db:
   host: ''
@@ -211,10 +212,12 @@ db:
   user: ''
   password: ''
   schema: public
-  sslRootCert: ""
-  sslCert: ""
-  sslKey: ""
-  sslMode: verify-full
+  tls:
+    enabled: false
+    sslRootCert: ""
+    sslCert: ""
+    sslKey: ""
+    sslMode: verify-full
 
 
 # @section Kafka settings

--- a/charts/navi-async-matrix/values.yaml
+++ b/charts/navi-async-matrix/values.yaml
@@ -182,6 +182,7 @@ dm:
   citiesUrl: ''
   citiesUpdatePeriod: 3600
   taskSplitSize: 5000
+  compositeTaskTimeoutSec: 3600
   archiver:
     enabled: true
     fetchLogs: false

--- a/charts/navi-async-matrix/values.yaml
+++ b/charts/navi-async-matrix/values.yaml
@@ -24,7 +24,7 @@ dgctlDockerRegistry: ''
 # @param terminationGracePeriodSeconds Kubernetes [termination grace period](https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/).
 # @param prometheusEnabled If Prometheus scrape is enabled.
 
-replicaCount: 1
+replicaCount: 2
 imagePullSecrets: []
 nameOverride: ''
 fullnameOverride: ''
@@ -51,7 +51,7 @@ prometheusEnabled: true
 image:
   repository: 2gis-on-premise/navi-async-matrix
   pullPolicy: IfNotPresent
-  tag: 1.3.3
+  tag: 1.6.0
 
 
 # @section Service account settings
@@ -172,9 +172,9 @@ vpa:
 # @param dm.citiesUpdatePeriod Period (in seconds) between requesting data from `citiesUrl`.
 
 dm:
+  host: '0.0.0.0'
   port: 8000
   configType: env
-  workerCount: 4
   citiesUrl: ''
   citiesUpdatePeriod: 3600
 
@@ -193,6 +193,7 @@ db:
   name: ''
   user: ''
   password: ''
+  schema: public
 
 
 # @section Kafka settings

--- a/charts/navi-async-matrix/values.yaml
+++ b/charts/navi-async-matrix/values.yaml
@@ -127,19 +127,17 @@ pdb:
 # @param hpa.enabled If HPA is enabled for the service.
 # @param hpa.minReplicas Lower limit for the number of replicas to which the autoscaler can scale down.
 # @param hpa.maxReplicas Upper limit for the number of replicas to which the autoscaler can scale up.
-# @param hpa.scaleDownStabilizationWindowSeconds Scale-down window.
-# @param hpa.scaleUpStabilizationWindowSeconds Scale-up window.
 # @param hpa.targetCPUUtilizationPercentage Target average CPU utilization (represented as a percentage of requested CPU) over all the pods; if not specified the default autoscaling policy will be used.
 # @param hpa.targetMemoryUtilizationPercentage Target average memory utilization (represented as a percentage of requested memory) over all the pods; if not specified the default autoscaling policy will be used.
+# @param hpa.behavior HPA Behavior
 
 hpa:
   enabled: false
   minReplicas: 1
   maxReplicas: 2
-  scaleDownStabilizationWindowSeconds: ''
-  scaleUpStabilizationWindowSeconds: ''
   targetCPUUtilizationPercentage: 80
   targetMemoryUtilizationPercentage: ''
+  behavior: {}
 
 
 # @section Kubernetes [Vertical Pod Autoscaling](https://github.com/kubernetes/autoscaler/blob/master/vertical-pod-autoscaler/README.md) settings

--- a/charts/navi-async-matrix/values.yaml
+++ b/charts/navi-async-matrix/values.yaml
@@ -200,10 +200,10 @@ dm:
 # @param db.password PostgreSQL password. **Required**
 # @param db.schema PostgreSQL schema.
 # @param db.tls.enabled If tls connection to postgresql is enabled.
-# @param db.tls.sslRootCert Root certificate file.
-# @param db.tls.sslCert Certificate of postgresql server.
-# @param db.tls.sslKey Key of postgresql server.
-# @param db.tls.sslMode Level of protection.
+# @param db.tls.rootCert Root certificate file.
+# @param db.tls.cert Certificate of postgresql server.
+# @param db.tls.key Key of postgresql server.
+# @param db.tls.mode Level of protection.
 
 db:
   host: ''
@@ -214,10 +214,10 @@ db:
   schema: public
   tls:
     enabled: false
-    sslRootCert: ""
-    sslCert: ""
-    sslKey: ""
-    sslMode: verify-full
+    rootCert: ""
+    cert: ""
+    key: ""
+    mode: verify-full
 
 
 # @section Kafka settings

--- a/charts/navi-async-matrix/values.yaml
+++ b/charts/navi-async-matrix/values.yaml
@@ -177,6 +177,17 @@ dm:
   configType: env
   citiesUrl: ''
   citiesUpdatePeriod: 3600
+  archiver:
+    enabled: true
+    fetchLogs: false
+    image:
+      repository: on-premise/archiver-async-service
+      pullPolicy: IfNotPresent
+      tag: 1.1.0
+    resources:
+      limits:
+        cpu: 2
+        memory: 6Gi
 
 
 # @section Database settings

--- a/charts/navi-async-matrix/values.yaml
+++ b/charts/navi-async-matrix/values.yaml
@@ -65,6 +65,12 @@ serviceAccount:
   annotations: {}
   name: ''
 
+# @section RBAC parameter
+
+# @param rbac.create Whether to create and use RBAC resources or not
+# @param rbac.annotations Role and RoleBinding annotations
+# @param rbac.labels Role and RoleBinding additional labels
+
 rbac:
   create: false
   annotations: {}
@@ -174,11 +180,18 @@ vpa:
 # @param dm.workerCount Number of Distance Matrix Async workers.
 # @param dm.citiesUrl URL of the information about cities provided by the Navi-Castle service, ex: http://navi-castle.svc/cities.conf. **Required**
 # @param dm.citiesUpdatePeriod Period (in seconds) between requesting data from `citiesUrl`.
+# @param dm.taskSplitSize Minimum size of matrix to get split in archiver job.
+# @param dm.compositeTaskTimeoutSec Timeout for executing split tasks.
+# @skip dm.host
+# @skip dm.archiver
+# @skip dm.labels
+# @skip dm.annotations
 
 dm:
   host: '0.0.0.0'
   port: 8000
   configType: env
+  workerCount: 4
   citiesUrl: ''
   citiesUpdatePeriod: 3600
   taskSplitSize: 5000
@@ -205,6 +218,7 @@ dm:
 # @param db.name PostgreSQL database name. **Required**
 # @param db.user PostgreSQL username. **Required**
 # @param db.password PostgreSQL password. **Required**
+# @param db.schema PostgreSQL schema.
 
 db:
   host: ''
@@ -220,6 +234,7 @@ db:
 # @param kafka.groupId Distance Matrix Async API group identifier.
 # @param kafka.statusTopic Name of the topic for sending new tasks to.
 # @param kafka.cancelTopic Name of the topic for canceling or receiving information about finished tasks.
+# @param kafka.archiveTopic Name of the topic for archiving tasks.
 # @extra kafka.properties Properties as supported by kafka-python. Refer to inline comments for details.
 # @skip kafka.properties.bootstrap.servers
 # @skip kafka.properties.security.protocol

--- a/charts/navi-async-matrix/values.yaml
+++ b/charts/navi-async-matrix/values.yaml
@@ -65,17 +65,6 @@ serviceAccount:
   annotations: {}
   name: ''
 
-# @section RBAC parameter
-
-# @param rbac.create Whether to create and use RBAC resources or not
-# @param rbac.annotations Role and RoleBinding annotations
-# @param rbac.labels Role and RoleBinding additional labels
-
-rbac:
-  create: false
-  annotations: {}
-  labels: {}
-
 # @section Strategy settings
 
 # @param updateStrategy.type Type of Kubernetes deployment. Can be `Recreate` or `RollingUpdate`.
@@ -181,8 +170,8 @@ vpa:
 # @param dm.workerCount Number of Distance Matrix Async workers.
 # @param dm.citiesUrl URL of the information about cities provided by the Navi-Castle service, ex: http://navi-castle.svc/cities.conf. **Required**
 # @param dm.citiesUpdatePeriod Period (in seconds) between requesting data from `citiesUrl`.
-# @param dm.taskSplitSize Minimum size of matrix to get split in archiver job.
-# @param dm.compositeTaskTimeoutSec Timeout for executing split tasks.
+# @skip dm.taskSplitSize
+# @skip dm.compositeTaskTimeoutSec
 # @skip dm.host
 # @skip dm.archiver
 # @skip dm.labels
@@ -200,15 +189,6 @@ dm:
   compositeTaskTimeoutSec: 3600
   archiver:
     enabled: false
-    fetchLogs: false
-    image:
-      repository: on-premise/archiver-async-service
-      pullPolicy: IfNotPresent
-      tag: 1.1.0
-    resources:
-      limits:
-        cpu: 2
-        memory: 6Gi
   labels: {}
   annotations: {}
 
@@ -244,7 +224,7 @@ db:
 # @param kafka.groupId Distance Matrix Async API group identifier.
 # @param kafka.statusTopic Name of the topic for sending new tasks to.
 # @param kafka.cancelTopic Name of the topic for canceling or receiving information about finished tasks.
-# @param kafka.archiveTopic Name of the topic for archiving tasks.
+# @skip kafka.archiveTopic
 # @extra kafka.properties Properties as supported by kafka-python. Refer to inline comments for details.
 # @skip kafka.properties.bootstrap.servers
 # @skip kafka.properties.security.protocol

--- a/charts/navi-async-matrix/values.yaml
+++ b/charts/navi-async-matrix/values.yaml
@@ -217,6 +217,7 @@ kafka:
   groupId: navi_async_matrix
   statusTopic: status_topic
   cancelTopic: cancel_topic
+  archiveTopic: archive_topic
   properties:
     bootstrap.servers: ''
     security.protocol: PLAINTEXT

--- a/charts/navi-async-matrix/values.yaml
+++ b/charts/navi-async-matrix/values.yaml
@@ -65,6 +65,10 @@ serviceAccount:
   annotations: {}
   name: ''
 
+rbac:
+  create: false
+  annotations: {}
+  labels: {}
 
 # @section Strategy settings
 
@@ -189,6 +193,8 @@ dm:
       limits:
         cpu: 2
         memory: 6Gi
+  labels: {}
+  annotations: {}
 
 
 # @section Database settings

--- a/charts/navi-async-matrix/values.yaml
+++ b/charts/navi-async-matrix/values.yaml
@@ -24,7 +24,7 @@ dgctlDockerRegistry: ''
 # @param terminationGracePeriodSeconds Kubernetes [termination grace period](https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/).
 # @param prometheusEnabled If Prometheus scrape is enabled.
 
-replicaCount: 2
+replicaCount: 1
 imagePullSecrets: []
 nameOverride: ''
 fullnameOverride: ''
@@ -51,7 +51,7 @@ prometheusEnabled: true
 image:
   repository: 2gis-on-premise/navi-async-matrix
   pullPolicy: IfNotPresent
-  tag: 1.6.0
+  tag: 1.6.1
 
 
 # @section Service account settings
@@ -177,6 +177,7 @@ vpa:
 
 # @param dm.port Distance Matrix Async API HTTP port.
 # @param dm.configType Configuration type. Must always be `env`.
+# @param dm.logLevel Logging level, one of: DEBUG, INFO, WARNING, ERROR, CRITICAL.
 # @param dm.workerCount Number of Distance Matrix Async workers.
 # @param dm.citiesUrl URL of the information about cities provided by the Navi-Castle service, ex: http://navi-castle.svc/cities.conf. **Required**
 # @param dm.citiesUpdatePeriod Period (in seconds) between requesting data from `citiesUrl`.
@@ -191,13 +192,14 @@ dm:
   host: '0.0.0.0'
   port: 8000
   configType: env
+  logLevel: INFO
   workerCount: 4
   citiesUrl: ''
   citiesUpdatePeriod: 3600
   taskSplitSize: 5000
   compositeTaskTimeoutSec: 3600
   archiver:
-    enabled: true
+    enabled: false
     fetchLogs: false
     image:
       repository: on-premise/archiver-async-service
@@ -219,6 +221,10 @@ dm:
 # @param db.user PostgreSQL username. **Required**
 # @param db.password PostgreSQL password. **Required**
 # @param db.schema PostgreSQL schema.
+# @param db.sslRootCert Root certificate file.
+# @param db.sslCert Certificate of postgresql server.
+# @param db.sslKey Key of postgresql server.
+# @param db.sslMode Level of protection.
 
 db:
   host: ''
@@ -227,6 +233,10 @@ db:
   user: ''
   password: ''
   schema: public
+  sslRootCert: ""
+  sslCert: ""
+  sslKey: ""
+  sslMode: verify-full
 
 
 # @section Kafka settings


### PR DESCRIPTION
В связи с новыми требованиями безопасности, весь питон код в docker образах dmasync упаковывается в бинарники.

Данные изменения являются ломающими, так как для успешного запуска образов с бандлами вносятся изменения в деплой.
Запуск dmasync сервисов теперь производится внутри docker образов, что повлекло к следующим изменениям:

- dmasync-service теперь не будет запускаться через command.
- параметр ```dm.workerCount``` больше недоступен (нельзя передать в бандл). Вместо этого увеличивается ```replicaCount``` до 2
- добавлен параметр ```dm.host``` принимает значения вида: ```0.0.0.0``` и вместе с ```dm.port``` пробрасывается через переменные ```DM_ASYNC_SERVICE_HOST``` и ```DM_ASYNC_SERVICE_HOST``` в деплой.
- параметризирована DB схема, чтобы появилась возможность использования не публичной схемы. Поддержана через параметр ```db.schema``` (любое строковое значене, в качестве имени схемы, default: ```public```) и проброшена в деплой переменной ```DM_ASYNC_SERVICE_DB_SCHEMA```, которая поддержана в коде.