### PR TITLE
NAVI-CASTLE: bugfix init import data

### DIFF
--- a/charts/navi-castle/README.md
+++ b/charts/navi-castle/README.md
@@ -130,6 +130,14 @@ See the [documentation](https://docs.2gis.com/en/on-premise/navigation) to learn
 | `cron.successfulJobsHistoryLimit` | How many completed and failed jobs should be kept.                  | `3`           |
 | `cron.prometheusPort`             | Container port for supercronic prometheus                           | `9476`        |
 
+### Init settings
+
+| Name                             | Description                                                                                                                       | Value   |
+| -------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| `init.enabled.import`            | If the `import` on init is enabled. Warning: if disable data not imported. Old data will be lost if not persistentVolume.enabled. | `true`  |
+| `init.enabled.restriction`       | If restrictions API enabled, incompatible with `restrictionImport`.                                                               | `false` |
+| `init.enabled.restrictionImport` | If restrictions import enabled, incompatible with `restriction`.                                                                  | `false` |
+
 ### Kubernetes [Persistence Volumes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) settings
 
 | Name                            | Description                                                                           | Value               |

--- a/charts/navi-castle/templates/configmapbuilder-runnable.yaml
+++ b/charts/navi-castle/templates/configmapbuilder-runnable.yaml
@@ -9,7 +9,7 @@ data:
     # 2. passes control down to supercronic for the same by schedule
     set -Ceux
     {{- range $_, $flavor := tuple "import" "restriction" "restrictionImport" }}
-    {{- if index $.Values.cron.enabled $flavor }}
+    {{- if index $.Values.init.enabled $flavor }}
     /opt/configuration_builder --config /opt/config_builder.conf --service={{ include "castle.serviceParameter" ( dict "flavor" $flavor ) }} --jobs={{ $.Values.castle.jobs | default 1 | int }}
     {{- end }}
     {{- end }}

--- a/charts/navi-castle/templates/configmapbuilder.yaml
+++ b/charts/navi-castle/templates/configmapbuilder.yaml
@@ -61,7 +61,7 @@ data:
       {{- end }}{{- /* if */}}
     {{- end }}{{- /* with */}}
 
-    {{- if .Values.cron.enabled.restriction }}
+    {{- if or .Values.cron.enabled.restriction .Values.init.enabled.restriction }}
     restriction:
     {
         remote_name: '',
@@ -82,9 +82,9 @@ data:
 
         store_period: 'week'
     }
-    {{- end }}{{- /* .Values.cron.enabled.restriction */}}
+    {{- end }}{{- /* or .Values.cron.enabled.restriction .Values.init.enabled.restriction */}}
 
-    {{- if .Values.cron.enabled.restrictionImport }}
+    {{- if or .Values.cron.enabled.restrictionImport .Values.init.enabled.restrictionImport }}
     import_restriction:
     {
         remote_name: '',
@@ -99,9 +99,9 @@ data:
         item: 'restriction',
         store_period: 'week'
     }
-    {{- end }}{{- /* .Values.cron.enabled.restrictionImport */}}
+    {{- end }}{{- /* or .Values.cron.enabled.restrictionImport .Values.init.enabled.restrictionImport */}}
 
-    {{- if .Values.cron.enabled.import }}
+    {{- if or .Values.cron.enabled.import .Values.init.enabled.import }}
     import_package:
     {
         remote_name: '',
@@ -115,7 +115,7 @@ data:
         item: 'package',
         store_period: 'month'
     }
-    {{- end }}{{- /* .Values.cron.enabled.import */}}
+    {{- end }}{{- /* or .Values.cron.enabled.import .Values.init.enabled.import */}}
 
   cities_template: |-
     [

--- a/charts/navi-castle/templates/cronjob.yaml
+++ b/charts/navi-castle/templates/cronjob.yaml
@@ -59,7 +59,7 @@ spec:
                 mountPath: {{ $.Values.castle.castleDataPath }}
               resources:
                 {{- toYaml $.Values.resources | nindent 16 }}
-{{- end -}} # if
-{{- end -}} # range $flavor
-{{- end -}} # range $i, $e
-{{- end -}} # if
+{{- end -}} {{/* if */}}
+{{- end -}} {{/* range $flavor */}}
+{{- end -}} {{/* range $i, $e */}}
+{{- end -}} {{/* if */}}

--- a/charts/navi-castle/templates/statefulset.yaml
+++ b/charts/navi-castle/templates/statefulset.yaml
@@ -109,8 +109,13 @@ spec:
           - name: {{ include "castle.fullname" $ }}-builder-config
             mountPath: /opt/update_services
             subPath: update_services
-          - name: {{ include "castle.fullname" $ }}-data
-            mountPath: {{ $.Values.castle.castleDataPath }}
+          {{- if .Values.persistentVolume.enabled }}
+          - name: {{ include "castle.fullname" . }}-pvc
+            mountPath: {{ .Values.castle.castleDataPath }}
+          {{- else }}
+          - name: {{ include "castle.fullname" . }}-data
+            mountPath: {{ .Values.castle.castleDataPath }}
+          {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/charts/navi-castle/values.yaml
+++ b/charts/navi-castle/values.yaml
@@ -173,6 +173,19 @@ cron:
   prometheusPort: 9476
 
 
+# @section Init settings
+
+# @param init.enabled.import If the `import` on init is enabled. Warning: if disable data not imported. Old data will be lost if not persistentVolume.enabled.
+# @param init.enabled.restriction If restrictions API enabled, incompatible with `restrictionImport`.
+# @param init.enabled.restrictionImport If restrictions import enabled, incompatible with `restriction`.
+
+init:
+  enabled:
+    import: true
+    restriction: false
+    restrictionImport: false
+
+
 # @section Kubernetes [Persistence Volumes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) settings
 
 # @param persistentVolume.enabled If Kubernetes persistence volume should be enabled for ZooKeeper.


### PR DESCRIPTION
Ранее:

- Если выключить кроны, то не импортируем данные на старте
- Если выключен PVC и выключены кроны - получаем пустой castle при перезапуске

Теперь:

- Можно управлять что именно ипортируем при старте
- Можно импортировать данные на старте, но не включать кроны