### PR TITLE
IODEV-1763: Добавил возможность использования кастомных CA в license

### DIFF
--- a/charts/license/README.md
+++ b/charts/license/README.md
@@ -114,3 +114,10 @@ See the [documentation](https://docs.2gis.com/en/on-premise/architecture/service
 | `tpm.pvcBind`                  | **Kubernetes PVC used to bind pod to the kubernetes node; not needed if FS persistence is used**                                                                          |         |
 | `tpm.pvcBind.enable`           | If PVC should be used to bind pod to the kubernetes node.                                                                                                                 | `false` |
 | `tpm.pvcBind.storageClassName` | Storage class name.                                                                                                                                                       | `""`    |
+
+### **Custom Certificate Authority**
+
+| Name                  | Description                                                                                                                 | Value |
+| --------------------- | --------------------------------------------------------------------------------------------------------------------------- | ----- |
+| `customCAs.bundle`    | Custom CA [text representation of the X.509 PEM public-key certificate](https://www.rfc-editor.org/rfc/rfc7468#section-5.1) | `""`  |
+| `customCAs.certsPath` | Custom CA bundle mount directory in the container.                                                                          | `""`  |

--- a/charts/license/templates/_helpers.tpl
+++ b/charts/license/templates/_helpers.tpl
@@ -94,3 +94,10 @@ Converts duration (1h2m3s) to integer seconds, accepts { duration: <duration> }
 {{- $add := $now | dateModify .duration -}}
 {{ sub ($add | unixEpoch) ($now | unixEpoch) }}
 {{- end -}}
+
+{{/*
+Mount directory for custom CA
+*/}}
+{{- define "license.customCA.mountPath" -}}
+{{ $.Values.customCAs.certsPath | default "/usr/local/share/ca-certificates" }}
+{{- end -}}

--- a/charts/license/templates/custom-ca.configmap.yaml
+++ b/charts/license/templates/custom-ca.configmap.yaml
@@ -1,0 +1,12 @@
+{{- if $.Values.customCAs.bundle }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "license.fullname" . }}-custom-ca
+  labels:
+    {{- include "license.labels" . | nindent 4 }}
+
+data:
+  custom-ca.crt: {{- $.Values.customCAs.bundle | toYaml | indent 1 }}
+{{- end }}

--- a/charts/license/templates/custom-ca.configmap.yaml
+++ b/charts/license/templates/custom-ca.configmap.yaml
@@ -8,5 +8,6 @@ metadata:
     {{- include "license.labels" . | nindent 4 }}
 
 data:
-  custom-ca.crt: {{- $.Values.customCAs.bundle | toYaml | indent 1 }}
+  custom-ca.crt: |-
+    {{- $.Values.customCAs.bundle | nindent 4 }}
 {{- end }}

--- a/charts/license/templates/statefulset.yaml
+++ b/charts/license/templates/statefulset.yaml
@@ -25,6 +25,7 @@ spec:
     metadata:
       annotations:
         checksum/config: {{ include "license.checksum" (merge (dict "path" "/configmap.yaml") $) }}
+        checksum/custom-ca: {{ include "license.checksum" (merge (dict "path" "/custom-ca.configmap.yaml") $) }}
         checksum/secret: {{ include "license.checksum" (merge (dict "path" "/secret.yaml") $) }}
         {{- if not (empty .podAnnotations) }}
         {{- toYaml .podAnnotations | nindent 8 }}

--- a/charts/license/templates/statefulset.yaml
+++ b/charts/license/templates/statefulset.yaml
@@ -76,6 +76,11 @@ spec:
             - mountPath: /dev/tpmrm0
               name: tpm-device
             {{- end }}
+            {{- if $.Values.customCAs.bundle }}
+            - mountPath: {{ include "license.customCA.mountPath" $ }}
+              name: custom-ca
+              readOnly: true
+            {{- end }}
           env:
             - name: CONFIG_PATH
               value: /config/config.yaml
@@ -107,6 +112,10 @@ spec:
                 secretKeyRef:
                   name: {{ include "license.fullname" $ }}
                   key: persistenceS3SecretKey
+            {{- if $.Values.customCAs.bundle }}
+            - name: SSL_CERT_DIR
+              value: {{ include "license.customCA.mountPath" $ }}
+            {{- end }}
           resources:
             {{- toYaml .resources | nindent 12 }}
           {{- if and (eq (include "license.type" $) "2") (not (empty .tpm.securityContext)) }}
@@ -121,6 +130,11 @@ spec:
         - name: tpm-device
           hostPath:
             path: /dev/tpmrm0
+        {{- end }}
+        {{- if $.Values.customCAs.bundle }}
+        - name: custom-ca
+          configMap:
+            name: {{ include "license.fullname" $ }}-custom-ca
         {{- end }}
       {{- if not (empty .nodeSelector) }}
       nodeSelector:

--- a/charts/license/values.yaml
+++ b/charts/license/values.yaml
@@ -164,3 +164,12 @@ tpm:
   pvcBind:
     enable: false
     storageClassName: ''
+
+# @section **Custom Certificate Authority**
+
+# @param customCAs.bundle Custom CA [text representation of the X.509 PEM public-key certificate](https://www.rfc-editor.org/rfc/rfc7468#section-5.1)
+# @param customCAs.certsPath Custom CA bundle mount directory in the container.
+
+customCAs:
+  bundle: ''
+  certsPath: ''

--- a/charts/license/values.yaml
+++ b/charts/license/values.yaml
@@ -172,4 +172,8 @@ tpm:
 
 customCAs:
   bundle: ''
+  # bundle: |
+  #   -----BEGIN CERTIFICATE-----
+  #   ...
+  #   -----END CERTIFICATE-----
   certsPath: ''

--- a/charts/license/values.yaml
+++ b/charts/license/values.yaml
@@ -63,7 +63,7 @@ imagePullSecrets: []
 
 image:
   repository: 2gis-on-premise/license
-  tag: 2.1.2
+  tag: 2.2.0
   pullPolicy: IfNotPresent
 
 # @section License service application settings


### PR DESCRIPTION
## Описание

Добавил возможность использования кастомных CA - честно всё скопировал из https://github.com/2gis/on-premise-helm-charts/pull/371.

Не стал мешать с другим открытым ПРом для `license` - они никак не зависят друг от друга.

## Как тестировать?

Надо запустить minio с TLS, я делал это вот так:
```yaml
ingress:
  enabled: true
  annotations:
    nginx.ingress.kubernetes.io/proxy-body-size: 1024m
    nginx.ingress.kubernetes.io/ssl-redirect: "false"
  hosts:
    - minio.${CLUSTER_DOMAIN}
  tls:
    - secretName: minio-tls
      hosts:
        - minio.${CLUSTER_DOMAIN}
```
Соответственно надо подготовить `tls` секрет.

Сервис лицензирования должен ходить по правильному адресу и с указанием TLS:
```yaml
dgctlStorage:
  host: minio.${CLUSTER_DOMAIN}:443
  secure: true
```

## На чём тестировать?

Изменения в коде не подразумеваются, можно взять соответствующий для `1.16.0` образ и потестировать с ним