### PR TITLE
IODEV-1748: Обновление сервиса лицензирования

### DIFF
--- a/Breaking-Changes.md
+++ b/Breaking-Changes.md
@@ -1,5 +1,13 @@
 # 2GIS On-Premise Breaking-Changes
 
+## [1.17.0]
+
+### license
+
+- Removed `fs` persistence type, now only `s3` is available.
+- Backward compatibility for license v1 is broken. If you have a version lower than `1.9.1`, you need to upgrade first
+  to version `1.16.0` to get license v2 without downtime - after that you can upgrade to version `1.17.0`.
+
 ## [1.16.0]
 
 ### catalog-api

--- a/Breaking-Changes.md
+++ b/Breaking-Changes.md
@@ -4,9 +4,22 @@
 
 ### license
 
-- Removed `fs` persistence type, now only `s3` is available.
 - Backward compatibility for license v1 is broken. If you have a version lower than `1.9.1`, you need to upgrade first
   to version `1.16.0` to get license v2 without downtime - after that you can upgrade to version `1.17.0`.
+- Removed `fs` persistence type, now only `s3` is available. `persistence.type` is no more provided, old `persistence.s3`
+  settings now should be located under `persistence`.
+
+```yaml
+--- # old
+persistence:
+  type: s3
+  s3:
+    ...
+
+--- # new
+persistence:
+  ...
+```
 
 ## [1.16.0]
 

--- a/charts/license/Chart.yaml
+++ b/charts/license/Chart.yaml
@@ -4,7 +4,7 @@ type: application
 description: A Helm chart for Kubernetes to deploy License service
 
 version: 1.16.0
-appVersion: 2.1.2
+appVersion: 2.2.0
 
 maintainers:
 - name: 2gis

