### PR TITLE
Update citylens chart for version 1.3.0

### DIFF
--- a/Breaking-Changes.md
+++ b/Breaking-Changes.md
@@ -2,6 +2,12 @@
 
 ## [1.17.0]
 
+### citylens
+
+- Backward compatibility for citylens 1.3.0 is broken. Parameters `api.auth.publicKey` and `api.auth.algoritm` are replaced
+  with `api.auth.authServerUrl`, `api.auth.realm`, `api.auth.verifySsl`.
+
+
 ### license
 
 - Backward compatibility for license v1 is broken. If you have a version lower than `1.9.1`, you need to upgrade first

--- a/charts/citylens/templates/api/configmap.yaml
+++ b/charts/citylens/templates/api/configmap.yaml
@@ -47,4 +47,4 @@ data:
     {{- end }}
     show_docs: {{ .Values.api.showDocs }}
     log_level: {{ .Values.api.logLevel }}
-    metrics_app_name: {{ include "citylens.api.metricsAppName" . }}
+    metrics_app_name: {{ .Values.api.metricsAppName }}

--- a/charts/citylens/templates/api/configmap.yaml
+++ b/charts/citylens/templates/api/configmap.yaml
@@ -33,9 +33,17 @@ data:
     auth:
       enabled: {{ .enabled }}
       {{- if .enabled }}
-      public_key: "-----BEGIN PUBLIC KEY-----\r\n{{ required "A valid .Values.api.auth.publicKey entry required" .publicKey }}\r\n-----END PUBLIC KEY-----"
+      auth_server_url: {{ required "A valid .Values.api.auth.authServerUrl entry required" .authServerUrl | quote }}
+      {{- if .verifySsl }}
+      verify_ssl: {{ .verifySsl }}
       {{- end }}
-      algorithm: {{ .algorithm | quote }}
+      {{- if .realm }}
+      realm: {{ .realm | quote }}
+      {{- end}}
+      {{- if .camcomToken }}
+      camcom_token: {{ .camcomToken | quote }}
+      {{- end }}
+      {{- end }}
     {{- end }}
     show_docs: {{ .Values.api.showDocs }}
     log_level: {{ .Values.api.logLevel }}

--- a/charts/citylens/templates/api/configmap.yaml
+++ b/charts/citylens/templates/api/configmap.yaml
@@ -47,3 +47,4 @@ data:
     {{- end }}
     show_docs: {{ .Values.api.showDocs }}
     log_level: {{ .Values.api.logLevel }}
+    metrics_app_name: {{ include "citylens.api.metricsAppName" . }}

--- a/charts/citylens/templates/api/deployment.yaml
+++ b/charts/citylens/templates/api/deployment.yaml
@@ -38,6 +38,8 @@ spec:
           ports:
             - name: http
               containerPort: {{ .Values.api.service.targetPort }}
+            - name: metrics
+              containerPort: {{ .Values.api.service.metricsTargetPort }}
           readinessProbe:
             tcpSocket:
               port: 8000

--- a/charts/citylens/templates/web/configmap.yaml
+++ b/charts/citylens/templates/web/configmap.yaml
@@ -26,6 +26,7 @@ data:
     dashboard_domain: {{ required "A valid .Values.dashboardDomain. entry required" .Values.dashboardDomain | squote }}
     default_locale: {{ .Values.locale | squote }}
     log_level: {{ .Values.web.logLevel | squote }}
+    metrics_app_name: {{ include "citylens.web.metricsAppName" . }}
     db_connections:
     {{- with .Values.postgres }}
       postgres: 'postgresql://{{ required "A valid .Values.postgres.username entry required" .username }}:{{ required "A valid .Values.postgres.password entry required" .password }}@{{ required "A valid .Values.postgres.host entry required" .host }}:{{ required "A valid .Values.postgres.port entry required" .port }}/{{ required "A valid .Values.postgres.database entry required" .database }}'

--- a/charts/citylens/templates/web/configmap.yaml
+++ b/charts/citylens/templates/web/configmap.yaml
@@ -26,7 +26,7 @@ data:
     dashboard_domain: {{ required "A valid .Values.dashboardDomain. entry required" .Values.dashboardDomain | squote }}
     default_locale: {{ .Values.locale | squote }}
     log_level: {{ .Values.web.logLevel | squote }}
-    metrics_app_name: {{ include "citylens.web.metricsAppName" . }}
+    metrics_app_name: {{ .Values.web.metricsAppName }}
     db_connections:
     {{- with .Values.postgres }}
       postgres: 'postgresql://{{ required "A valid .Values.postgres.username entry required" .username }}:{{ required "A valid .Values.postgres.password entry required" .password }}@{{ required "A valid .Values.postgres.host entry required" .host }}:{{ required "A valid .Values.postgres.port entry required" .port }}/{{ required "A valid .Values.postgres.database entry required" .database }}'

--- a/charts/citylens/templates/web/deployment.yaml
+++ b/charts/citylens/templates/web/deployment.yaml
@@ -38,6 +38,8 @@ spec:
           ports:
             - name: http
               containerPort: {{ .Values.web.service.targetPort }}
+            - name: metrics
+              containerPort: {{ .Values.web.service.metricsTargetPort }}
           readinessProbe:
             tcpSocket:
               port: 5000

--- a/charts/citylens/values.yaml
+++ b/charts/citylens/values.yaml
@@ -47,6 +47,7 @@ dgctlStorage:
 # @param api.service.type Kubernetes [service type](https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types).
 # @param api.service.port Service port.
 # @param api.service.targetPort Service target port.
