### PR TITLE
PRO-3260: update helm for pro-ui

### DIFF
--- a/charts/pro-ui/Chart.yaml
+++ b/charts/pro-ui/Chart.yaml
@@ -3,10 +3,10 @@ name: pro-ui
 type: application
 description: A Helm chart for Kubernetes to deploy 2GIS Pro UI service
 
-version: 1.10.0
-appVersion: 1.0.2
+version: 1.11.0
+appVersion: 1.1.0
 
 maintainers:
-- name: 2gis
-  url: https://github.com/2gis
-  email: on-premise@2gis.com
+  - name: 2gis
+    url: https://github.com/2gis
+    email: on-premise@2gis.com

--- a/charts/pro-ui/templates/ui/deployment.yaml
+++ b/charts/pro-ui/templates/ui/deployment.yaml
@@ -41,7 +41,7 @@ spec:
               containerPort: 3000
           readinessProbe:
             httpGet:
-              path: /api/healthcheck/app
+              path: {{ .Values.ui.healthcheckPath }}
               port: http
           resources:
             {{- toYaml .Values.ui.resources | nindent 12 }}

--- a/charts/pro-ui/values.schema.json
+++ b/charts/pro-ui/values.schema.json
@@ -17,7 +17,8 @@
         "supportDocumentationLink",
         "auth",
         "api",
-        "mapgl"
+        "mapgl",
+        "healthcheckPath"
       ],
       "properties": {
         "logLevel": {
@@ -39,6 +40,9 @@
           "type": "string"
         },
         "supportDocumentationLink": {
+          "type": "string"
+        },
+        "healthcheckPath": {
           "type": "string"
         },
         "auth": {

--- a/charts/pro-ui/values.yaml
+++ b/charts/pro-ui/values.yaml
@@ -18,6 +18,7 @@ ui:
   # @param ui.podLabels Kubernetes [pod labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/).
   # @param ui.annotations Kubernetes [annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/).
   # @param ui.labels Kubernetes [labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/).
+  # @param ui.healthcheckPath Kubernetes [live/ready probes path](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/). Possible values: `/api/healthcheck/app` (checks current app healthcheck only), `/api/api/healthcheck/integration` (checks healthchecks of current app and all integrations).
 
   replicas: 1
   nodeSelector: {}
@@ -27,6 +28,7 @@ ui:
   podLabels: {}
   annotations: {}
   labels: {}
+  healthcheckPath: /api/healthcheck/app
 
   # @section Deployment settings
 
@@ -138,7 +140,7 @@ ui:
   ingress:
     enabled: false
     hosts:
-    - host: pro-ui.host
+      - host: pro-ui.host
 
   # @section Limits
 

--- a/charts/pro-ui/values.yaml
+++ b/charts/pro-ui/values.yaml
@@ -18,7 +18,7 @@ ui:
   # @param ui.podLabels Kubernetes [pod labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/).
   # @param ui.annotations Kubernetes [annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/).
   # @param ui.labels Kubernetes [labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/).
-  # @param ui.healthcheckPath Kubernetes [live/ready probes path](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/). Possible values: `/api/healthcheck/app` (checks current app healthcheck only), `/api/api/healthcheck/integration` (checks healthchecks of current app and all integrations).
+  # @param ui.healthcheckPath Kubernetes [live/ready probes path](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/). Possible values: `/api/healthcheck/app` (checks current app healthcheck only), `/api/healthcheck/integration` (checks healthchecks of current app and all integrations).
 
   replicas: 1
   nodeSelector: {}


### PR DESCRIPTION
По мотивам долгих бесед с @endryhold и тикета https://jira.2gis.ru/browse/PRO-3260

Обсудили проблему, кажется, IO-спецам не хватает хелсчека у pro-ui, который бы ответил на вопрос, а в фронт или бек сломался. Для этого в приложении завели новый URL, где возвращается инфа по ready-статусу бека и фронта — /api/api/healthcheck/integration

Мы думали, как это отразить в хельме, вот решили в комменте описать. Но для этого путь до основного хелсчека (который в пробах k8s используется), мы вынесли в values.