--- a/charts/license/README.md
+++ b/charts/license/README.md
@@ -58,12 +58,11 @@ See the [documentation](https://docs.2gis.com/en/on-premise/architecture/service
 
 ### License service application settings
 
-| Name                      | Description                                                                                                                                                                                    | Value |
-| ------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----- |
-| `license.type`            | License type. Should be auto generated with `dgctl pull --generate-values`.                                                                                                                    | `""`  |
-| `license.updatePeriod`    | Duration how often service should fetch new license from storage. Duration format is any string supported by (time.ParseDuration)[https://pkg.go.dev/time#ParseDuration].                      | `1h`  |
-| `license.retryPeriod`     | Duration how often service should try to fetch license from storage if previous attempts were failing.                                                                                         | `30s` |
-| `license.softBlockPeriod` | Duration until the license expiration time when license service should respond with 'soft' block status. For this duration additional time units 'd' for days and 'w' for weeks are supported. | `2w`  |
+| Name                      | Description                                                                                                                                                                                                    | Value |
+| ------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----- |
+| `license.type`            | License type. Should be auto generated with `dgctl pull --generate-values`.                                                                                                                                    | `""`  |
+| `license.retryPeriod`     | Duration how often service should try to fetch license from storage if previous attempts were failing. Duration format is any string supported by (time.ParseDuration)[https://pkg.go.dev/time#ParseDuration]. | `30s` |
+| `license.softBlockPeriod` | Duration until the license expiration time when license service should respond with 'soft' block status. For this duration additional time units 'd' for days and 'w' for weeks are supported.                 | `2w`  |
 
 ### Service settings
 
@@ -95,21 +94,16 @@ See the [documentation](https://docs.2gis.com/en/on-premise/architecture/service
 | `resources.limits.cpu`      | A CPU limit.      | `1`     |
 | `resources.limits.memory`   | A memory limit.   | `512Mi` |
 
-### Persistence
+### Persistence settings
 
-| Name                              | Description                                                                                            | Value   |
-| --------------------------------- | ------------------------------------------------------------------------------------------------------ | ------- |
-| `persistence.type`                | Type of storage used for persistence, should be one of: 's3' - for S3 storage, 'fs' - for PVC storage. | `s3`    |
-| `persistence.fs`                  | **PVC setting for the 'fs' persistence type**                                                          |         |
-| `persistence.fs.storage`          | Storage size, should be at least 10Mi.                                                                 | `10Mi`  |
-| `persistence.fs.storageClassName` | Storage class name.                                                                                    | `""`    |
-| `persistence.s3`                  | **S3 setting for the 's3' persistence type**                                                           |         |
-| `persistence.s3.host`             | S3 endpoint. Format: `host:port`.                                                                      | `""`    |
-| `persistence.s3.secure`           | If S3 uses https.                                                                                      | `false` |
-| `persistence.s3.bucket`           | S3 bucket name.                                                                                        | `""`    |
-| `persistence.s3.root`             | Root directory in S3 bucket.                                                                           | `""`    |
-| `persistence.s3.accessKey`        | S3 access key for accessing the bucket.                                                                | `""`    |
-| `persistence.s3.secretKey`        | S3 secret key for accessing the bucket.                                                                | `""`    |
+| Name                    | Description                             | Value   |
+| ----------------------- | --------------------------------------- | ------- |
+| `persistence.host`      | S3 endpoint. Format: `host:port`.       | `""`    |
+| `persistence.secure`    | If S3 uses https.                       | `false` |
+| `persistence.bucket`    | S3 bucket name.                         | `""`    |
+| `persistence.root`      | Root directory in S3 bucket.            | `""`    |
+| `persistence.accessKey` | S3 access key for accessing the bucket. | `""`    |
+| `persistence.secretKey` | S3 secret key for accessing the bucket. | `""`    |
 
 ### TPM-related settings for license type 2
 

--- a/charts/license/templates/configmap.yaml
+++ b/charts/license/templates/configmap.yaml
@@ -11,8 +11,6 @@ data:
   config.yaml: |
     {{- with .license }}
     license:
-      path: license
-      update-period: {{ .updatePeriod }}
       retry-period: {{ .retryPeriod }}
       warning-period: {{ .softBlockPeriod }}
     server:
@@ -21,27 +19,16 @@ data:
     {{- end }}
     {{- with .dgctlStorage }}
     storage:
-      type: s3
-      s3:
-        host: {{ required "A valid $.Values.dgctlStorage.host entry is required" .host }}
-        secure: {{ .secure }}
-        bucket: {{ required "A valid $.Values.dgctlStorage.bucket entry is required" .bucket }}
+      host: {{ required "A valid $.Values.dgctlStorage.host entry is required" .host }}
+      secure: {{ .secure }}
+      bucket: {{ required "A valid $.Values.dgctlStorage.bucket entry is required" .bucket }}
     {{- end }}
     {{- with .persistence }}
     persistence:
-      type: {{ .type }}
-      {{- if eq .type "fs" }}
-      fs:
-        root: /persistence
-      {{- else if eq .type "s3" }}
-      s3:
-        host: {{ .s3.host }}
-        secure: {{ .s3.secure }}
-        bucket: {{ .s3.bucket }}
-        root: {{ .s3.root }}
-      {{- else }}
-      {{- required "$.persistence.type should be one of: ['fs', 's3']" ""}}
-      {{- end }}
+      host: {{ .host }}
+      secure: {{ .secure }}
+      bucket: {{ .bucket }}
+      root: {{ .root }}
     {{- end }}
 
 {{- end -}}

--- a/charts/license/templates/secret.yaml
+++ b/charts/license/templates/secret.yaml
@@ -13,9 +13,9 @@ data:
   s3AccessKey: {{ required "A valid $.Values.dgctlStorage.accessKey entry is required" .accessKey | b64enc }}
   s3SecretKey: {{ required "A valid $.Values.dgctlStorage.secretKey entry is required" .secretKey | b64enc }}
   {{- end }}
-  {{- if eq .persistence.type "s3" }}
-  persistenceS3AccessKey: {{ required "A valid $.Values.persistence.s3.accessKey entry is required" .persistence.s3.accessKey | b64enc }}
-  persistenceS3SecretKey: {{ required "A valid $.Values.persistence.s3.secretKey entry is required" .persistence.s3.secretKey | b64enc }}
+  {{- with .persistence }}
+  persistenceS3AccessKey: {{ required "A valid $.Values.persistence.s3.accessKey entry is required" .accessKey | b64enc }}
+  persistenceS3SecretKey: {{ required "A valid $.Values.persistence.s3.secretKey entry is required" .secretKey | b64enc }}
   {{- end }}
 
 {{- end }}

--- a/charts/license/templates/statefulset.yaml
+++ b/charts/license/templates/statefulset.yaml
@@ -76,10 +76,6 @@ spec:
             - mountPath: /dev/tpmrm0
               name: tpm-device
             {{- end }}
-            {{- if eq .persistence.type "fs" }}
-            - mountPath: /persistence
-              name: persistence
-            {{- end }}
           env:
             - name: CONFIG_PATH
               value: /config/config.yaml
@@ -101,7 +97,6 @@ spec:
                 secretKeyRef:
                   name: {{ include "license.fullname" $ }}
                   key: s3SecretKey
-            {{- if eq .persistence.type "s3"}}
             - name: PERSISTENCE_ACCESS_KEY
               valueFrom:
                 secretKeyRef:
@@ -112,7 +107,6 @@ spec:
                 secretKeyRef:
                   name: {{ include "license.fullname" $ }}
                   key: persistenceS3SecretKey
-            {{- end }}
           resources:
             {{- toYaml .resources | nindent 12 }}
           {{- if and (eq (include "license.type" $) "2") (not (empty .tpm.securityContext)) }}
@@ -145,20 +139,6 @@ spec:
         {{- toYaml .imagePullSecrets | nindent 8 }}
       {{- end }}
   volumeClaimTemplates:
-    {{- if eq .persistence.type "fs" }}
-    {{- with .persistence.fs }}
-    - metadata:
-        name: persistence
-      spec:
-        accessModes:
-          - ReadWriteOnce
-        volumeMode: Filesystem
-        resources:
-          requests:
-            storage: {{ .storage }}
-        storageClassName: {{ .storageClassName }}
-    {{- end }}
-    {{- end }}
     {{- if and (eq (include "license.type" $) "2") (.tpm.pvcBind.enable) }}
     - metadata:
         name: tpm-node-bind

--- a/charts/license/values.yaml
+++ b/charts/license/values.yaml
@@ -69,15 +69,13 @@ image:
 # @section License service application settings
 
 # @param license.type License type. Should be auto generated with `dgctl pull --generate-values`.
-# @param license.updatePeriod Duration how often service should fetch new license from storage. Duration format is any string supported by (time.ParseDuration)[https://pkg.go.dev/time#ParseDuration].
-# @param license.retryPeriod Duration how often service should try to fetch license from storage if previous attempts were failing.
+# @param license.retryPeriod Duration how often service should try to fetch license from storage if previous attempts were failing. Duration format is any string supported by (time.ParseDuration)[https://pkg.go.dev/time#ParseDuration].
 # @param license.softBlockPeriod Duration until the license expiration time when license service should respond with 'soft' block status. For this duration additional time units 'd' for days and 'w' for weeks are supported.
 # @skip license.statusPort
 # @skip license.apiPort
 
 license:
   type: ''
-  updatePeriod: 1h
   retryPeriod: 30s
   softBlockPeriod: 2w
   statusPort: 8080
@@ -135,34 +133,22 @@ resources:
     cpu: 500m
     memory: 128Mi
 
-# @section Persistence
+# @section Persistence settings
 
-# @param persistence.type Type of storage used for persistence, should be one of: 's3' - for S3 storage, 'fs' - for PVC storage.
-
-# @extra persistence.fs **PVC setting for the 'fs' persistence type**
-# @param persistence.fs.storage Storage size, should be at least 10Mi.
-# @param persistence.fs.storageClassName Storage class name.
-
-# @extra persistence.s3 **S3 setting for the 's3' persistence type**
-# @param persistence.s3.host S3 endpoint. Format: `host:port`.
-# @param persistence.s3.secure If S3 uses https.
-# @param persistence.s3.bucket S3 bucket name.
-# @param persistence.s3.root Root directory in S3 bucket.
-# @param persistence.s3.accessKey S3 access key for accessing the bucket.
-# @param persistence.s3.secretKey S3 secret key for accessing the bucket.
+# @param persistence.host S3 endpoint. Format: `host:port`.
+# @param persistence.secure If S3 uses https.
+# @param persistence.bucket S3 bucket name.
+# @param persistence.root Root directory in S3 bucket.
+# @param persistence.accessKey S3 access key for accessing the bucket.
+# @param persistence.secretKey S3 secret key for accessing the bucket.
 
 persistence:
-  type: s3
-  fs:
-    storage: 10Mi
-    storageClassName: ''
-  s3:
-    host: ''
-    secure: false
-    bucket: ''
-    root: ''
-    accessKey: ''
-    secretKey: ''
+  host: ''
+  secure: false
+  bucket: ''
+  root: ''
+  accessKey: ''
+  secretKey: ''
 
 # @section TPM-related settings for license type 2
 


### PR DESCRIPTION
## Описание

С обновлением сервиса лицензирования до `2.2.0` произошли несколько ломающих изменений, которые тут отразил:
1. убрали поддержку persistence через PVC - оставили только S3, соответственно теперь конфигмапа и values выглядят немного по-другому,
2. убрали обратную совместимость с лицензией v1 - теперь будем принимать только лицензию v2.

## Про обратную совместимость с лицензией v1

> Влияет ли это как-то на использование `/api/v1`?

Нет - `/api/v1` теперь просто работает поверх лицензии v2, с этой стороны ничего не изменилось.

> На что это влияет вообще?

Если после обновления в контуре будет только старая лицензия, которая пишется в `datagateway:/license`, то сервис лицензирования никак не будет её использовать и всё сломается.

> Что делать, если у клиента супер старая версия, в которой нет файла с лицензией v2?

Надо сначала обновиться до последней версии перед этой (`1.16.0`) и получить новую лицензию. После этого можно смело обновляться дальше.

## Как тестировать?

Версия образа для тестирования - `2.2.0`.

Правки в песочницу - https://gitlab.2gis.ru/iodev/on-premise/sandbox/-/merge_requests/18