### PR TITLE
[PRO-4107] update pro API to version 1.1.66

### DIFF
--- a/charts/navi-front/templates/configmap-extra.yaml
+++ b/charts/navi-front/templates/configmap-extra.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "front.fullname" . }}-extra-config
+  name: {{ include "front.fullname" . }}-extra
 data:
 {{- if .Values.serverBlock }}
   server-block.conf: |-

--- a/charts/pro-api/templates/asset-import-starter.yaml
+++ b/charts/pro-api/templates/asset-import-starter.yaml
@@ -43,6 +43,8 @@ spec:
               value: "{{ .Values.dgctlStorage.manifest }}"
             - name: S3Settings__Url
               value: {{ required "A valid .Values.dgctlStorage.host entry required" $.Values.dgctlStorage.host }}
+            - name: S3Settings__Secure
+              value: "{{ .Values.dgctlStorage.secure }}"
             - name: S3Settings__DgctlStorageBucket
               value: {{ required "A valid .Values.dgctlStorage.bucket entry required" $.Values.dgctlStorage.bucket }}
             - name: S3Settings__AssetDataBucket

--- a/charts/pro-api/templates/asset-importer.yaml
+++ b/charts/pro-api/templates/asset-importer.yaml
@@ -7,6 +7,7 @@ spec:
   concurrencyPolicy: Forbid
   schedule: "{{ .Values.assetImporter.schedule }}"
   successfulJobsHistoryLimit: {{ .Values.assetImporter.successfulJobsHistoryLimit }}
+  suspend: {{ .Values.assetImporter.suspended }}
   jobTemplate:
     spec:
       backoffLimit: {{ .Values.assetImporter.backoffLimit }}
@@ -45,6 +46,8 @@ spec:
                   value: "{{ .Values.dgctlStorage.manifest }}"
                 - name: S3Settings__Url
                   value: {{ required "A valid .Values.dgctlStorage.host entry required" $.Values.dgctlStorage.host }}
+                - name: S3Settings__Secure
+                  value: "{{ .Values.dgctlStorage.secure }}"
                 - name: S3Settings__DgctlStorageBucket
                   value: {{ required "A valid .Values.dgctlStorage.bucket entry required" $.Values.dgctlStorage.bucket }}
                 - name: S3Settings__AssetDataBucket
@@ -102,6 +105,15 @@ spec:
                   value: "{{ .Values.api.logging.targets }}"
                 - name: Common__EsMetricsEnabled
                   value: "{{ .Values.assetImporter.esMetricsEnabled }}"
+                - name: Digger__Address
+                  value: "{{ .Values.digger.url}}"
+                - name: Digger__UserName
+                  value: "{{ .Values.digger.userName}}"
+                - name: Digger__Password
+                  valueFrom:
+                    secretKeyRef:
+                      key: diggerPassword
+                      name: {{ include "pro-api.name" . }}-secret
                 - name: Navi__Url
                   value: {{ .Values.navi.url }}
                 - name: Navi__Key

--- a/charts/pro-api/templates/asset-preparer.yaml
+++ b/charts/pro-api/templates/asset-preparer.yaml
@@ -42,6 +42,8 @@ spec:
                   value: "{{ .Values.assetPreparer.maxParallelJobs }}"
                 - name: S3Settings__Url
                   value: {{ required "A valid .Values.dgctlStorage.host entry required" $.Values.dgctlStorage.host }}
+                - name: S3Settings__Secure
+                  value: "{{ .Values.dgctlStorage.secure }}"
                 - name: S3Settings__AssetDataBucket
                   value: {{ required "A valid .Values.s3.assetsDataBucket entry required" $.Values.s3.assetsDataBucket }}
                 - name: S3Settings__UserAssetDataBucket
@@ -86,8 +88,10 @@ spec:
                   value: "{{ .Values.api.logging.format }}"
                 - name: Common__Logging__Targets
                   value: "{{ .Values.api.logging.targets }}"
+                - name: Digger__Address
+                  value: "{{ .Values.digger.url}}"
                 - name: Digger__UserName
-                  value: "{{ .Values.api.diggerUserName}}"
+                  value: "{{ .Values.digger.userName}}"
                 - name: Digger__Password
                   valueFrom:
                     secretKeyRef:

--- a/charts/pro-api/templates/deployment.yaml
+++ b/charts/pro-api/templates/deployment.yaml
@@ -168,6 +168,8 @@ spec:
                   name: {{ include "pro-api.name" . }}-secret
             - name: S3Settings__Url
               value: {{ required "A valid .Values.dgctlStorage.host entry required" $.Values.dgctlStorage.host }}
