### PR TITLE
navi-castle: startup probe added

### DIFF
--- a/charts/navi-castle/README.md
+++ b/charts/navi-castle/README.md
@@ -102,13 +102,16 @@ See the [documentation](https://docs.2gis.com/en/on-premise/navigation) to learn
 
 ### Navi-Castle service settings
 
-| Name                       | Description                                         | Value                          |
-| -------------------------- | --------------------------------------------------- | ------------------------------ |
-| `castle.castleDataPath`    | Path to the data directory.                         | `/opt/castle/data/`            |
-| `castle.restrictions`      | Section ignored if castle.restriction.enabled=false |                                |
-| `castle.restrictions.host` | Restrictions API base URL.                          | `http://restrictions-api.host` |
-| `castle.restrictions.key`  | Restrictions API key.                               | `""`                           |
-| `castle.jobs`              | Number of parallel downloading jobs.                | `1`                            |
+| Name                                   | Description                                         | Value                          |
+| -------------------------------------- | --------------------------------------------------- | ------------------------------ |
+| `castle.castleDataPath`                | Path to the data directory.                         | `/opt/castle/data/`            |
+| `castle.restrictions`                  | Section ignored if castle.restriction.enabled=false |                                |
+| `castle.restrictions.host`             | Restrictions API base URL.                          | `http://restrictions-api.host` |
+| `castle.restrictions.key`              | Restrictions API key.                               | `""`                           |
+| `castle.jobs`                          | Number of parallel downloading jobs.                | `1`                            |
+| `castle.startupProbe`                  | Settings for startup probes                         |                                |
+| `castle.startupProbe.periodSeconds`    | Check period for startup probes.                    | `5`                            |
+| `castle.startupProbe.failureThreshold` | Threshold for startup probes.                       | `180`                          |
 
 ### Navi-Front settings
 

--- a/charts/navi-castle/templates/statefulset.yaml
+++ b/charts/navi-castle/templates/statefulset.yaml
@@ -85,6 +85,13 @@ spec:
           - /opt/update_services_init.sh
           resources:
             {{- toYaml $.Values.resources | nindent 12 }}
+          startupProbe:
+            {{- /* checks if supercronic prometheus port is open */}}
+            httpGet:
+              path: /health
+              port: {{ .Values.cron.prometheusPort | int }}
+            failureThreshold: {{ (.Values.castle.startupProbe).failureThreshold | default 180 | int }}
+            periodSeconds: {{ (.Values.castle.startupProbe).periodSeconds | default 5 | int }}
           livenessProbe:
             {{- /* checks if supercronic prometheus port is open */}}
             httpGet:

--- a/charts/navi-castle/values.yaml
+++ b/charts/navi-castle/values.yaml
@@ -123,6 +123,9 @@ resources: {}
 # @param castle.restrictions.host Restrictions API base URL.
 # @param castle.restrictions.key Restrictions API key.
 # @param castle.jobs Number of parallel downloading jobs.
+# @extra castle.startupProbe [nullable] Settings for startup probes
+# @param castle.startupProbe.periodSeconds Check period for startup probes.
+# @param castle.startupProbe.failureThreshold Threshold for startup probes.
 
 castle:
   image:
@@ -134,6 +137,9 @@ castle:
     host: http://restrictions-api.host
     key: ''
   jobs: 1
+  startupProbe:
+    periodSeconds: 5
+    failureThreshold: 180
 
 
 # @section Navi-Front settings


### PR DESCRIPTION
В случае, когда данные импортируются долго, инициализация контейнера превышает тайминги `livenessProbe` и castle невозможно запустить.

Добавлен параметризованный startupProbe.