### PR TITLE
PRO-0: upgrade PRO API to 1.5.1

### DIFF
--- a/charts/pro-api/Chart.yaml
+++ b/charts/pro-api/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 
 
 version: 1.19.0
-appVersion: 1.5.0
+appVersion: 1.5.1
 
 maintainers:
 - name: 2gis

--- a/charts/pro-api/README.md
+++ b/charts/pro-api/README.md
@@ -74,7 +74,7 @@
 | Name               | Description | Value                     |
 | ------------------ | ----------- | ------------------------- |
 | `image.repository` | Repository  | `2gis-on-premise/pro-api` |
-| `image.tag`        | Tag         | `1.5.0`                   |
+| `image.tag`        | Tag         | `1.5.1`                   |
 | `image.pullPolicy` | Pull Policy | `IfNotPresent`            |
 
 ### 2GIS PRO Storage configuration
@@ -208,7 +208,7 @@
 | Name                                       | Description                                                                                                                                              | Value                          |
 | ------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------ |
 | `assetImporter.repository`                 | Docker Repository Image.                                                                                                                                 | `2gis-on-premise/pro-importer` |
-| `assetImporter.tag`                        | Docker image tag.                                                                                                                                        | `1.5.0`                        |
+| `assetImporter.tag`                        | Docker image tag.                                                                                                                                        | `1.5.1`                        |
 | `assetImporter.schedule`                   | Import job schedule.                                                                                                                                     | `0 18 * * *`                   |
 | `assetImporter.backoffLimit`               | The number of [retries](https://kubernetes.io/docs/concepts/workloads/controllers/job/#pod-backoff-failure-policy) before considering a Job as failed.   | `2`                            |
 | `assetImporter.successfulJobsHistoryLimit` | How many completed and failed jobs should be kept. See [docs](https://kubernetes.io/docs/tasks/job/automated-tasks-with-cron-jobs/#jobs-history-limits). | `3`                            |

--- a/charts/pro-api/values.yaml
+++ b/charts/pro-api/values.yaml
@@ -1,4 +1,4 @@
-# @section Docker Registry settings
+﻿# @section Docker Registry settings
 
 # @param dgctlDockerRegistry Docker Registry endpoint where On-Premise services' images reside. Format: `host:port`.
 
@@ -119,14 +119,14 @@ vpa:
 
 image:
   repository: 2gis-on-premise/pro-api
-  tag: 1.5.0
+  tag: 1.5.1
   pullPolicy: IfNotPresent
 
 # @skip permissionsApiImage
 
 permissionsApiImage:
   repository: 2gis-on-premise/pro-permissions-api
-  tag: 1.5.0
+  tag: 1.5.1
   pullPolicy: IfNotPresent
 
 # @section 2GIS PRO Storage configuration
@@ -401,7 +401,7 @@ permissionsApi:
 
 assetImporter:
   repository: 2gis-on-premise/pro-importer
-  tag: 1.5.0
+  tag: 1.5.1
   schedule: 0 18 * * *
   backoffLimit: 2
   successfulJobsHistoryLimit: 3
@@ -431,7 +431,7 @@ userAssetImporter:
 
 assetPreparer:
   repository: 2gis-on-premise/pro-importer
-  tag: 1.5.0
+  tag: 1.5.1
   schedule: 0 16 * * 6
   backoffLimit: 2
   successfulJobsHistoryLimit: 1

--- a/image_versions.txt
+++ b/image_versions.txt
@@ -52,10 +52,10 @@ navi-splitter
 platform
 	platform-ui:0.8.1
 pro-api
-	pro-api:1.5.0
-	pro-importer:1.5.0
-	pro-importer:1.5.0
-	pro-permissions-api:1.5.0
+	pro-api:1.5.1
+	pro-importer:1.5.1
+	pro-importer:1.5.1
+	pro-permissions-api:1.5.1
 pro-ui
 	pro-ui:1.9.0
 search-api


### PR DESCRIPTION
Хотфикс проблемы: https://mm.2gis.one/2gis-rd/pl/kmpms8cu1jyfjdcdn3g5jb5qow

>  в pro-api версии 1.5.0 обнаружен баг: при чтении данных из стриминговых ассетов, которые из кафки, происходит лишнее экранирование символов, в итоге получаем вот такое некрасивое что то (см. картинку). Баг поправили, тестируем, будем выпускать фикс в ближайшее время.

Проверить так:
1. Должен быть доступ к ассету `momrah_pollution`
2. Открыть загруженный фрейм. Например:

```
/search/assetId/momrah_pollution/filters/territories-%7B"value"%3A"1"%2C"value_type"%3A"list"%7D%3Bdatetime_utc-%7B"value"%3A"2024-02-27T00%3A00%3A00.000Z%2C2024-02-27T00%3A00%3A00.000Z"%2C"value_type"%3A"date_range"%7D/tab/list/entity/momrah_pollution_6573797/37.596345%2C55.574494/momrah_pollution?m=38.172981%2C55.677585%2F9.24
```

ОР: экранирования в полях не должно быть

<img width="1728" alt="Screenshot 2024-02-28 at 11 50 08" src="https://github.com/2gis/on-premise-helm-charts/assets/108522609/4dc53a1e-e58e-4aef-a7c1-2a8698fd056e">

Changelog:
https://tsup.2gis.dev/pro/pro-api/1.5.1