+            - name: S3Settings__Secure
+              value: "{{ .Values.dgctlStorage.secure }}"
             - name: S3Settings__AssetDataBucket
               value: {{ required "A valid .Values.s3.assetsDataBucket entry required" $.Values.s3.assetsDataBucket }}
             - name: S3Settings__UserAssetDataBucket
@@ -277,3 +279,8 @@ spec:
               value: "{{ .Values.api.rateLimiter.requestsLimit }}"
             - name: RateLimiter__WindowSizeInSeconds
               value: "{{ .Values.api.rateLimiter.windowSizeInSeconds }}"
+            - name: LocalCache__Enabled
+              value: "{{ .Values.api.localCache.enabled }}"
+            - name: LocalCache__TrackStatistics
+              value: "{{ .Values.api.localCache.trackStatistics }}"
+              

--- a/charts/pro-api/templates/permissions-api-deployment.yaml
+++ b/charts/pro-api/templates/permissions-api-deployment.yaml
@@ -181,5 +181,8 @@ spec:
               value: "{{ $.Values.kafka.permissionsTopic.name }}"
             - name: Kafka__PermissionsTopicSettings__ReaderGroupId
               value: "{{ $.Values.kafka.permissionsTopic.readerGroupId }}"
-
+            - name: LocalCache__Enabled
+              value: "{{ .Values.permissionsApi.localCache.enabled }}"
+            - name: LocalCache__TrackStatistics
+              value: "{{ .Values.permissionsApi.localCache.trackStatistics }}"
 {{- end }}

--- a/charts/pro-api/templates/secrets.yaml
+++ b/charts/pro-api/templates/secrets.yaml
@@ -9,8 +9,8 @@ data:
   dbConnectionPwd: {{ required "Valid .Values.postgres.password required!" .Values.postgres.password | b64enc }}
   s3AccessKey: {{ required "Valid .Values.dgctlStorage.accessKey required!" .Values.dgctlStorage.accessKey | b64enc }}
   s3SecretKey: {{ required "Valid .Values.dgctlStorage.secretKey required!" .Values.dgctlStorage.secretKey | b64enc }}
-  {{ if .Values.api.diggerPassword }}
-  diggerPassword: {{ .Values.api.diggerPassword | b64enc }}
+  {{ if .Values.digger.password }}
+  diggerPassword: {{ .Values.digger.password | b64enc }}
   {{ end }}
   {{ if .Values.auth.permissionsApiKey }}
   permissionsApiKey: {{ required "Valid .Values.auth.permissionsApiKey required!" .Values.auth.permissionsApiKey | b64enc }}

--- a/charts/pro-api/templates/user-asset-importer.yaml
+++ b/charts/pro-api/templates/user-asset-importer.yaml
@@ -45,7 +45,9 @@ spec:
                 - name: MAX_PARALLEL_JOBS
                   value: "{{ .Values.assetImporter.maxParallelJobs }}"
                 - name: S3Settings__Url
-                  value: "{{ .Values.dgctlStorage.host }}"
+                  value: {{ required "A valid .Values.dgctlStorage.host entry required" $.Values.dgctlStorage.host }}
+                - name: S3Settings__Secure
+                  value: "{{ .Values.dgctlStorage.secure }}"
                 - name: S3Settings__AssetDataBucket
                   value: {{ required "A valid .Values.s3.assetsDataBucket entry required" $.Values.s3.assetsDataBucket }}
                 - name: S3Settings__UserAssetDataBucket

--- a/charts/pro-api/values.yaml
+++ b/charts/pro-api/values.yaml
@@ -1,4 +1,4 @@
-# @section Docker Registry settings
+﻿# @section Docker Registry settings
 
 # @param dgctlDockerRegistry Docker Registry endpoint where On-Premise services' images reside. Format: `host:port`.
 
@@ -41,6 +41,7 @@ revisionHistoryLimit: 3
 # @section Deployment Artifacts Storage settings
 
 # @param dgctlStorage.host S3 endpoint. Format: `host:port`. **Required**
+# @param dgctlStorage.secure Set to `true` if dgctlStorage.host must be accessed via https. **Required**
 # @param dgctlStorage.bucket S3 bucket name. **Required**
 # @param dgctlStorage.accessKey S3 access key for accessing the bucket. **Required**
 # @param dgctlStorage.secretKey S3 secret key for accessing the bucket. **Required**
@@ -48,6 +49,7 @@ revisionHistoryLimit: 3
 
 dgctlStorage:
   host: ''
+  secure: false
   bucket: ''
   accessKey: ''
   secretKey: ''
@@ -113,14 +115,14 @@ vpa:
 
 image:
   repository: 2gis-on-premise/pro-api
-  tag: 1.1.60
+  tag: 1.1.66
   pullPolicy: IfNotPresent
 
 # @skip permissionsApiImage
 
 permissionsApiImage:
   repository: 2gis-on-premise/pro-permissions-api
