### PR TITLE
Update citylens chart for version 1.2.0

### DIFF
--- a/charts/citylens/Chart.yaml
+++ b/charts/citylens/Chart.yaml
@@ -4,7 +4,7 @@ type: application
 description: A Helm chart for Kubernetes to deploy Citylens service
 
 version: 1.15.0
-appVersion: 1.1.2
+appVersion: 1.2.0
 
 maintainers:
 - name: 2gis

--- a/charts/citylens/templates/web/configmap.yaml
+++ b/charts/citylens/templates/web/configmap.yaml
@@ -7,7 +7,9 @@ data:
   {{- with .Values.web.auth }}
   keycloak.json: |
     {
-      "realm": {{ .realm }},
+      {{- if .realm }}
+      "realm": {{ .realm | quote }},
+      {{- end }}
       "auth-server-url": {{ required "A valid .Values.web.auth.authServerUrl entry required" .authServerUrl | quote }},
       "resource": {{ required "A valid .Values.web.auth.clientId entry required" .clientId | quote }},
       "verify-ssl": {{ .verifySsl }},
@@ -16,7 +18,7 @@ data:
       }
     }
   {{- end }}
-  {{- end }}
+    {{- end }}
   dashboard_config.yaml: |
     dashboard_domain: {{ required "A valid .Values.dashboardDomain. entry required" .Values.dashboardDomain | squote }}
     default_locale: {{ .Values.locale | squote }}

--- a/charts/citylens/templates/web/configmap.yaml
+++ b/charts/citylens/templates/web/configmap.yaml
@@ -44,9 +44,9 @@ data:
       set_public_read_acl: {{ .setPublicReadACL }}
       {{- end }}
       key_templates:
-        log: {{ required "A valid .Values.s3.logKeyTemplate entry required" .logKeyTemplate | squote }}
-        log_prefix: {{ required "A valid .Values.s3.logPrefixKeyTemplate entry required" .logPrefixKeyTemplate | squote }}
-        frame: {{ required "A valid .Values.s3.frameKeyTemplate entry required" .frameKeyTemplate | squote }}
+        log: '{track_uuid}/log_{log_timestamp_ms}'
+        log_prefix: '{track_uuid}/log_'
+        frame: '{track_uuid}/{frame_timestamp_ms}.jpg'
       client_params:
         aws_access_key_id: {{ required "A valid .Values.s3.accessKey entry required" .accessKey | squote }}
         aws_secret_access_key: {{ required "A valid .Values.s3.secretAccessKey entry required" .secretAccessKey | squote }}

--- a/charts/citylens/templates/web/configmap.yaml
+++ b/charts/citylens/templates/web/configmap.yaml
@@ -10,6 +10,9 @@ data:
       {{- if .realm }}
       "realm": {{ .realm | quote }},
       {{- end }}
+      {{- if .pkce }}
+      "pkce": {{ .pkce }},
+      {{- end }}
       "auth-server-url": {{ required "A valid .Values.web.auth.authServerUrl entry required" .authServerUrl | quote }},
       "resource": {{ required "A valid .Values.web.auth.clientId entry required" .clientId | quote }},
       "verify-ssl": {{ .verifySsl }},

--- a/charts/citylens/templates/web/configmap.yaml
+++ b/charts/citylens/templates/web/configmap.yaml
@@ -103,9 +103,9 @@ data:
       track_downloader:
         frames_topics: {{ .Values.kafka.topics.frames }}
         metadata_topics: {{ .Values.kafka.topics.tracks }}
+        frames_lifecycle_topic: {{ required "A valid .Values.kafka.topics.framesLifecycle entry required" .Values.kafka.topics.framesLifecycle | squote }}
       logs_saver:
         logs_topic: {{ .Values.kafka.topics.logs }}
-      frames_lifecycle_topic: {{ required "A valid .Values.kafka.topics.framesLifecycle entry required" .Values.kafka.topics.framesLifecycle | squote }}
       reporters:
       {{- range .Values.reporters }}
         - name: {{ .name }}

