### PR TITLE
[PRO-4361] Обновление pro-api до версии 1.1.79

### DIFF
--- a/charts/pro-api/Chart.yaml
+++ b/charts/pro-api/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 
 
 version: 1.17.0
-appVersion: 1.1.77
+appVersion: 1.1.78
 
 maintainers:
 - name: 2gis

--- a/charts/pro-api/Chart.yaml
+++ b/charts/pro-api/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 
 
 version: 1.17.0
-appVersion: 1.1.74
+appVersion: 1.1.77
 
 maintainers:
 - name: 2gis

--- a/charts/pro-api/Chart.yaml
+++ b/charts/pro-api/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 
 
 version: 1.17.0
-appVersion: 1.1.67
+appVersion: 1.1.74
 
 maintainers:
 - name: 2gis

--- a/charts/pro-api/Chart.yaml
+++ b/charts/pro-api/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 
 
 version: 1.17.0
-appVersion: 1.1.78
+appVersion: 1.1.79
 
 maintainers:
 - name: 2gis

--- a/charts/pro-api/README.md
+++ b/charts/pro-api/README.md
@@ -72,7 +72,7 @@
 | Name               | Description | Value                     |
 | ------------------ | ----------- | ------------------------- |
 | `image.repository` | Repository  | `2gis-on-premise/pro-api` |
-| `image.tag`        | Tag         | `1.1.77`                  |
+| `image.tag`        | Tag         | `1.1.78`                  |
 | `image.pullPolicy` | Pull Policy | `IfNotPresent`            |
 
 ### 2GIS PRO Storage configuration
@@ -205,7 +205,7 @@
 | Name                                       | Description                                                                                                                                              | Value                          |
 | ------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------ |
 | `assetImporter.repository`                 | Docker Repository Image.                                                                                                                                 | `2gis-on-premise/pro-importer` |