-  tag: 1.1.60
+  tag: 1.1.66
   pullPolicy: IfNotPresent
 
 # @section 2GIS PRO Storage configuration
@@ -148,20 +150,19 @@ s3:
 # @extra api.rateLimiter rate limiter settings
 # @param api.rateLimiter.requestsLimit max number of requests from one user during time window (0 means rate limiter is disabled)
 # @param api.rateLimiter.windowSizeInSeconds the size of time windows to count and limit incoming requests
-# @skip api.diggerPassword
-# @skip api.diggerUserName
 # @skip api.logEsQueries
 # @skip api.debug
 # @skip api.env
 # @skip api.token
 # @skip api.filterByZoneCodes
 # @skip api.esDataCentersCount
+# @extra Local cache settings
+# @skip localCache.enabled
+# @skip localCache.trackStatistics 
 
 api:
   serviceAccount: runner
   tempPath: /tmp
-  diggerPassword: ''
-  diggerUserName: ''
   allowAnyOrigin: false
   logEsQueries: false
   debug: false
@@ -175,6 +176,9 @@ api:
   rateLimiter:
     requestsLimit: 0
     windowSizeInSeconds: 1
+  localCache:
+    enabled: true
+    trackStatistics: false    
 
 # @section Auth configuration
 
@@ -196,6 +200,13 @@ auth:
   autoRegisterUsers: true
   turnOffCertValidation: false
   shareKeys: []
+
+# @skip digger
+
+digger:
+  url: ''
+  userName: ''
+  password: ''
 
 # @section PostgreSQL settings
 
@@ -349,10 +360,16 @@ permissionsPodSettings:
 # @section 2GIS PRO Permissions API configuration
 # @skip permissionsApi.host
 # @param permissionsApi.enabled If permissionsApi is enabled for the service.
+# @extra Local cache settings
+# @skip localCache.enabled
+# @skip localCache.trackStatistics 
 
 permissionsApi:
   host: ''
   enabled: false
+  localCache:
+    enabled: true
+    trackStatistics: false  
 
 # @section Import job settings
 
@@ -369,10 +386,11 @@ permissionsApi:
 # @param assetImporter.externalLinksProxyUrl URL to proxy http links from assets data (including query parameters, if any, i.e. 'https://someserver.com/proxy?url=' )
 # @skip assetImporter.files
 # @skip assetImporter.esMetricsEnabled
+# @skip assetImporter.suspended
 
 assetImporter:
   repository: 2gis-on-premise/pro-importer
-  tag: 1.1.60
+  tag: 1.1.66
   schedule: 0 18 * * *
   backoffLimit: 2
   successfulJobsHistoryLimit: 3
@@ -383,9 +401,10 @@ assetImporter:
       memory: 768M
     limits:
       cpu: 1000m
-      memory: 2560M
+      memory: 8Gi
   maxParallelJobs: 1
   enabled: true
+  suspended: false
   startOnDeploy: true
   files: ''
   imageProxyUrl: ''
@@ -400,7 +419,7 @@ userAssetImporter:
 
 assetPreparer:
   repository: 2gis-on-premise/pro-importer
-  tag: 1.1.60
+  tag: 1.1.66
   schedule: 0 16 * * 6
   backoffLimit: 2
   successfulJobsHistoryLimit: 1
@@ -450,10 +469,10 @@ ingress:
   enabled: false
   className: nginx
   hosts:
-  - host: pro-api.example.com
-    paths:
-    - path: /
-      pathType: Prefix
+    - host: pro-api.example.com
+      paths:
+        - path: /
+          pathType: Prefix
   tls: []
   # - hosts:
   #   - pro-api.example.com


### PR DESCRIPTION
**Основные изменения:**

-  Добавить поле secure для S3 в хелм-чарты (клауд и он-прем) [PRO-3400](https://jira.2gis.ru/browse/PRO-3400)
-  Добавить к ассету/файлу дату последнего изменения [PRO-3439](https://jira.2gis.ru/browse/PRO-3439)
-  Поддержка авторизации по разным АПИ ключам [PRO-3618](https://jira.2gis.ru/browse/PRO-3618)
-  Поддержать поле description у ассета [PRO-3667](https://jira.2gis.ru/browse/PRO-3667)
-  Загрузка ассета с арабскими символами [PRO-3860](https://jira.2gis.ru/browse/PRO-3860)
-  Бесконечное удаление подготовленных данных стриминговых ассетов [PRO-3896](https://jira.2gis.ru/browse/PRO-3896)
-  Доработки по библиотеке ассетов [PRO-3753](https://jira.2gis.ru/browse/PRO-3753)

**Полные изменения:**
[API](https://tsup.2gis.dev/pro/pro-api/changelog/1.1.62..1.1.66)