### PR TITLE
API keys moved to secrets

### DIFF
--- a/Breaking-Changes.md
+++ b/Breaking-Changes.md
@@ -1,5 +1,9 @@
 # 2GIS On-Premise Breaking-Changes
 
+### navi-router
+
+- `router.keyManagementService.apis.*` tokens renamed, `-api` suffix added
+
 ## [1.13.0]
 
 ### tiles-api

--- a/charts/navi-router/Chart.yaml
+++ b/charts/navi-router/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
 - navi
 - router
 version: 1.14.0
-appVersion: 6.16.0
+appVersion: 6.17.0.2
 maintainers:
 - name: 2gis
   url: https://github.com/2gis

--- a/charts/navi-router/README.md
+++ b/charts/navi-router/README.md
@@ -64,7 +64,8 @@ See the [documentation](https://docs.2gis.com/en/on-premise/navigation) to learn
 | `router.keyManagementService.host`               | Address if key management service server                                                                                                     | `http://keys.api.example.com` |
 | `router.keyManagementService.refreshIntervalSec` | Keys refresh interval in seconds                                                                                                             | `30`                          |
 | `router.keyManagementService.downloadTimeoutSec` | Keys download timeout in seconds                                                                                                             | `30`                          |
-| `router.keyManagementService.apis`               | Used API types and their tokens. Format: `type: token`                                                                                       | `nil`                         |
+| `router.keyManagementService.commonToken`        | Mater key to retrieve all per-service API keys, router.keyManagementService.apis ignored, if commonToken set                                 | `""`                          |
+| `router.keyManagementService.apis`               | Used API types and their tokens. Format: `type: token`                                                                                       | `undefined`                   |
 
 
 ### Service account settings
@@ -116,6 +117,7 @@ See the [documentation](https://docs.2gis.com/en/on-premise/navigation) to learn
 | `resources.requests.memory` | Memory request, recommended value `384Mi`.  | `undefined` |
 | `resources.limits.cpu`      | CPU limit, recommended value `1000m`.       | `undefined` |
 | `resources.limits.memory`   | Memory limit, recommended value `768Mi`.    | `undefined` |
+
 
 ### Kubernetes [Horizontal Pod Autoscaling](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/) settings
 

--- a/charts/navi-router/templates/configmap.yaml
+++ b/charts/navi-router/templates/configmap.yaml
@@ -57,6 +57,13 @@ data:
         },
         "server_info": {
           "server_id": "{{ include "router.fullname" . }}"
+        },
+        "local_restrictions_for_keys": {
+            "distance_between_points_km": [
+                {"type" : "directions-api", "value" : 50},
+                {"type" : "distance-matrix-api", "value" : 50},
+                {"type" : "pairs-directions-api", "value" : 50}
+            ]
         }
         {{- with .Values.router.keyManagementService }}
         {{- if .enabled }}
@@ -65,19 +72,7 @@ data:
         {
           "service_remote_address" : {{ .host | quote }},
           "keys_refresh_interval_sec" : {{ .refreshIntervalSec | int }},
-          "keys_download_timeout_sec" : {{ .downloadTimeoutSec | int }},
-          "service_apis" :
-          [
-              {{- $first := true }}
-              {{- range $type, $token := .apis }}
-              {{- if $first }}
-                  {{- $first = false }}
-              {{- else }}
-                  {{- print "," }}
-              {{- end }}
-              {"type" : {{ $type | quote }}, "token" : {{ $token | quote }} }
-              {{- end }}
-          ]
+          "keys_download_timeout_sec" : {{ .downloadTimeoutSec | int }}
         }
         {{- end }}
         {{- end }}

--- a/charts/navi-router/templates/deployment.yaml
+++ b/charts/navi-router/templates/deployment.yaml
@@ -20,6 +20,7 @@ spec:
     metadata:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
       {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -72,6 +73,23 @@ spec:
             failureThreshold: 3
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          env:
+            {{- range $type, $token := (.Values.router.keyManagementService).apis }}
+            {{- if $token }}
+            - name: {{ $type | replace "-" "_" | upper | quote }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "router.fullname" $ | quote }}
+                  key: {{ $type | quote }}
+            {{- end }}{{- /* if $token */}}
+            {{- end }}{{- /* range $type, $token */}}
+            {{- if (.Values.router.keyManagementService).commonToken }}
+            - name: COMMON_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "router.fullname" . | quote }}
+                  key: common_token
+            {{- end }}
       terminationGracePeriodSeconds: {{ .Values.termination_grace_period_seconds | default 60 }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/charts/navi-router/templates/ingress.yaml
+++ b/charts/navi-router/templates/ingress.yaml
@@ -1,7 +1,18 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "router.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
+{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -12,7 +23,9 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
   ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
   {{- if .Values.ingress.tls }}
   tls:
     {{- range .Values.ingress.tls }}
@@ -30,12 +43,19 @@ spec:
         paths:
           {{- range .paths }}
           - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
             pathType: {{ .pathType }}
+            {{- end }}
             backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
               service:
                 name: {{ $fullName }}
                 port:
                   number: {{ $svcPort }}
+              {{- else }}
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+              {{- end }}
           {{- end }}
     {{- end }}
 {{- end }}

--- a/charts/navi-router/templates/secret.yaml
+++ b/charts/navi-router/templates/secret.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "router.fullname" . | quote }}
+  labels:
+    {{- include "router.labels" . | nindent 4 }}
+    {{- if .Values.labels }}
+    {{- toYaml .Values.labels | nindent 4 }}
+    {{- end }}
+type: Opaque
+data:
+  {{- range $type, $token := (.Values.router.keyManagementService).apis }}
+  {{ $type | quote }}: {{ $token | b64enc | quote }}
+  {{- end }}
+  common_token: {{ (.Values.router.keyManagementService).commonToken | default "" | b64enc | quote }}

