### PR TITLE
IODEV-1568: [tiles-api] Changed description of license.url param

### DIFF
--- a/charts/tiles-api/README.md
+++ b/charts/tiles-api/README.md
@@ -221,7 +221,7 @@ See the [documentation](https://docs.2gis.com/en/on-premise/map) to learn about:
 
 | Name                  | Description                                                                                     | Value |
 | --------------------- | ----------------------------------------------------------------------------------------------- | ----- |
-| `license.url`         | Address of the License service. Ex: http(s)://license.svc                                       | `""`  |
+| `license.url`         | Address of the License service. Ex: https://license.svc                                         | `""`  |
 | `license.retryPeriod` | Duration how often tiles server should try to update license status if it is failing to get it. | `30s` |
 
 

--- a/charts/tiles-api/values.yaml
+++ b/charts/tiles-api/values.yaml
@@ -394,7 +394,7 @@ importer:
 
 # @section License service settings
 
-# @param license.url Address of the License service. Ex: http(s)://license.svc
+# @param license.url Address of the License service. Ex: https://license.svc
 # @param license.retryPeriod Duration how often tiles server should try to update license status if it is failing to get it.
 
 license:


### PR DESCRIPTION
## Описание

Начиная с версии `4.49.0` мы планируем отказаться от поддержки лицензирования v1 и перейти на лицензирование v2 - соответственно эндпойнт сервиса лицензирования обязательно должен быть `https` эндпойнтом