### PR TITLE
navi-castle: adds restrictions import

### DIFF
--- a/charts/navi-castle/README.md
+++ b/charts/navi-castle/README.md
@@ -51,18 +51,20 @@ See the [documentation](https://docs.2gis.com/en/on-premise/navigation) to learn
 
 ### Common settings
 
-| Name                 | Description                                                                                                                 | Value |
-| -------------------- | --------------------------------------------------------------------------------------------------------------------------- | ----- |
-| `replicaCount`       | A replica count for the pod.                                                                                                | `1`   |
-| `imagePullSecrets`   | Kubernetes image pull secrets.                                                                                              | `[]`  |
-| `nameOverride`       | Base name to use in all the Kubernetes entities deployed by this chart.                                                     | `""`  |
-| `fullnameOverride`   | Base fullname to use in all the Kubernetes entities deployed by this chart.                                                 | `""`  |
-| `podAnnotations`     | Kubernetes [pod annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/).               | `{}`  |
-| `podSecurityContext` | Kubernetes [pod security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/).              | `{}`  |
-| `securityContext`    | Kubernetes [security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/).                  | `{}`  |
-| `nodeSelector`       | Kubernetes [node selectors](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector).         | `{}`  |
-| `tolerations`        | Kubernetes [tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) settings.           | `[]`  |
-| `affinity`           | Kubernetes pod [affinity settings](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity). | `{}`  |
+| Name                            | Description                                                                                                                 | Value |
+| ------------------------------- | --------------------------------------------------------------------------------------------------------------------------- | ----- |
+| `replicaCount`                  | A replica count for the pod.                                                                                                | `1`   |
+| `imagePullSecrets`              | Kubernetes image pull secrets.                                                                                              | `[]`  |
+| `nameOverride`                  | Base name to use in all the Kubernetes entities deployed by this chart.                                                     | `""`  |
+| `fullnameOverride`              | Base fullname to use in all the Kubernetes entities deployed by this chart.                                                 | `""`  |
+| `podAnnotations`                | Kubernetes [pod annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/).               | `{}`  |
+| `podSecurityContext`            | Kubernetes [pod security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/).              | `{}`  |
+| `securityContext`               | Kubernetes [security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/).                  | `{}`  |
+| `nodeSelector`                  | Kubernetes [node selectors](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector).         | `{}`  |
+| `tolerations`                   | Kubernetes [tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) settings.           | `[]`  |
+| `affinity`                      | Kubernetes pod [affinity settings](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity). | `{}`  |
+| `terminationGracePeriodSeconds` | Maximum time allowed for graceful shutdown.                                                                                 | `60`  |
+
 
 
 ### Service account settings
@@ -104,14 +106,17 @@ See the [documentation](https://docs.2gis.com/en/on-premise/navigation) to learn
 | `resources.limits.cpu`      | CPU limit, recommended value `1000m`.       | `undefined` |
 | `resources.limits.memory`   | Memory limit, recommended value `512Mi`.    | `undefined` |
 
+
 ### Navi-Castle service settings
 
-| Name                       | Description                          | Value                          |
-| -------------------------- | ------------------------------------ | ------------------------------ |
-| `castle.castleDataPath`    | Path to the data directory.          | `/opt/castle/data/`            |
-| `castle.restrictions.host` | Restrictions API base URL.           | `http://restrictions-api.host` |
-| `castle.restrictions.key`  | Restrictions API key.                | `""`                           |
-| `castle.jobs`              | Number of parallel downloading jobs. | `1`                            |
+| Name                       | Description                                         | Value                          |
+| -------------------------- | --------------------------------------------------- | ------------------------------ |
+| `castle.castleDataPath`    | Path to the data directory.                         | `/opt/castle/data/`            |
+| `castle.restrictions`      | Section ignored if castle.restriction.enabled=false |                                |
+| `castle.restrictions.host` | Restrictions API base URL.                          | `http://restrictions-api.host` |
+| `castle.restrictions.key`  | Restrictions API key.                               | `""`                           |
+| `castle.jobs`              | Number of parallel downloading jobs.                | `1`                            |
+
 
 
 ### Navi-Front settings
@@ -123,14 +128,17 @@ See the [documentation](https://docs.2gis.com/en/on-premise/navigation) to learn
 
 ### Cron settings
 
-| Name                              | Description                                        | Value         |
-| --------------------------------- | -------------------------------------------------- | ------------- |
-| `cron.enabled.import`             | If the `import` cron job is enabled.               | `false`       |
-| `cron.enabled.restriction`        | If the `restriction` cron job is enabled.          | `false`       |
-| `cron.schedule.import`            | Cron job schedule for `import`.                    | `11 * * * *`  |
-| `cron.schedule.restriction`       | Cron job schedule for `restriction`.               | `*/5 * * * *` |
-| `cron.concurrencyPolicy`          | Cron job concurrency policy: `Allow` or `Forbid`.  | `Forbid`      |
-| `cron.successfulJobsHistoryLimit` | How many completed and failed jobs should be kept. | `3`           |
+| Name                              | Description                                                         | Value         |
+| --------------------------------- | ------------------------------------------------------------------- | ------------- |
+| `cron.enabled.import`             | If the `import` cron job is enabled.                                | `false`       |
+| `cron.enabled.restriction`        | If restrictions API enabled, incompatible with `restrictionImport`. | `false`       |
+| `cron.enabled.restrictionImport`  | If restrictions import enabled, incompatible with `restriction`.    | `false`       |
+| `cron.schedule.import`            | Cron job schedule for `import`.                                     | `11 * * * *`  |
+| `cron.schedule.restriction`       | Cron job schedule for `restriction`.                                | `*/5 * * * *` |
+| `cron.schedule.restrictionImport` | Cron job schedule for `restrictionImport`.                          | `*/5 * * * *` |
+| `cron.concurrencyPolicy`          | Cron job concurrency policy: `Allow` or `Forbid`.                   | `Forbid`      |
+| `cron.successfulJobsHistoryLimit` | How many completed and failed jobs should be kept.                  | `3`           |
+
 
 
 ### Kubernetes [Persistence Volumes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) settings

--- a/charts/navi-castle/README.md
+++ b/charts/navi-castle/README.md
@@ -66,7 +66,6 @@ See the [documentation](https://docs.2gis.com/en/on-premise/navigation) to learn
 | `terminationGracePeriodSeconds` | Maximum time allowed for graceful shutdown.                                                                                 | `60`  |
 
 
-
 ### Service account settings
 
 | Name                         | Description                                                                                                             | Value   |
@@ -118,7 +117,6 @@ See the [documentation](https://docs.2gis.com/en/on-premise/navigation) to learn
 | `castle.jobs`              | Number of parallel downloading jobs.                | `1`                            |
 
 
-
 ### Navi-Front settings
 
 | Name         | Description                                      | Value  |
@@ -138,7 +136,6 @@ See the [documentation](https://docs.2gis.com/en/on-premise/navigation) to learn
 | `cron.schedule.restrictionImport` | Cron job schedule for `restrictionImport`.                          | `*/5 * * * *` |
 | `cron.concurrencyPolicy`          | Cron job concurrency policy: `Allow` or `Forbid`.                   | `Forbid`      |
 | `cron.successfulJobsHistoryLimit` | How many completed and failed jobs should be kept.                  | `3`           |
-
 
 
 ### Kubernetes [Persistence Volumes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) settings

--- a/charts/navi-castle/templates/_helpers.tpl
+++ b/charts/navi-castle/templates/_helpers.tpl
@@ -62,7 +62,6 @@ Create the name of the service account to use
 {{- end }}
 
 
-{{/* vim: set filetype=mustache: */}}
 {{/*
 Renders a value that contains template.
 Usage:
@@ -74,4 +73,13 @@ Usage:
     {{- else }}
         {{- tpl (.value | toYaml) .context }}
     {{- end }}
+{{- end -}}
+
+
+{{/*
+Determine --service parameter for a specific cron job flavor
+{{ include "castle.serviceParameter" ( dict "flavor" <a key one of .Values.cron.enabled.* > ) }}
+*/}}
+{{- define "castle.serviceParameter" -}}
+{{- eq "restrictionImport" .flavor | ternary "import-restrictions" .flavor -}}
 {{- end -}}

--- a/charts/navi-castle/templates/configmapbuilder.yaml
+++ b/charts/navi-castle/templates/configmapbuilder.yaml
@@ -44,34 +44,23 @@ data:
     manifest:
     {
         pattern: '{{ default "/manifests/" .Values.dgctlStorage.manifest }}',
-        service: 'navi',
+        service: ['navi','navi-restrictions'],
+        mapping: {
+            'navi': 'import_package',
+            'navi-restrictions': 'import_restriction'
+        }
     }
     # --------------------------------------------
     # DATA PACKAGE
 
-    imports:
-    {
-        remote_name: '%path%',
-        remote_dir: '',
+    {{- /* Guard incompatible services enabling */}}
+    {{- with .Values.cron.enabled }}
+      {{- if (and .restriction .restrictionImport) }}
+        {{- fail "Only one of restriction and restrictionImport can be active at once." }}
+      {{- end }}{{- /* if */}}
+    {{- end }}{{- /* with */}}
 
-        package: '%project%.2gis',
-        package_info:
-        {
-            local_name: '%issue-month%_%timestamp%.2gis',
-            local_dir: 'packages/%project%',
-        },
-
-        restriction: '%project%-restriction.json',
-        restriction_info:
-        {
-            local_name: '%current-date%_%hour%.json',
-            local_dir: 'restrictions_json/%project%'
-        },
-
-        unpack: 'tar',
-        meta: '%project%.json'
-    }
-
+    {{- if .Values.cron.enabled.restriction }}
     restriction:
     {
         remote_name: '',
@@ -92,6 +81,40 @@ data:
 
         store_period: 'week'
     }
+    {{- end }}{{- /* .Values.cron.enabled.restriction */}}
+
+    {{- if .Values.cron.enabled.restrictionImport }}
+    import_restriction:
+    {
+        remote_name: '',
+        remote_dir: '',
+
+        local_name: '%current-date%_%hour%.json',
+        local_dir: 'restrictions_json/%project%'
+
+        unpack: 'tar',
+        meta: '%project%.json'
+        content: '%project%-restriction.json',
+        item: 'restriction',
+        store_period: 'week'
+    }
+    {{- end }}{{- /* .Values.cron.enabled.restrictionImport */}}
+
+    {{- if .Values.cron.enabled.import }}
+    import_package:
+    {
+        remote_name: '',
+        remote_dir: '',
+        local_name: '%issue-month%_%timestamp%.2gis',
+        local_dir: 'packages/%project%',
+
+        unpack: 'tar',
+        meta: '%project%.json',
+        content: '%project%.2gis',
+        item: 'package',
+        store_period: 'month'
+    }
+    {{- end }}{{- /* .Values.cron.enabled.import */}}
 
   cities_template: |-
     [
@@ -109,7 +132,7 @@ data:
     ]
 
   update_services: |
-    {{- range $_, $flavor := tuple "import" "restriction" }}
+    {{- range $_, $flavor := tuple "import" "restriction" "restrictionImport" }}
     {{- if index $.Values.cron.enabled $flavor }}
     {{ index $.Values.cron.schedule $flavor }} /opt/configuration_builder --config /opt/config_builder.conf --service={{ $flavor }} --jobs={{ $.Values.castle.jobs | default 1 | int }}
     {{- end }}

--- a/charts/navi-castle/templates/configmapbuilder.yaml
+++ b/charts/navi-castle/templates/configmapbuilder.yaml
@@ -12,8 +12,6 @@ data:
     log_level: 'DEBUG'
     log_location:'/var/log/castle-%service%.log'
     # PATHS AND FILE PROPERTIES
-    # owner for result files
-    owner: 'root:root'
     # path to store city data
     data_destination_dir: {{ .Values.castle.castleDataPath | quote }}
     # --------------------------------------------

--- a/charts/navi-castle/templates/configmapbuilder.yaml
+++ b/charts/navi-castle/templates/configmapbuilder.yaml
@@ -132,6 +132,6 @@ data:
   update_services: |
     {{- range $_, $flavor := tuple "import" "restriction" "restrictionImport" }}
     {{- if index $.Values.cron.enabled $flavor }}
-    {{ index $.Values.cron.schedule $flavor }} /opt/configuration_builder --config /opt/config_builder.conf --service={{ $flavor }} --jobs={{ $.Values.castle.jobs | default 1 | int }}
+    {{ index $.Values.cron.schedule $flavor }} /opt/configuration_builder --config /opt/config_builder.conf --service={{ include "castle.serviceParameter" ( dict "flavor" $flavor ) }} --jobs={{ $.Values.castle.jobs | default 1 | int }}
     {{- end }}
     {{- end }}

--- a/charts/navi-castle/templates/configmapnginx.yaml
+++ b/charts/navi-castle/templates/configmapnginx.yaml
@@ -13,6 +13,13 @@ data:
             autoindex on;
         }
 
+        location /spartacus {
+            expires epoch;
+            alias  {{ .Values.castle.castleDataPath }}/backup;
+            autoindex on;
+            autoindex_format json;
+        }
+
         location /healthcheck {
           return 200 "Ok!";
         }

--- a/charts/navi-castle/templates/cronjob.yaml
+++ b/charts/navi-castle/templates/cronjob.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.persistentVolume.enabled }}
 {{- range $i, $e := until ( .Values.replicaCount | int ) }}
-{{- range $_, $flavor := tuple "import" "restriction" }}
+{{- range $_, $flavor := tuple "import" "restriction" "restrictionImport" }}
 {{- if index $.Values.cron.enabled $flavor }}
 ---
 apiVersion: batch/v1
@@ -46,8 +46,7 @@ spec:
               args:
               - --config
               - /opt/config_builder.conf
-              - --service={{ $flavor }}
-              - --jobs={{ $.Values.castle.jobs | default 1 | int }}
+              - --service={{ include "castle.serviceParameter" ( dict "flavor" $flavor ) | quote }}
               volumeMounts:
               - name: {{ include "castle.fullname" $ }}-builder-config
                 mountPath: /opt/config_builder.conf

--- a/charts/navi-castle/templates/cronjob.yaml
+++ b/charts/navi-castle/templates/cronjob.yaml
@@ -6,7 +6,7 @@
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: {{ include "castle.fullname" $ }}-cronjob-{{ $flavor }}-{{ $i }}
+  name: {{ include "castle.fullname" $ }}-cronjob-{{ $flavor | kebabcase }}-{{ $i }}
   labels:
     {{- include "castle.labels" $ | nindent 4 }}
 spec:

--- a/charts/navi-castle/templates/cronjob.yaml
+++ b/charts/navi-castle/templates/cronjob.yaml
@@ -46,7 +46,7 @@ spec:
               args:
               - --config
               - /opt/config_builder.conf
-              - --service={{ include "castle.serviceParameter" ( dict "flavor" $flavor ) | toYaml }}
+              - --service={{ include "castle.serviceParameter" ( dict "flavor" $flavor ) }}
               volumeMounts:
               - name: {{ include "castle.fullname" $ }}-builder-config
                 mountPath: /opt/config_builder.conf

--- a/charts/navi-castle/templates/cronjob.yaml
+++ b/charts/navi-castle/templates/cronjob.yaml
@@ -47,6 +47,7 @@ spec:
               - --config
               - /opt/config_builder.conf
               - --service={{ include "castle.serviceParameter" ( dict "flavor" $flavor ) }}
+              - --jobs={{ $.Values.castle.jobs | default 1 | int }}
               volumeMounts:
               - name: {{ include "castle.fullname" $ }}-builder-config
                 mountPath: /opt/config_builder.conf

--- a/charts/navi-castle/templates/cronjob.yaml
+++ b/charts/navi-castle/templates/cronjob.yaml
@@ -46,7 +46,7 @@ spec:
               args:
               - --config
               - /opt/config_builder.conf
-              - --service={{ include "castle.serviceParameter" ( dict "flavor" $flavor ) | quote }}
+              - --service={{ include "castle.serviceParameter" ( dict "flavor" $flavor ) | toYaml }}
               volumeMounts:
               - name: {{ include "castle.fullname" $ }}-builder-config
                 mountPath: /opt/config_builder.conf

--- a/charts/navi-castle/templates/ingress.yaml
+++ b/charts/navi-castle/templates/ingress.yaml
@@ -1,8 +1,18 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "castle.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-
+{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -13,7 +23,9 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
   ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
   {{- if .Values.ingress.tls }}
   tls:
     {{- range .Values.ingress.tls }}
@@ -31,12 +43,19 @@ spec:
         paths:
           {{- range .paths }}
           - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
             pathType: {{ .pathType }}
+            {{- end }}
             backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
               service:
                 name: {{ $fullName }}
                 port:
                   number: {{ $svcPort }}
+              {{- else }}
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+              {{- end }}
           {{- end }}
     {{- end }}
 {{- end }}

--- a/charts/navi-castle/templates/statefulset.yaml
+++ b/charts/navi-castle/templates/statefulset.yaml
@@ -54,7 +54,7 @@ spec:
           args: 
            - --config 
            - /opt/config_builder.conf 
-           - --service={{ include "castle.serviceParameter" ( dict "flavor" $flavor ) | quote }}
+           - --service={{ include "castle.serviceParameter" ( dict "flavor" $flavor ) | toYaml }}
           volumeMounts:
           - name: {{ include "castle.fullname" $ }}-builder-config
             mountPath: /opt/config_builder.conf

--- a/charts/navi-castle/templates/statefulset.yaml
+++ b/charts/navi-castle/templates/statefulset.yaml
@@ -51,10 +51,11 @@ spec:
         - name: castle-{{ $flavor | kebabcase }}-init
           image: {{ required "A valid $.Values.dgctlDockerRegistry entry required" $.Values.dgctlDockerRegistry }}/{{ $.Values.castle.image.repository }}:{{ $.Values.castle.image.tag }}
           command: [ "/opt/configuration_builder" ]
-          args: 
-           - --config 
-           - /opt/config_builder.conf 
+          args:
+           - --config
+           - /opt/config_builder.conf
            - --service={{ include "castle.serviceParameter" ( dict "flavor" $flavor ) }}
+           - --jobs={{ $.Values.castle.jobs | default 1 | int }}
           volumeMounts:
           - name: {{ include "castle.fullname" $ }}-builder-config
             mountPath: /opt/config_builder.conf

--- a/charts/navi-castle/templates/statefulset.yaml
+++ b/charts/navi-castle/templates/statefulset.yaml
@@ -46,16 +46,15 @@ spec:
         {{- end }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       initContainers:
-        {{- range $flavor, $init_enabled := dict "import" true "restriction" .Values.cron.enabled.restriction }}
-        {{- if $init_enabled }}
+        {{- range $_, $flavor := tuple "import" "restriction" "restrictionImport" }}
+        {{- if index $.Values.cron.enabled $flavor }}
         - name: castle-{{ $flavor }}-init
           image: {{ required "A valid $.Values.dgctlDockerRegistry entry required" $.Values.dgctlDockerRegistry }}/{{ $.Values.castle.image.repository }}:{{ $.Values.castle.image.tag }}
           command: [ "/opt/configuration_builder" ]
-          args:
-           - --config
-           - /opt/config_builder.conf
-           - --service={{ $flavor }}
-           - --jobs={{ $.Values.castle.jobs | default 1 | int }}
+          args: 
+           - --config 
+           - /opt/config_builder.conf 
+           - --service={{ include "castle.serviceParameter" ( dict "flavor" $flavor ) | quote }}
           volumeMounts:
           - name: {{ include "castle.fullname" $ }}-builder-config
             mountPath: /opt/config_builder.conf
@@ -72,8 +71,8 @@ spec:
           {{- end }}
           resources:
             {{- toYaml $.Values.resources | nindent 12 }}
-        {{- end }} # if
-        {{- end }} # range
+        {{- end }}{{- /* if index $.Values.cron.enabled $flavor */}}
+        {{- end }}{{- /* range $_, $flavor */}}
       containers:
         - name: castle-nginx
           image: {{ required "A valid .Values.dgctlDockerRegistry entry required" .Values.dgctlDockerRegistry }}/{{ .Values.nginx.image.repository }}:{{ .Values.nginx.image.tag }}

--- a/charts/navi-castle/templates/statefulset.yaml
+++ b/charts/navi-castle/templates/statefulset.yaml
@@ -54,7 +54,7 @@ spec:
           args: 
            - --config 
            - /opt/config_builder.conf 
-           - --service={{ include "castle.serviceParameter" ( dict "flavor" $flavor ) | toYaml }}
+           - --service={{ include "castle.serviceParameter" ( dict "flavor" $flavor ) }}
           volumeMounts:
           - name: {{ include "castle.fullname" $ }}-builder-config
             mountPath: /opt/config_builder.conf

--- a/charts/navi-castle/templates/statefulset.yaml
+++ b/charts/navi-castle/templates/statefulset.yaml
@@ -48,7 +48,7 @@ spec:
       initContainers:
         {{- range $_, $flavor := tuple "import" "restriction" "restrictionImport" }}
         {{- if index $.Values.cron.enabled $flavor }}
-        - name: castle-{{ $flavor }}-init
+        - name: castle-{{ $flavor | kebabcase }}-init
           image: {{ required "A valid $.Values.dgctlDockerRegistry entry required" $.Values.dgctlDockerRegistry }}/{{ $.Values.castle.image.repository }}:{{ $.Values.castle.image.tag }}
           command: [ "/opt/configuration_builder" ]
           args: 

--- a/charts/navi-castle/values.yaml
+++ b/charts/navi-castle/values.yaml
@@ -42,6 +42,7 @@ dgctlStorage:
 # @param nodeSelector Kubernetes [node selectors](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector).
 # @param tolerations Kubernetes [tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) settings.
 # @param affinity Kubernetes pod [affinity settings](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity).
+# @param terminationGracePeriodSeconds Maximum time allowed for graceful shutdown.
 
 replicaCount: 1
 imagePullSecrets: []
@@ -53,6 +54,7 @@ securityContext: {}
 nodeSelector: {}
 tolerations: []
 affinity: {}
+terminationGracePeriodSeconds: 60
 
 
 # @section Service account settings
@@ -99,7 +101,6 @@ ingress:
   #    navi-castle.example.com
   #  secretName: secret.tls
 
-
 # @section Limits
 
 # @param resources [nullable] Container resources requirements structure.
@@ -114,6 +115,7 @@ resources: {}
 # @section Navi-Castle service settings
 
 # @param castle.castleDataPath Path to the data directory.
+# @extra castle.restrictions Section ignored if castle.restriction.enabled=false
 # @param castle.restrictions.host Restrictions API base URL.
 # @param castle.restrictions.key Restrictions API key.
 # @param castle.jobs Number of parallel downloading jobs.
@@ -144,9 +146,11 @@ nginx:
 # @section Cron settings
 
 # @param cron.enabled.import If the `import` cron job is enabled.
-# @param cron.enabled.restriction If the `restriction` cron job is enabled.
+# @param cron.enabled.restriction If restrictions API enabled, incompatible with `restrictionImport`.
+# @param cron.enabled.restrictionImport If restrictions import enabled, incompatible with `restriction`.
 # @param cron.schedule.import Cron job schedule for `import`.
 # @param cron.schedule.restriction Cron job schedule for `restriction`.
+# @param cron.schedule.restrictionImport Cron job schedule for `restrictionImport`.
 # @param cron.concurrencyPolicy Cron job concurrency policy: `Allow` or `Forbid`.
 # @param cron.successfulJobsHistoryLimit How many completed and failed jobs should be kept.
 
@@ -154,9 +158,11 @@ cron:
   enabled:
     import: false
     restriction: false
+    restrictionImport: false
   schedule:
     import: 11 * * * *
     restriction: '*/5 * * * *'
+    restrictionImport: '*/5 * * * *'
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 3
 


### PR DESCRIPTION
- do not try changing imported files (it did not work in fact)
- new import `import_restriction` available under `restrictions_json/`
- new job `restrictionImport` for the same
- new location `/spartacus` aliasing to `/backup` but in JSON for future integrations
- standard API compatibility boilerplate for ingress resource
- support for `terminationGracePeriodSeconds` documented