### PR TITLE
IODEV-1762: Поправил securityContext для license

### DIFF
--- a/charts/license/Chart.yaml
+++ b/charts/license/Chart.yaml
@@ -4,7 +4,7 @@ type: application
 description: A Helm chart for Kubernetes to deploy License service
 
 version: 1.17.0
-appVersion: 2.2.0
+appVersion: 2.2.1
 
 maintainers:
 - name: 2gis

--- a/charts/license/README.md
+++ b/charts/license/README.md
@@ -53,7 +53,7 @@ See the [documentation](https://docs.2gis.com/en/on-premise/architecture/service
 | Name               | Description  | Value                     |
 | ------------------ | ------------ | ------------------------- |
 | `image.repository` | Repository.  | `2gis-on-premise/license` |
-| `image.tag`        | Tag.         | `2.2.0`                   |
+| `image.tag`        | Tag.         | `2.2.1`                   |
 | `image.pullPolicy` | Pull Policy. | `IfNotPresent`            |
 
 ### License service application settings
@@ -107,13 +107,12 @@ See the [documentation](https://docs.2gis.com/en/on-premise/architecture/service
 
 ### TPM-related settings for license type 2
 
-| Name                           | Description                                                                                                                                                               | Value   |
-| ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
-| `tpm.securityContext`          | Main container [security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/). Should enable access to the host TPM device (/dev/tpmrm0). | `{}`    |
-| `tpm.mountTPMDevice`           | If TPM device should be mounted to the main container. Required if no TPM device plugin is used. Additionally, requires privileged access for the main container.         | `false` |
-| `tpm.pvcBind`                  | **Kubernetes PVC used to bind pod to the kubernetes node; not needed if FS persistence is used**                                                                          |         |
-| `tpm.pvcBind.enable`           | If PVC should be used to bind pod to the kubernetes node.                                                                                                                 | `false` |
-| `tpm.pvcBind.storageClassName` | Storage class name.                                                                                                                                                       | `""`    |
+| Name                           | Description                                                                                                                                     | Value   |
+| ------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| `tpm.mountTPMDevice`           | If TPM device should be mounted to the main container. Required if no TPM device plugin is used. Adds privileged access for the main container. | `false` |
+| `tpm.pvcBind`                  | **Kubernetes PVC used to bind pod to the kubernetes node**                                                                                      |         |
+| `tpm.pvcBind.enable`           | If PVC should be used to bind pod to the kubernetes node.                                                                                       | `false` |
+| `tpm.pvcBind.storageClassName` | Storage class name.                                                                                                                             | `""`    |
 
 ### **Custom Certificate Authority**
 

--- a/charts/license/templates/statefulset.yaml
+++ b/charts/license/templates/statefulset.yaml
@@ -119,9 +119,13 @@ spec:
             {{- end }}
           resources:
             {{- toYaml .resources | nindent 12 }}
-          {{- if and (eq (include "license.type" $) "2") (not (empty .tpm.securityContext)) }}
+          {{- if eq (include "license.type" $) "2" }}
           securityContext:
-            {{- toYaml .tpm.securityContext | nindent 12 }}
+            runAsUser: 0
+            runAsGroup: 0
+            {{- if $.Values.tpm.mountTPMDevice }}
+            privileged: true
+            {{- end }}
           {{- end }}
       volumes:
         - name: config

--- a/charts/license/values.yaml
+++ b/charts/license/values.yaml
@@ -63,7 +63,7 @@ imagePullSecrets: []
 
 image:
   repository: 2gis-on-premise/license
-  tag: 2.2.0
+  tag: 2.2.1
   pullPolicy: IfNotPresent
 
 # @section License service application settings
@@ -152,14 +152,12 @@ persistence:
 
 # @section TPM-related settings for license type 2
 
-# @param tpm.securityContext Main container [security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/). Should enable access to the host TPM device (/dev/tpmrm0).
-# @param tpm.mountTPMDevice If TPM device should be mounted to the main container. Required if no TPM device plugin is used. Additionally, requires privileged access for the main container.
-# @extra tpm.pvcBind **Kubernetes PVC used to bind pod to the kubernetes node; not needed if FS persistence is used**
+# @param tpm.mountTPMDevice If TPM device should be mounted to the main container. Required if no TPM device plugin is used. Adds privileged access for the main container.
+# @extra tpm.pvcBind **Kubernetes PVC used to bind pod to the kubernetes node**
 # @param tpm.pvcBind.enable If PVC should be used to bind pod to the kubernetes node.
 # @param tpm.pvcBind.storageClassName Storage class name.
 
 tpm:
-  securityContext: {}
   mountTPMDevice: false
   pvcBind:
     enable: false


### PR DESCRIPTION
## Описание

В `2.2.1` мы поменяли дефолтного пользователя в контейнере сервиса лицензирования с `root` на `1234`. Для работы с TPM нужен `root` пользователь, поэтому теперь для `license.type: 2` обязательно должен проставляться `securityContext` с `root` пользователем.

Соответственно немного поменял чарты:
1. убрал из values `tpm.securityContext` - тут больше не нужна вариативность,
2. переделал блок `securityContext` в STS, чтобы для `license.type: 2` выбирался `root` пользователь:
```yaml
securityContext:
  runAsUser: 0
  runAsGroup: 0
```
3. для прямого монтирования TPM (не через девайс плагин) дополнительно выставляется `privileged` флаг:
```yaml
securityContext:
  runAsUser: 0
  runAsGroup: 0
  privileged: true
```

## Как тестировать

Можно тестировать с образом `2.2.1`.