-| `assetImporter.tag`                        | Docker image tag.                                                                                                                                        | `1.1.77`                       |
+| `assetImporter.tag`                        | Docker image tag.                                                                                                                                        | `1.1.78`                       |
 | `assetImporter.schedule`                   | Import job schedule.                                                                                                                                     | `0 18 * * *`                   |
 | `assetImporter.backoffLimit`               | The number of [retries](https://kubernetes.io/docs/concepts/workloads/controllers/job/#pod-backoff-failure-policy) before considering a Job as failed.   | `2`                            |
 | `assetImporter.successfulJobsHistoryLimit` | How many completed and failed jobs should be kept. See [docs](https://kubernetes.io/docs/tasks/job/automated-tasks-with-cron-jobs/#jobs-history-limits). | `3`                            |

--- a/charts/pro-api/README.md
+++ b/charts/pro-api/README.md
@@ -72,7 +72,7 @@
 | Name               | Description | Value                     |
 | ------------------ | ----------- | ------------------------- |
 | `image.repository` | Repository  | `2gis-on-premise/pro-api` |
-| `image.tag`        | Tag         | `1.1.74`                  |
+| `image.tag`        | Tag         | `1.1.77`                  |
 | `image.pullPolicy` | Pull Policy | `IfNotPresent`            |
 
 ### 2GIS PRO Storage configuration
@@ -205,7 +205,7 @@
 | Name                                       | Description                                                                                                                                              | Value                          |
 | ------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------ |
 | `assetImporter.repository`                 | Docker Repository Image.                                                                                                                                 | `2gis-on-premise/pro-importer` |
-| `assetImporter.tag`                        | Docker image tag.                                                                                                                                        | `1.1.74`                       |
+| `assetImporter.tag`                        | Docker image tag.                                                                                                                                        | `1.1.77`                       |
 | `assetImporter.schedule`                   | Import job schedule.                                                                                                                                     | `0 18 * * *`                   |
 | `assetImporter.backoffLimit`               | The number of [retries](https://kubernetes.io/docs/concepts/workloads/controllers/job/#pod-backoff-failure-policy) before considering a Job as failed.   | `2`                            |
 | `assetImporter.successfulJobsHistoryLimit` | How many completed and failed jobs should be kept. See [docs](https://kubernetes.io/docs/tasks/job/automated-tasks-with-cron-jobs/#jobs-history-limits). | `3`                            |

--- a/charts/pro-api/README.md
+++ b/charts/pro-api/README.md
@@ -72,7 +72,7 @@
 | Name               | Description | Value                     |
 | ------------------ | ----------- | ------------------------- |
 | `image.repository` | Repository  | `2gis-on-premise/pro-api` |
-| `image.tag`        | Tag         | `1.1.67`                  |
+| `image.tag`        | Tag         | `1.1.74`                  |
 | `image.pullPolicy` | Pull Policy | `IfNotPresent`            |
 
 ### 2GIS PRO Storage configuration
@@ -205,7 +205,7 @@
 | Name                                       | Description                                                                                                                                              | Value                          |
 | ------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------ |
 | `assetImporter.repository`                 | Docker Repository Image.                                                                                                                                 | `2gis-on-premise/pro-importer` |
-| `assetImporter.tag`                        | Docker image tag.                                                                                                                                        | `1.1.67`                       |
+| `assetImporter.tag`                        | Docker image tag.                                                                                                                                        | `1.1.74`                       |
 | `assetImporter.schedule`                   | Import job schedule.                                                                                                                                     | `0 18 * * *`                   |
 | `assetImporter.backoffLimit`               | The number of [retries](https://kubernetes.io/docs/concepts/workloads/controllers/job/#pod-backoff-failure-policy) before considering a Job as failed.   | `2`                            |
 | `assetImporter.successfulJobsHistoryLimit` | How many completed and failed jobs should be kept. See [docs](https://kubernetes.io/docs/tasks/job/automated-tasks-with-cron-jobs/#jobs-history-limits). | `3`                            |

--- a/charts/pro-api/README.md
+++ b/charts/pro-api/README.md
@@ -72,7 +72,7 @@
 | Name               | Description | Value                     |
 | ------------------ | ----------- | ------------------------- |
 | `image.repository` | Repository  | `2gis-on-premise/pro-api` |
-| `image.tag`        | Tag         | `1.1.78`                  |
+| `image.tag`        | Tag         | `1.1.79`                  |
 | `image.pullPolicy` | Pull Policy | `IfNotPresent`            |
 
 ### 2GIS PRO Storage configuration
@@ -205,7 +205,7 @@
 | Name                                       | Description                                                                                                                                              | Value                          |
 | ------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------ |
 | `assetImporter.repository`                 | Docker Repository Image.                                                                                                                                 | `2gis-on-premise/pro-importer` |
-| `assetImporter.tag`                        | Docker image tag.                                                                                                                                        | `1.1.78`                       |
+| `assetImporter.tag`                        | Docker image tag.                                                                                                                                        | `1.1.79`                       |
 | `assetImporter.schedule`                   | Import job schedule.                                                                                                                                     | `0 18 * * *`                   |
 | `assetImporter.backoffLimit`               | The number of [retries](https://kubernetes.io/docs/concepts/workloads/controllers/job/#pod-backoff-failure-policy) before considering a Job as failed.   | `2`                            |
 | `assetImporter.successfulJobsHistoryLimit` | How many completed and failed jobs should be kept. See [docs](https://kubernetes.io/docs/tasks/job/automated-tasks-with-cron-jobs/#jobs-history-limits). | `3`                            |

--- a/charts/pro-api/templates/deployment.yaml
+++ b/charts/pro-api/templates/deployment.yaml
@@ -118,6 +118,8 @@ spec:
               value: {{ include "pro-api.user-asset-importer-name" . }}
             - name: Import__ExternalLinksProxyUrl
               value: "{{ .Values.assetImporter.externalLinksProxyUrl }}"
+            - name: Import__ExternalLinksAllowedHosts
+              value: "{{ .Values.assetImporter.externalLinksAllowedHosts }}"
             - name: TEMP_PATH
               value: "{{ .Values.api.tempPath }}"
             - name: CATALOG_API_2GIS_URL

--- a/charts/pro-api/values.yaml
+++ b/charts/pro-api/values.yaml
@@ -115,14 +115,14 @@ vpa:
 
 image:
   repository: 2gis-on-premise/pro-api
-  tag: 1.1.77
+  tag: 1.1.78
   pullPolicy: IfNotPresent
 
 # @skip permissionsApiImage
 
 permissionsApiImage:
   repository: 2gis-on-premise/pro-permissions-api
-  tag: 1.1.77
+  tag: 1.1.78
   pullPolicy: IfNotPresent
 
 # @section 2GIS PRO Storage configuration
@@ -391,7 +391,7 @@ permissionsApi:
 
 assetImporter:
   repository: 2gis-on-premise/pro-importer
-  tag: 1.1.77
+  tag: 1.1.78
   schedule: 0 18 * * *
   backoffLimit: 2
   successfulJobsHistoryLimit: 3
@@ -421,7 +421,7 @@ userAssetImporter:
 
 assetPreparer:
   repository: 2gis-on-premise/pro-importer
-  tag: 1.1.77
+  tag: 1.1.78
   schedule: 0 16 * * 6
   backoffLimit: 2
   successfulJobsHistoryLimit: 1

--- a/charts/pro-api/values.yaml
+++ b/charts/pro-api/values.yaml
@@ -115,14 +115,14 @@ vpa:
 
 image:
   repository: 2gis-on-premise/pro-api
-  tag: 1.1.78
+  tag: 1.1.79
   pullPolicy: IfNotPresent
 
 # @skip permissionsApiImage
 
 permissionsApiImage:
   repository: 2gis-on-premise/pro-permissions-api
-  tag: 1.1.78
+  tag: 1.1.79
   pullPolicy: IfNotPresent
 
 # @section 2GIS PRO Storage configuration
@@ -391,7 +391,7 @@ permissionsApi:
 
 assetImporter:
   repository: 2gis-on-premise/pro-importer
-  tag: 1.1.78
+  tag: 1.1.79
   schedule: 0 18 * * *
   backoffLimit: 2
   successfulJobsHistoryLimit: 3
@@ -421,7 +421,7 @@ userAssetImporter:
 
 assetPreparer:
   repository: 2gis-on-premise/pro-importer
-  tag: 1.1.78
+  tag: 1.1.79
   schedule: 0 16 * * 6
   backoffLimit: 2
   successfulJobsHistoryLimit: 1

--- a/charts/pro-api/values.yaml
+++ b/charts/pro-api/values.yaml
@@ -1,4 +1,4 @@
-# @section Docker Registry settings
+﻿# @section Docker Registry settings
 
 # @param dgctlDockerRegistry Docker Registry endpoint where On-Premise services' images reside. Format: `host:port`.
 
@@ -14,7 +14,7 @@ dgctlDockerRegistry: ''
 # @param nodeSelector Kubernetes [node selectors](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector).
 # @param affinity Kubernetes pod [affinity settings](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity).
 # @param priorityClassName Kubernetes [pod priority](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/).
-# @param terminationGracePeriodSeconds Kubernetes [termination grace period](https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/).
+# @param terminationGracePeriodSeconds Kubernetes [termination grace period](https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/). Should be at least 300 seconds
 # @param tolerations Kubernetes [tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) settings.
 # @param podAnnotations Kubernetes [pod annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/).
 # @param podLabels Kubernetes [pod labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/).
@@ -30,7 +30,7 @@ fullnameOverride: ''
 nodeSelector: {}
 affinity: {}
 priorityClassName: ''
-terminationGracePeriodSeconds: 60
+terminationGracePeriodSeconds: 300
 tolerations: []
 podAnnotations: {}
 podLabels: {}
@@ -115,14 +115,14 @@ vpa:
 
 image:
   repository: 2gis-on-premise/pro-api
-  tag: 1.1.67
+  tag: 1.1.74
   pullPolicy: IfNotPresent
 
 # @skip permissionsApiImage
 
 permissionsApiImage:
   repository: 2gis-on-premise/pro-permissions-api
-  tag: 1.1.67
+  tag: 1.1.74
   pullPolicy: IfNotPresent
 
 # @section 2GIS PRO Storage configuration
@@ -157,8 +157,8 @@ s3:
 # @skip api.filterByZoneCodes
 # @skip api.esDataCentersCount
 # @skip Local cache settings
-# @skip api.localCache.enabled
-# @skip api.localCache.trackStatistics
+# @skip localCache.enabled
+# @skip localCache.trackStatistics
 
 api:
   serviceAccount: runner
@@ -361,8 +361,8 @@ permissionsPodSettings:
 # @skip permissionsApi.host
 # @param permissionsApi.enabled If permissionsApi is enabled for the service.
 # @skip Local cache settings
-# @skip permissionsApi.localCache.enabled
-# @skip permissionsApi.localCache.trackStatistics
+# @skip localCache.enabled
+# @skip localCache.trackStatistics
 
 permissionsApi:
   host: ''
@@ -384,13 +384,14 @@ permissionsApi:
 # @param assetImporter.startOnDeploy Indicates that asset import should start when service installed or updated
 # @param assetImporter.imageProxyUrl URL to proxy image links (including query parameters, if any, i.e. 'https://someserver.com/proxy?url=' )
 # @param assetImporter.externalLinksProxyUrl URL to proxy http links from assets data (including query parameters, if any, i.e. 'https://someserver.com/proxy?url=' )
+# @param assetImporter.externalLinksAllowedHosts Comma separated hosts, i.e. 'someserver.com,someserver2.com' )
 # @skip assetImporter.files
 # @skip assetImporter.esMetricsEnabled
 # @skip assetImporter.suspended
 
 assetImporter:
   repository: 2gis-on-premise/pro-importer
-  tag: 1.1.67
+  tag: 1.1.74
   schedule: 0 18 * * *
   backoffLimit: 2
   successfulJobsHistoryLimit: 3
@@ -409,6 +410,7 @@ assetImporter:
   files: ''
   imageProxyUrl: ''
   externalLinksProxyUrl: ''
+  externalLinksAllowedHosts: ''
   esMetricsEnabled: false
 
 # @skip userAssetImporter
@@ -419,7 +421,7 @@ userAssetImporter:
 
 assetPreparer:
   repository: 2gis-on-premise/pro-importer
-  tag: 1.1.67
+  tag: 1.1.74
   schedule: 0 16 * * 6
   backoffLimit: 2
   successfulJobsHistoryLimit: 1
@@ -470,10 +472,10 @@ ingress:
   enabled: false
   className: nginx
   hosts:
-  - host: pro-api.example.com
-    paths:
-    - path: /
-      pathType: Prefix
+    - host: pro-api.example.com
+      paths:
+        - path: /
+          pathType: Prefix
   tls: []
   # - hosts:
   #   - pro-api.example.com
@@ -490,10 +492,10 @@ permissionsApiIngress:
   enabled: false
   className: nginx
   hosts:
-  - host: pro-permissions-api.example.com
-    paths:
-    - path: /
-      pathType: Prefix
+    - host: pro-permissions-api.example.com
+      paths:
+        - path: /
+          pathType: Prefix
   tls: []
   # - hosts:
   #   - pro-permissions-api.example.com

--- a/charts/pro-api/values.yaml
+++ b/charts/pro-api/values.yaml
@@ -115,14 +115,14 @@ vpa:
 
 image:
   repository: 2gis-on-premise/pro-api
-  tag: 1.1.74
+  tag: 1.1.77
   pullPolicy: IfNotPresent
 
 # @skip permissionsApiImage
 
 permissionsApiImage:
   repository: 2gis-on-premise/pro-permissions-api
-  tag: 1.1.74
+  tag: 1.1.77
   pullPolicy: IfNotPresent
 
 # @section 2GIS PRO Storage configuration
@@ -391,7 +391,7 @@ permissionsApi:
 
 assetImporter:
   repository: 2gis-on-premise/pro-importer
-  tag: 1.1.74
+  tag: 1.1.77
   schedule: 0 18 * * *
   backoffLimit: 2
   successfulJobsHistoryLimit: 3
@@ -421,7 +421,7 @@ userAssetImporter:
 
 assetPreparer:
   repository: 2gis-on-premise/pro-importer
-  tag: 1.1.74
+  tag: 1.1.77
   schedule: 0 16 * * 6
   backoffLimit: 2
   successfulJobsHistoryLimit: 1

--- a/image_versions.txt
+++ b/image_versions.txt
@@ -51,9 +51,9 @@ navi-splitter
 platform
 	platform-ui:0.5.5
 pro-api
-	pro-api:1.1.77
-	pro-importer:1.1.77
-	pro-permissions-api:1.1.77
+	pro-api:1.1.78
+	pro-importer:1.1.78
+	pro-permissions-api:1.1.78
 pro-ui
 	pro-ui:1.4.0
 search-api

--- a/image_versions.txt
+++ b/image_versions.txt
@@ -51,9 +51,9 @@ navi-splitter
 platform
 	platform-ui:0.5.5
 pro-api
-	pro-api:1.1.74
-	pro-importer:1.1.74
-	pro-permissions-api:1.1.74
+	pro-api:1.1.77
+	pro-importer:1.1.77
+	pro-permissions-api:1.1.77
 pro-ui
 	pro-ui:1.4.0
 search-api

--- a/image_versions.txt
+++ b/image_versions.txt
@@ -51,9 +51,9 @@ navi-splitter
 platform
 	platform-ui:0.5.5
 pro-api
-	pro-api:1.1.78
-	pro-importer:1.1.78
-	pro-permissions-api:1.1.78
+	pro-api:1.1.79
+	pro-importer:1.1.79
+	pro-permissions-api:1.1.79
 pro-ui
 	pro-ui:1.4.0
 search-api

--- a/image_versions.txt
+++ b/image_versions.txt
@@ -51,10 +51,9 @@ navi-splitter
 platform
 	platform-ui:0.5.5
 pro-api
-	pro-api:1.1.67
-	pro-importer:1.1.67
-	pro-importer:1.1.67
-	pro-permissions-api:1.1.67
+	pro-api:1.1.74
+	pro-importer:1.1.74
+	pro-permissions-api:1.1.74
 pro-ui
 	pro-ui:1.4.0
 search-api


### PR DESCRIPTION
Основные изменения в Pro API:
- [PRO-4106 Включить UI сервиса пермиссий в он-прем поставке](https://jira.2gis.ru/browse/PRO-4106)
- [PRO-3205 Поддержка NOT фильтров](https://jira.2gis.ru/browse/PRO-3205)
- [PRO-3809 Добавить ассетам поле с group id](https://jira.2gis.ru/browse/PRO-3809)
- [PRO-3981 Убрать символы $.[''] в названии полей при парсинге geojson](https://jira.2gis.ru/browse/PRO-3981)
- [PRO-4074 Научиться выбирать районы в РФ](https://jira.2gis.ru/browse/PRO-4074)
- [PRO-3094 Добавление точечных данных в загруженный ассет](https://jira.2gis.ru/browse/PRO-3094)
- [PRO-3281 Сделать email уникальным атрибутом пользователя](https://jira.2gis.ru/browse/PRO-3281)
- [PRO-3969 Cохранения текущего стиля карты в группу слоев](https://jira.2gis.ru/browse/PRO-3969)
- [PRO-4066 Поддержка ограничений на кол-во запросов, подсчёт и сохранение](https://jira.2gis.ru/browse/PRO-4066)
- [PRO-4212 Запрет на удаление системных ассетов для обычных пользователей](https://jira.2gis.ru/browse/PRO-4212)
- [PRO-3489 "Правильно" считать центроид геометрий](https://jira.2gis.ru/browse/PRO-3489)
- [PRO-4078 Уметь менять порядок фильтров в put filters](https://jira.2gis.ru/browse/PRO-4078)
- [PRO-4083 Агрегация по площадным объектам](https://jira.2gis.ru/browse/PRO-4083)
- [PRO-3967 Cохранения текущего стиля карты в пользователя](https://jira.2gis.ru/browse/PRO-3967)


**UPDATE 1.1.77**

Permission UI:
- Добавлена возможность поиска по рубрикам в Permissions UI (https://jira.2gis.ru/browse/PRO-3393)
- Добавлена возможность продления действия тарифа с сохранением текущих прав (https://jira.2gis.ru/browse/PRO-3578)

https://jira.2gis.ru/browse/PRO-4303:
- Поправлена проверка наличия прав на возможность загрузки пользовательских ассетов
- пользователей теперь нет доступа ко всем ассетам, только к фирмам и зданиям

Полный список изменений: https://tsup.2gis.dev/pro/pro-api/changelog/1.1.68..1.1.79