--- a/charts/navi-router/values.yaml
+++ b/charts/navi-router/values.yaml
@@ -39,7 +39,7 @@ affinity: {}
 image:
   repository: 2gis-on-premise/navi-router
   pullPolicy: IfNotPresent
-  tag: 6.16.0
+  tag: 6.17.0.2
 
 
 # @section Navi-Router service settings
@@ -52,7 +52,8 @@ image:
 # @param router.keyManagementService.host Address if key management service server
 # @param router.keyManagementService.refreshIntervalSec Keys refresh interval in seconds
 # @param router.keyManagementService.downloadTimeoutSec Keys download timeout in seconds
-# @param router.keyManagementService.apis Used API types and their tokens. Format: `type: token`
+# @param router.keyManagementService.commonToken Mater key to retrieve all per-service API keys, router.keyManagementService.apis ignored, if commonToken set
+# @param router.keyManagementService.apis [nullable] Used API types and their tokens. Format: `type: token`
 
 router:
   appPort: 8080
@@ -64,17 +65,19 @@ router:
     host: http://keys.api.example.com
     refreshIntervalSec: 30
     downloadTimeoutSec: 30
+    commonToken: ''
     apis:
-      # directions: "DIRECTIONS_TOKEN"
-      # distance-matrix: "DISTANCE_MATRIX_TOKEN"
-      # pairs-directions: "PAIRS_DIRECTIONS_TOKEN"
-      # truck-directions: "TRUCK_DIRECTIONS_TOKEN"
-      # public-transport: "PUBLIC_TRANSPORT_TOKEN"
-      # isochrone: "ISOCHRONE_TOKEN"
-      # map-matching : "MAP_MATCHING_TOKEN"
-      # ppnot: "PPNOT_TOKEN"
-      # combo-routes: "COMBO_ROUTES_TOKEN"
-      # free-roam: "FREE_ROAM_TOKEN"
+      comboroutes-api: ''
+      directions-api: ''
+      distance-matrix-api: ''
+      freeroam-api: ''
+      isochrone-api: ''
+      map-matching-api: ''
+      pairs-directions-api: ''
+      ppnot-api: ''
+      public-transport-api: ''
+      truck-directions-api: ''
+      truck-distance-matrix-api: ''
 
 
 # @section Service account settings


### PR DESCRIPTION
API keys are moved out of config to secrets

commonToken can be used as a master token to retrieve all per-service keys from the key service

`router.keyManagementService.apis.*` keys renamed, `-api` suffix added