### PR TITLE
mfront fix name configmap-extra

### DIFF
--- a/charts/navi-front/templates/configmap-extra.yaml
+++ b/charts/navi-front/templates/configmap-extra.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "front.fullname" . }}-extra-config
+  name: {{ include "front.fullname" . }}-extra
 data:
 {{- if .Values.serverBlock }}
   server-block.conf: |-


### PR DESCRIPTION
Fix name for configmap extra. Need for locationsBlock value location: pedestrian MSDK