### PR TITLE
Get rid of init containers

### DIFF
--- a/charts/navi-castle/README.md
+++ b/charts/navi-castle/README.md
@@ -104,6 +104,7 @@ See the [documentation](https://docs.2gis.com/en/on-premise/navigation) to learn
 | `resources.limits.cpu`      | CPU limit, recommended value `1000m`.       | `undefined` |
 | `resources.limits.memory`   | Memory limit, recommended value `512Mi`.    | `undefined` |
 
+
 ### Navi-Castle service settings
 
 | Name                       | Description                          | Value                          |
@@ -131,6 +132,7 @@ See the [documentation](https://docs.2gis.com/en/on-premise/navigation) to learn
 | `cron.schedule.restriction`       | Cron job schedule for `restriction`.               | `*/5 * * * *` |
 | `cron.concurrencyPolicy`          | Cron job concurrency policy: `Allow` or `Forbid`.  | `Forbid`      |
 | `cron.successfulJobsHistoryLimit` | How many completed and failed jobs should be kept. | `3`           |
+| `cron.prometheusPort`             | Container port for supercronic prometheus          | `9476`        |
 
 
 ### Kubernetes [Persistence Volumes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) settings

--- a/charts/navi-castle/templates/statefulset.yaml
+++ b/charts/navi-castle/templates/statefulset.yaml
@@ -23,6 +23,7 @@ spec:
     metadata:
       annotations:
         checksum/configbuilder: {{ include (print $.Template.BasePath "/configmapbuilder.yaml") . | sha256sum }}
+        checksum/configbuilder-runnable: {{ include (print $.Template.BasePath "/configmapbuilder-runnable.yaml") . | sha256sum }}
         checksum/confignginx: {{ include (print $.Template.BasePath "/configmapnginx.yaml") . | sha256sum }}
       {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
@@ -37,6 +38,10 @@ spec:
         - name: {{ include "castle.fullname" . }}-builder-config
           configMap:
             name: {{ include "castle.fullname" . }}-builder-config
+        - name: {{ include "castle.fullname" . }}-runnable
+          configMap:
+            name: {{ include "castle.fullname" . }}-runnable
+            defaultMode: 0775
         - name: {{ include "castle.fullname" . }}-castle-nginx-config
           configMap:
             name: {{ include "castle.fullname" . }}-castle-nginx-config
@@ -45,35 +50,6 @@ spec:
           emptyDir: {}
         {{- end }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
-      initContainers:
-        {{- range $flavor, $init_enabled := dict "import" true "restriction" .Values.cron.enabled.restriction }}
-        {{- if $init_enabled }}
-        - name: castle-{{ $flavor }}-init
-          image: {{ required "A valid $.Values.dgctlDockerRegistry entry required" $.Values.dgctlDockerRegistry }}/{{ $.Values.castle.image.repository }}:{{ $.Values.castle.image.tag }}
-          command: [ "/opt/configuration_builder" ]
-          args:
-           - --config
-           - /opt/config_builder.conf
-           - --service={{ $flavor }}
-           - --jobs={{ $.Values.castle.jobs | default 1 | int }}
-          volumeMounts:
-          - name: {{ include "castle.fullname" $ }}-builder-config
-            mountPath: /opt/config_builder.conf
-            subPath: config_builder.conf
-          - name: {{ include "castle.fullname" $ }}-builder-config
-            mountPath: {{ $.Values.castle.castleDataPath }}/cities_template
-            subPath: cities_template
-          {{- if $.Values.persistentVolume.enabled }}
-          - name: {{ include "castle.fullname" $ }}-pvc
-            mountPath: {{ $.Values.castle.castleDataPath }}
-          {{- else }}
-          - name: {{ include "castle.fullname" $ }}-data
-            mountPath: {{ $.Values.castle.castleDataPath }}
-          {{- end }}
-          resources:
-            {{- toYaml $.Values.resources | nindent 12 }}
-        {{- end }} # if
-        {{- end }} # range
       containers:
         - name: castle-nginx
           image: {{ required "A valid .Values.dgctlDockerRegistry entry required" .Values.dgctlDockerRegistry }}/{{ .Values.nginx.image.repository }}:{{ .Values.nginx.image.tag }}
@@ -102,33 +78,31 @@ spec:
             periodSeconds: 5
             timeoutSeconds: 3
             failureThreshold: 2
-        # If Persistent volume is not enabled then cron jobs will be running as sidecar containers
-        {{- if (not .Values.persistentVolume.enabled) }}
         - name: castle-cron
-          image: "{{ required "A valid $.Values.dgctlDockerRegistry entry required" $.Values.dgctlDockerRegistry }}/{{ $.Values.castle.image.repository }}:{{ $.Values.castle.image.tag }}"
+          image: {{ required "A valid $.Values.dgctlDockerRegistry entry required" $.Values.dgctlDockerRegistry }}/{{ $.Values.castle.image.repository }}:{{ $.Values.castle.image.tag }}
           command: ["/tini","--"]
           args:
-          - /usr/local/bin/supercronic
-          - -json
-          - -prometheus-listen-address
-          - '0.0.0.0:9476'
-          - /opt/update_services
+          - /opt/update_services_init.sh
           resources:
             {{- toYaml $.Values.resources | nindent 12 }}
           livenessProbe:
+            {{- /* checks if supercronic prometheus port is open */}}
             httpGet:
               path: /health
-              port: 9476
+              port: {{ .Values.cron.prometheusPort | int }}
             initialDelaySeconds: 10
             periodSeconds: 10
           ports:
             - name: cron-prom
-              containerPort: 9476
+              containerPort: {{ .Values.cron.prometheusPort | int }}
               protocol: TCP
           volumeMounts:
           - name: {{ include "castle.fullname" $ }}-builder-config
             mountPath: /opt/config_builder.conf
             subPath: config_builder.conf
+          - name: {{ include "castle.fullname" $ }}-runnable
+            mountPath: /opt/update_services_init.sh
+            subPath: update_services_init.sh
           - name: {{ include "castle.fullname" $ }}-builder-config
             mountPath: {{ $.Values.castle.castleDataPath }}/cities_template
             subPath: cities_template
@@ -137,7 +111,6 @@ spec:
             subPath: update_services
           - name: {{ include "castle.fullname" $ }}-data
             mountPath: {{ $.Values.castle.castleDataPath }}
-        {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/charts/navi-castle/values.yaml
+++ b/charts/navi-castle/values.yaml
@@ -149,6 +149,7 @@ nginx:
 # @param cron.schedule.restriction Cron job schedule for `restriction`.
 # @param cron.concurrencyPolicy Cron job concurrency policy: `Allow` or `Forbid`.
 # @param cron.successfulJobsHistoryLimit How many completed and failed jobs should be kept.
+# @param cron.prometheusPort Container port for supercronic prometheus
 
 cron:
   enabled:
@@ -159,6 +160,7 @@ cron:
     restriction: '*/5 * * * *'
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 3
+  prometheusPort: 9476
 
 
 # @section Kubernetes [Persistence Volumes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) settings


### PR DESCRIPTION
initial import of data moved to regular container

init containers are avoided for sidecars are required to work correctly