### PR TITLE
[PRO-4517] Обновление pro-api до версии 1.5.0

### DIFF
--- a/charts/pro-api/templates/asset-import-starter.yaml
+++ b/charts/pro-api/templates/asset-import-starter.yaml
@@ -39,12 +39,16 @@ spec:
               value: "ScheduleManifest"
             - name: MAX_PARALLEL_JOBS
               value: "{{ .Values.assetImporter.maxParallelJobs }}"
-            - name: manifest
+            - name: manifest_filename
               value: "{{ .Values.dgctlStorage.manifest }}"
             - name: S3Settings__Url
               value: {{ required "A valid .Values.dgctlStorage.host entry required" $.Values.dgctlStorage.host }}
             - name: S3Settings__Secure
               value: "{{ .Values.dgctlStorage.secure }}"
+            - name: S3Settings__Region
+              value: {{ .Values.dgctlStorage.region }}
+            - name: S3Settings__DisablePayloadSigning
+              value: "{{ .Values.dgctlStorage.disablePayloadSigning }}"
             - name: S3Settings__DgctlStorageBucket
               value: {{ required "A valid .Values.dgctlStorage.bucket entry required" $.Values.dgctlStorage.bucket }}
             - name: S3Settings__AssetDataBucket

--- a/charts/pro-api/templates/asset-importer.yaml
+++ b/charts/pro-api/templates/asset-importer.yaml
@@ -48,6 +48,10 @@ spec:
                   value: {{ required "A valid .Values.dgctlStorage.host entry required" $.Values.dgctlStorage.host }}
                 - name: S3Settings__Secure
                   value: "{{ .Values.dgctlStorage.secure }}"
+                - name: S3Settings__Region
+                  value: {{ .Values.dgctlStorage.region }}
+                - name: S3Settings__DisablePayloadSigning
+                  value: "{{ .Values.dgctlStorage.disablePayloadSigning }}"
                 - name: S3Settings__DgctlStorageBucket
                   value: {{ required "A valid .Values.dgctlStorage.bucket entry required" $.Values.dgctlStorage.bucket }}
                 - name: S3Settings__AssetDataBucket

--- a/charts/pro-api/templates/asset-preparer.yaml
+++ b/charts/pro-api/templates/asset-preparer.yaml
@@ -44,6 +44,10 @@ spec:
                   value: {{ required "A valid .Values.dgctlStorage.host entry required" $.Values.dgctlStorage.host }}
                 - name: S3Settings__Secure
                   value: "{{ .Values.dgctlStorage.secure }}"
+                - name: S3Settings__Region
+                  value: {{ .Values.dgctlStorage.region }}
+                - name: S3Settings__DisablePayloadSigning
+                  value: "{{ .Values.dgctlStorage.disablePayloadSigning }}"
                 - name: S3Settings__AssetDataBucket
                   value: {{ required "A valid .Values.s3.assetsDataBucket entry required" $.Values.s3.assetsDataBucket }}
                 - name: S3Settings__UserAssetDataBucket

--- a/charts/pro-api/templates/deployment.yaml
+++ b/charts/pro-api/templates/deployment.yaml
@@ -172,6 +172,10 @@ spec:
               value: {{ required "A valid .Values.dgctlStorage.host entry required" $.Values.dgctlStorage.host }}
             - name: S3Settings__Secure
               value: "{{ .Values.dgctlStorage.secure }}"
+            - name: S3Settings__Region
+              value: {{ .Values.dgctlStorage.region }}
+            - name: S3Settings__DisablePayloadSigning
+              value: "{{ .Values.dgctlStorage.disablePayloadSigning }}"
             - name: S3Settings__AssetDataBucket
               value: {{ required "A valid .Values.s3.assetsDataBucket entry required" $.Values.s3.assetsDataBucket }}
             - name: S3Settings__UserAssetDataBucket
@@ -180,6 +184,8 @@ spec:
               value: {{ required "A valid .Values.s3.layerDataBucket entry required" $.Values.s3.layerDataBucket }}
             - name: S3Settings__SnapshotBucket
               value: {{ required "A valid .Values.s3.snapshotBucket entry required" $.Values.s3.snapshotBucket }}
+            - name: S3Settings__ResourcesBucket
+              value: {{ required "A valid .Values.s3.resourcesBucket entry required" $.Values.s3.resourcesBucket }}
             - name: S3Settings__AccessKey
               valueFrom:
                 secretKeyRef:

--- a/charts/pro-api/templates/user-asset-importer.yaml
+++ b/charts/pro-api/templates/user-asset-importer.yaml
@@ -48,6 +48,10 @@ spec:
                   value: {{ required "A valid .Values.dgctlStorage.host entry required" $.Values.dgctlStorage.host }}
                 - name: S3Settings__Secure
                   value: "{{ .Values.dgctlStorage.secure }}"
+                - name: S3Settings__Region
+                  value: {{ .Values.dgctlStorage.region }}
+                - name: S3Settings__DisablePayloadSigning
+                  value: "{{ .Values.dgctlStorage.disablePayloadSigning }}"
                 - name: S3Settings__AssetDataBucket
                   value: {{ required "A valid .Values.s3.assetsDataBucket entry required" $.Values.s3.assetsDataBucket }}
                 - name: S3Settings__UserAssetDataBucket

