### PR TITLE
[DEVOPS-982] navi-front: update default locations

### DIFF
--- a/charts/navi-front/templates/configmap-base.yaml
+++ b/charts/navi-front/templates/configmap-base.yaml
@@ -34,6 +34,10 @@ data:
         {{ if .Values.hullLocation }}
         {{ include "tplvalues.render" ( dict "value" .Values.hullLocation "context" $ ) | indent 4 }}
         {{ else  }}
+        location ^~ /get_hull {
+            js_content bundle.geo_coding;
+        }
+        {{- end }}
 
         location ^~ /get_dist_matrix {
             js_content bundle.geo_coding;
@@ -47,12 +51,19 @@ data:
             js_content bundle.geo_coding;
         }
 
-        location ^~ /get_hull {
+        location ^~ /routing/ {
             js_content bundle.geo_coding;
         }
-        {{- end }}
 
-        location ^~ /routing/ {
+        location ^~ /map_matching/ {
+            js_content bundle.geo_coding;
+        }
+
+        location ^~ /get_pairs/ {
+            js_content bundle.geo_coding;
+        }
+
+        location ^~ /truck/ {
             js_content bundle.geo_coding;
         }
 


### PR DESCRIPTION
Синхронизировал дефолтные локейшены в конфиге фронта с теми API, которые заявлены у нас в документации.

Вынес всё кроме get_hull из-под условия на hullLocation. Возможно это условие можно вообще выкосить