+# @param api.service.metricsTargetPort Service prometheus metrics target port. Metrics are available on /healthz/metrics endpoint.
 # @param api.service.annotations Kubernetes [service annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/).
 # @param api.service.labels Kubernetes [service labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/).
 
@@ -72,6 +73,7 @@ dgctlStorage:
 
 # @param api.showDocs Show documentation link if needed.
 # @param api.logLevel Log level.
+# @param api.metricsAppName Value for service prometheus metrics label "app_name".
 
 # @section Metadata settings
 
@@ -88,7 +90,7 @@ api:
   image:
     repository: 2gis-on-premise/citylens-api
     pullPolicy: IfNotPresent
-    tag: 1.3.0
+    tag: 1.3.1
 
   replicas: 4
 
@@ -106,6 +108,7 @@ api:
     type: ClusterIP
     port: 80
     targetPort: 8000
+    metricsTargetPort: 8001
 
   ingress:
     enabled: false
@@ -132,6 +135,8 @@ api:
   showDocs: false
 
   logLevel: INFO
+
+  metricsAppName: citylens-api
 
   annotations: {}
   labels: {}
@@ -163,6 +168,7 @@ api:
 # @param web.service.type Kubernetes [service type](https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types).
 # @param web.service.port Service port.
 # @param web.service.targetPort Service target port.
+# @param web.service.targetPort Service prometheus metrics target port. Metrics are available on /healthz/metrics endpoint.
 # @param web.service.annotations Kubernetes [service annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/).
 # @param web.service.labels Kubernetes [service labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/).
 
@@ -189,6 +195,7 @@ api:
 # @section Custom settings
 
 # @param web.logLevel Log level.
+# @param web.metricsAppName Value for service prometheus metrics label "app_name".
 
 # @section Metadata settings
 
@@ -205,7 +212,7 @@ web:
   image:
     repository: 2gis-on-premise/citylens-web
     pullPolicy: IfNotPresent
-    tag: 1.3.0
+    tag: 1.3.1
 
   replicas: 1
 
@@ -223,6 +230,7 @@ web:
     type: ClusterIP
     port: 80
     targetPort: 5000
+    metricsTargetPort: 5001
 
   ingress:
     enabled: false
@@ -249,6 +257,7 @@ web:
     pkce: false
 
   logLevel: WARNING
+  metricsAppName: citylens-web
 
   annotations: {}
   labels: {}

--- a/charts/citylens/values.yaml
+++ b/charts/citylens/values.yaml
@@ -63,8 +63,10 @@ dgctlStorage:
 # @section Auth settings for authentication
 
 # @param api.auth.enabled If authentication is needed.
-# @param api.auth.publicKey Public Key for authentication. Visit `http(s)://keycloak.ingress.host/realms/CityLens_app/` to obtain a Public Key.
-# @param api.auth.algorithm Authentication algorithm type.
+# @param api.auth.authServerUrl API URL of authentication service, OIDC-compatibility expected. Ex.: `http(s)://keycloak.ingress.host/`. **Required**
+# @param api.auth.realm Authentication realm. Used for constructing openid-configuration endpoint: `/realms/realm/.well-known/openid-configuration` if realm defined, `/.well-known/openid-configuration` othervise. Ex: CityLens_app
+# @param api.auth.verifySsl Enable\Disable SSL check.
+# @param api.auth.camcomToken Bearer token, expected on CamCom callback endpoint (if integration with CamCom enabled).
 
 # @section Custom settings
 
@@ -86,7 +88,7 @@ api:
   image:
     repository: 2gis-on-premise/citylens-api
     pullPolicy: IfNotPresent
-    tag: 1.2.6
+    tag: 1.3.0
 
   replicas: 4
 
@@ -122,8 +124,10 @@ api:
 
   auth:
     enabled: true
-    publicKey: ''
-    algorithm: RS256
+    authServerUrl: ''
+    realm: ''
+    verifySsl: true
+    camcomToken: ''
 
   showDocs: false
 
@@ -176,7 +180,7 @@ api:
 
 # @param web.auth.enabled If authentication is needed.
 # @param web.auth.realm Authentication realm. Used for constructing openid-configuration endpoint: `/realms/realm/.well-known/openid-configuration` if realm defined, `/.well-known/openid-configuration` othervise. Ex: Inspection_Portal_backend
-# @param web.auth.authServerUrl API URL of authentication service. Ex: `http(s)://keycloak.ingress.host` **Required**
+# @param web.auth.authServerUrl API URL of authentication service, OIDC-compatibility expected. Ex: `http(s)://keycloak.ingress.host` **Required**
 # @param web.auth.clientId Client id from keycloak. Ex: citylens-web-client **Required**
 # @param web.auth.clientSecret Client Secret from keycloak. **Required**
 # @param web.auth.verifySsl Enable\Disable SSL check.
@@ -201,7 +205,7 @@ web:
   image:
     repository: 2gis-on-premise/citylens-web
     pullPolicy: IfNotPresent
-    tag: 1.2.6
+    tag: 1.3.0
 
   replicas: 1
 


### PR DESCRIPTION
Changelog:
* citylens-api:
  * authorization: check token exipiry via auth service
  * authorization: add support for auth on camcom callback endpoint 
  * request validation: expect frames with same email as current user
  * prometheus metrics: added citylens-api:8001/healthz/metrics endpoint
* citylens-web:
  * prometheus metrics: added citylens-web:5001/healthz/metrics endpoint