--- a/charts/pro-api/values.yaml
+++ b/charts/pro-api/values.yaml
@@ -46,6 +46,8 @@ revisionHistoryLimit: 3
 # @param dgctlStorage.accessKey S3 access key for accessing the bucket. **Required**
 # @param dgctlStorage.secretKey S3 secret key for accessing the bucket. **Required**
 # @param dgctlStorage.manifest The path to the [manifest file](https://docs.2gis.com/en/on-premise/overview#nav-lvl2@paramCommon_deployment_steps). Format: `manifests/0000000000.json`.<br> This file contains the description of pieces of data that the service requires to operate. **Required**
+# @param dgctlStorage.region AuthenticationRegion property for S3 client. Used in AWS4 request signing, this is an optional property
+# @param dgctlStorage.disablePayloadSigning Turns off payload signing, this is an optional property. Should be TRUE for Oracle S3 storage
 
 dgctlStorage:
   host: ''
@@ -54,6 +56,8 @@ dgctlStorage:
   accessKey: ''
   secretKey: ''
   manifest: ''
+  region: ''
+  disablePayloadSigning: false
 
 # @section Strategy settings
 
@@ -115,14 +119,14 @@ vpa:
 
 image:
   repository: 2gis-on-premise/pro-api
-  tag: 1.1.79
+  tag: 1.5.0
   pullPolicy: IfNotPresent
 
 # @skip permissionsApiImage
 
 permissionsApiImage:
   repository: 2gis-on-premise/pro-permissions-api
-  tag: 1.1.79
+  tag: 1.5.0
   pullPolicy: IfNotPresent
 
 # @section 2GIS PRO Storage configuration
@@ -131,12 +135,14 @@ permissionsApiImage:
 # @param s3.userAssetsDataBucket S3 bucket with user-created assets, aggregations, and filters. **Required**
 # @param s3.layerDataBucket S3 bucket with prepared layer data. **Required**
 # @param s3.snapshotBucket S3 bucket for storing snapshots of inclemental data updates. **Required**
+# @param s3.resourcesBucket S3 bucket for storing static resources. **Required**
 
 s3:
   assetsDataBucket: ''
   userAssetsDataBucket: ''
   layerDataBucket: ''
   snapshotBucket: ''
+  resourcesBucket: ''
 
 # @section 2GIS PRO API configuration
 
@@ -159,8 +165,6 @@ s3:
 # @skip Local cache settings
 # @skip localCache.enabled
 # @skip localCache.trackStatistics
-# @skip api.localCache.enabled
-# @skip api.localCache.trackStatistics
 
 api:
   serviceAccount: runner
@@ -365,8 +369,6 @@ permissionsPodSettings:
 # @skip Local cache settings
 # @skip localCache.enabled
 # @skip localCache.trackStatistics
-# @skip permissionsApi.localCache.enabled
-# @skip permissionsApi.localCache.trackStatistics
 
 permissionsApi:
   host: ''
@@ -395,7 +397,7 @@ permissionsApi:
 
 assetImporter:
   repository: 2gis-on-premise/pro-importer
-  tag: 1.1.79
+  tag: 1.5.0
   schedule: 0 18 * * *
   backoffLimit: 2
   successfulJobsHistoryLimit: 3
@@ -425,7 +427,7 @@ userAssetImporter:
 
 assetPreparer:
   repository: 2gis-on-premise/pro-importer
-  tag: 1.1.79
+  tag: 1.5.0
   schedule: 0 16 * * 6
   backoffLimit: 2
   successfulJobsHistoryLimit: 1


### PR DESCRIPTION
Основные изменения в Pro API:
- [PRO-3449 Генерировать ключи для шаринга в онпреме](https://jira.2gis.ru/browse/PRO-3449)
- [PRO-4437 Добавить параметр region к dgctlStorage](https://jira.2gis.ru/browse/PRO-4437)
- [PRO-4234 500 при передаче двух одинаковых атрибутов](https://jira.2gis.ru/browse/PRO-4234)
- [PRO-4498 Не отображаются фильтры в ассете Frames](https://jira.2gis.ru/browse/PRO-4498)
- [PRO-4488 400 При генерации слоя с агрегатами](https://jira.2gis.ru/browse/PRO-4488)
- [PRO-4443 Включить отображение территорий в системных ассетах](https://jira.2gis.ru/browse/PRO-4443)
- [PRO-4511 Авторизованное получение подготовленных данных слоя](https://jira.2gis.ru/browse/PRO-4511)
- [PRO-4627 Добавить параметр для отключения PayloadSigning в S3-клиенте](https://jira.2gis.ru/browse/PRO-4627)
- [PRO-4687 Ошибки при записи в бакет S3 Oracle в он-преме](https://jira.2gis.ru/browse/PRO-4687)

Полный список изменений: https://tsup.2gis.dev/pro/pro-api/changelog/1.1.80..1.5.0