--- a/charts/citylens/templates/web/configmap.yaml
+++ b/charts/citylens/templates/web/configmap.yaml
@@ -7,7 +7,7 @@ data:
   {{- with .Values.web.auth }}
   keycloak.json: |
     {
-      "realm": {{ required "A valid .Values.web.auth.realm entry required" .realm | quote }},
+      "realm": {{ .realm }},
       "auth-server-url": {{ required "A valid .Values.web.auth.authServerUrl entry required" .authServerUrl | quote }},
       "resource": {{ required "A valid .Values.web.auth.clientId entry required" .clientId | quote }},
       "verify-ssl": {{ .verifySsl }},
@@ -40,6 +40,13 @@ data:
     {{- with .Values.s3 }}
       bucket_prefix: {{ required "A valid .Values.s3.bucketPrefix entry required" .bucketPrefix | squote }}
       logs_bucket_prefix: {{ required "A valid .Values.s3.logsBucketPrefix entry required" .logsBucketPrefix | squote }}
+      {{- if .setPublicReadACL }}
+      set_public_read_acl: {{ .setPublicReadACL }}
+      {{- end }}
+      key_templates:
+        log: {{ required "A valid .Values.s3.logKeyTemplate entry required" .logKeyTemplate | squote }}
+        log_prefix: {{ required "A valid .Values.s3.logPrefixKeyTemplate entry required" .logPrefixKeyTemplate | squote }}
+        frame: {{ required "A valid .Values.s3.frameKeyTemplate entry required" .frameKeyTemplate | squote }}
       client_params:
         aws_access_key_id: {{ required "A valid .Values.s3.accessKey entry required" .accessKey | squote }}
         aws_secret_access_key: {{ required "A valid .Values.s3.secretAccessKey entry required" .secretAccessKey | squote }}
@@ -97,6 +104,7 @@ data:
         metadata_topics: {{ .Values.kafka.topics.tracks }}
       logs_saver:
         logs_topic: {{ .Values.kafka.topics.logs }}
+      frames_lifecycle_topic: {{ required "A valid .Values.kafka.topics.framesLifecycle entry required" .Values.kafka.topics.framesLifecycle | squote }}
       reporters:
       {{- range .Values.reporters }}
         - name: {{ .name }}
@@ -104,6 +112,9 @@ data:
             {{- toYaml .predictors | nindent 12 }}
       {{- if eq .name "pro" }}
           topic: {{ $.Values.kafka.topics.pro }}
+          {{- if .trackTimeoutDays }}
+          timeout: {{ .trackTimeoutDays }}
+          {{- end }}
         {{- end }}
       {{- end }}
       predictors:

--- a/charts/citylens/templates/web/configmap.yaml
+++ b/charts/citylens/templates/web/configmap.yaml
@@ -70,6 +70,7 @@ data:
         period: {{ .requestRateLimit.period }}
       request_retries: {{ .requestRetries }}
       request_retries_backoff: {{ .requestRetriesBackoff }}
+      source_env: {{ .sourceEnv }}
     {{- end }}
     {{- end }}
     {{- with .Values.pro }}

--- a/charts/citylens/values.yaml
+++ b/charts/citylens/values.yaml
@@ -564,9 +564,9 @@ kafka:
 # @param s3.logsBucketPrefix S3 bucket name prefix for the mobile app logs buckets. **Required**
 # @param s3.region S3 region.
 # @param s3.setPublicReadACL Set "public-read" ACL on buckets and objects.
-# @param s3.logKeyTemplate S3 key template for mobile app log files. Template variables available: track_uuid, log_date, log_timestamp_ms. Ex: `{track_uuid}/log_{log_timestamp_ms}` **Required**
-# @param s3.logPrefixKeyTemplate S3 key prefix template for mobile app log files. Template variables available: track_uuid, log_date. Ex: `{track_uuid}/log_` **Required**
-# @param s3.frameKeyTemplate S3 key prefix template for frames images. Template variables available: track_email, track_uuid, frame_date, frame_timestamp_ms, lat, lon. Ex: `{track_uuid}/{frame_timestamp_ms}.jpg` **Required**
+# @param s3.logKeyTemplate S3 key template for mobile app log files. **Required**
+# @param s3.logPrefixKeyTemplate S3 key prefix template for mobile app log files. **Required**
+# @param s3.frameKeyTemplate S3 key prefix template for frames images. **Required**
 
 s3:
   verifySsl: true
@@ -577,9 +577,9 @@ s3:
   logsBucketPrefix: ''
   region: ''
   setPublicReadACL: false
-  logKeyTemplate: ''
-  logPrefixKeyTemplate: ''
-  frameKeyTemplate: ''
+  logKeyTemplate: '{track_uuid}/log_{log_timestamp_ms}'
+  logPrefixKeyTemplate: '{track_uuid}/log_'
+  frameKeyTemplate: '{track_uuid}/{frame_timestamp_ms}.jpg'
 
 # @section postgres **Database settings**
 

--- a/charts/citylens/values.yaml
+++ b/charts/citylens/values.yaml
@@ -564,9 +564,6 @@ kafka:
 # @param s3.logsBucketPrefix S3 bucket name prefix for the mobile app logs buckets. **Required**
 # @param s3.region S3 region.
 # @param s3.setPublicReadACL Set "public-read" ACL on buckets and objects.
-# @param s3.logKeyTemplate S3 key template for mobile app log files. **Required**
-# @param s3.logPrefixKeyTemplate S3 key prefix template for mobile app log files. **Required**
-# @param s3.frameKeyTemplate S3 key prefix template for frames images. **Required**
 
 s3:
   verifySsl: true
@@ -577,9 +574,6 @@ s3:
   logsBucketPrefix: ''
   region: ''
   setPublicReadACL: false
-  logKeyTemplate: '{track_uuid}/log_{log_timestamp_ms}'
-  logPrefixKeyTemplate: '{track_uuid}/log_'
-  frameKeyTemplate: '{track_uuid}/{frame_timestamp_ms}.jpg'
 
 # @section postgres **Database settings**
 

--- a/charts/citylens/values.yaml
+++ b/charts/citylens/values.yaml
@@ -201,7 +201,7 @@ web:
   image:
     repository: 2gis-on-premise/citylens-web
     pullPolicy: IfNotPresent
-    tag: 1.2.3
+    tag: 1.2.4
 
   replicas: 1
 

--- a/charts/citylens/values.yaml
+++ b/charts/citylens/values.yaml
@@ -311,6 +311,8 @@ worker:
 # @param worker.camcomSender.requestRetries Camcom request retries
 # @param worker.camcomSender.requestRetriesBackoff request retries backoff
 
+# @param worker.camcomSender.sourceEnv Environment name to send to CamCam (source_env field in request), ignored if empty.
+
 
 # @param worker.camcomSender.annotations Kubernetes [annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/).
 # @param worker.camcomSender.labels Kubernetes [labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/).
@@ -335,6 +337,7 @@ worker:
       period: 60
     requestRetries: 3
     requestRetriesBackoff: 1
+    sourceEnv: ''
 
     annotations: {}
     labels: {}

--- a/charts/citylens/values.yaml
+++ b/charts/citylens/values.yaml
@@ -201,7 +201,7 @@ web:
   image:
     repository: 2gis-on-premise/citylens-web
     pullPolicy: IfNotPresent
-    tag: 1.2.2
+    tag: 1.2.3
 
   replicas: 1
 

--- a/charts/citylens/values.yaml
+++ b/charts/citylens/values.yaml
@@ -86,7 +86,7 @@ api:
   image:
     repository: 2gis-on-premise/citylens-api
     pullPolicy: IfNotPresent
-    tag: 1.2.2
+    tag: 1.2.5
 
   replicas: 4
 
@@ -201,7 +201,7 @@ web:
   image:
     repository: 2gis-on-premise/citylens-web
     pullPolicy: IfNotPresent
-    tag: 1.2.4
+    tag: 1.2.5
 
   replicas: 1
 

--- a/charts/citylens/values.yaml
+++ b/charts/citylens/values.yaml
@@ -86,7 +86,7 @@ api:
   image:
     repository: 2gis-on-premise/citylens-api
     pullPolicy: IfNotPresent
-    tag: 1.2.1
+    tag: 1.2.2
 
   replicas: 4
 
@@ -180,6 +180,7 @@ api:
 # @param web.auth.clientId Client id from keycloak. Ex: citylens-web-client **Required**
 # @param web.auth.clientSecret Client Secret from keycloak. **Required**
 # @param web.auth.verifySsl Enable\Disable SSL check.
+# @param web.auth.pkce Enable\Disable PKCE (Proof Key for Code Exchange) in Authorization Code flow.
 
 # @section Custom settings
 
@@ -200,7 +201,7 @@ web:
   image:
     repository: 2gis-on-premise/citylens-web
     pullPolicy: IfNotPresent
-    tag: 1.2.1
+    tag: 1.2.2
 
   replicas: 1
 
@@ -241,6 +242,7 @@ web:
     clientId: ''
     clientSecret: ''
     verifySsl: true
+    pkce: false
 
   logLevel: WARNING
 

--- a/charts/citylens/values.yaml
+++ b/charts/citylens/values.yaml
@@ -86,7 +86,7 @@ api:
   image:
     repository: 2gis-on-premise/citylens-api
     pullPolicy: IfNotPresent
-    tag: 1.2.0
+    tag: 1.2.1
 
   replicas: 4
 
@@ -200,7 +200,7 @@ web:
   image:
     repository: 2gis-on-premise/citylens-web
     pullPolicy: IfNotPresent
-    tag: 1.2.0
+    tag: 1.2.1
 
   replicas: 1
 

--- a/charts/citylens/values.yaml
+++ b/charts/citylens/values.yaml
@@ -86,7 +86,7 @@ api:
   image:
     repository: 2gis-on-premise/citylens-api
     pullPolicy: IfNotPresent
-    tag: 1.1.2
+    tag: 1.2.0
 
   replicas: 4
 
@@ -175,9 +175,9 @@ api:
 # @section Auth settings for authentication
 
 # @param web.auth.enabled If authentication is needed.
-# @param web.auth.realm Authenitcation realm, example: Inspection_Portal_backend **Required**
-# @param web.auth.authServerUrl API URL of authentication service. Example: `http(s)://keycloak.ingress.host` **Required**
-# @param web.auth.clientId Client id from keycloak, example: citylens-web-client **Required**
+# @param web.auth.realm Authentication realm. Used for constructing openid-configuration endpoint: `/realms/realm/.well-known/openid-configuration` if realm defined, `/.well-known/openid-configuration` othervise. Ex: Inspection_Portal_backend
+# @param web.auth.authServerUrl API URL of authentication service. Ex: `http(s)://keycloak.ingress.host` **Required**
+# @param web.auth.clientId Client id from keycloak. Ex: citylens-web-client **Required**
 # @param web.auth.clientSecret Client Secret from keycloak. **Required**
 # @param web.auth.verifySsl Enable\Disable SSL check.
 
@@ -200,7 +200,7 @@ web:
   image:
     repository: 2gis-on-premise/citylens-web
     pullPolicy: IfNotPresent
-    tag: 1.1.2
+    tag: 1.2.0
 
   replicas: 1
 
@@ -503,7 +503,7 @@ migrations:
   image:
     repository: 2gis-on-premise/citylens-database
     pullPolicy: IfNotPresent
-    tag: 1.1.2
+    tag: 1.2.0
 
   resources:
     requests:
@@ -525,6 +525,7 @@ migrations:
 # @param kafka.topics.pro List of topics for Reporter pro worker. **Required**
 # @param kafka.topics.uploader List of topics for Uploader worker. **Required**
 # @param kafka.topics.logs List of topics for API logs. **Required**
+# @param kafka.topics.framesLifecycle Topic for frames lifecycle events logs. **Required**
 # @param kafka.consumerGroups.prefix Kafka topics prefix. **Required**
 # @param kafka.predictors[0].name Name of predictor **Required**
 # @param kafka.predictors[0].topic Topic used by predictor **Required**
@@ -542,6 +543,7 @@ kafka:
     pro: ''
     logs: ''
     uploader: ''
+    framesLifecycle: ''
   consumerGroups:
     prefix: ''
   predictors:
@@ -558,6 +560,10 @@ kafka:
 # @param s3.bucketPrefix S3 bucket name prefix for the frames buckets. **Required**
 # @param s3.logsBucketPrefix S3 bucket name prefix for the mobile app logs buckets. **Required**
 # @param s3.region S3 region.
+# @param s3.setPublicReadACL Set "public-read" ACL on buckets and objects.
+# @param s3.logKeyTemplate S3 key template for mobile app log files. Template variables available: track_uuid, log_date, log_timestamp_ms. Ex: `{track_uuid}/log_{log_timestamp_ms}` **Required**
+# @param s3.logPrefixKeyTemplate S3 key prefix template for mobile app log files. Template variables available: track_uuid, log_date. Ex: `{track_uuid}/log_` **Required**
+# @param s3.frameKeyTemplate S3 key prefix template for frames images. Template variables available: track_email, track_uuid, frame_date, frame_timestamp_ms, lat, lon. Ex: `{track_uuid}/{frame_timestamp_ms}.jpg` **Required**
 
 s3:
   verifySsl: true
@@ -567,6 +573,10 @@ s3:
   bucketPrefix: ''
   logsBucketPrefix: ''
   region: ''
+  setPublicReadACL: false
+  logKeyTemplate: ''
+  logPrefixKeyTemplate: ''
+  frameKeyTemplate: ''
 
 # @section postgres **Database settings**
 
@@ -607,6 +617,7 @@ map:
 # @param headerLinks List of links for navbar.
 # @param reporters[0].name Reporter name.
 # @param reporters[0].predictors Predictor used by reporter.
+# @param reporters[0].trackTimeoutDays Time in days to wait for track completion and receiving frames prediction before marking as not synced with Pro.
 
 dashboardDomain: ''
 
@@ -620,6 +631,7 @@ headerLinks:
 reporters:
 - name: pro
   predictors: [camcom]
+  trackTimeoutDays: 1
 
 # @section PRO integration (only when Pro reporter enabled)
 

--- a/charts/citylens/values.yaml
+++ b/charts/citylens/values.yaml
@@ -86,7 +86,7 @@ api:
   image:
     repository: 2gis-on-premise/citylens-api
     pullPolicy: IfNotPresent
-    tag: 1.2.5
+    tag: 1.2.6
 
   replicas: 4
 
@@ -201,7 +201,7 @@ web:
   image:
     repository: 2gis-on-premise/citylens-web
     pullPolicy: IfNotPresent
-    tag: 1.2.5
+    tag: 1.2.6
 
   replicas: 1
 


### PR DESCRIPTION
Changelog:
* OpenId Connect (OIDC): поддержка PKCE, поддержка работы с OpenID Provider не требующего указания realm
* Поддержка мультиязычного рендеринга детекций на кадрах в Про
* CamCom: логгирование в БД ответов API, дашборд со статистикой, передача в API CamCom данных о картинке на s3 вместо самой картинки кадра
* Синхронизация с Про на уровне кадров трека (ранее - только все кадры трека одновременно) при загрузке кадра и сохранении детекций с кадра.
* Работа с S3: ACL public-read по умолчанию больше не проставляется для бакетов с кадрами. S3 ключ кадра теперь имеет вид `uuid трека/timestamp кадра.jpg` (убран e-mail пользователя, координаты кадра, дата)