### PR TITLE
Citylens 1.6.0

### DIFF
--- a/Breaking-Changes.md
+++ b/Breaking-Changes.md
@@ -4,10 +4,12 @@
 
 ### citylens
 
-- Backward compatibility for citylens 1.5.0 is broken:
+- Backward compatibility for citylens 1.6.0 is broken:
   - Parameter `api.auth.camcomToken` is replaced with `api.auth.predictorsTokens.camcom`
   - License v2 service now required: `api.licensing.url`
   - Parameter `map.tileserverUrl` now required
+  - Parameters group `worker.reporterProTracks` now required
+  - Database structure changed
 
 ## [1.17.0]
 

--- a/Breaking-Changes.md
+++ b/Breaking-Changes.md
@@ -1,5 +1,14 @@
 # 2GIS On-Premise Breaking-Changes
 
+## [0.0.0]
+
+### citylens
+
+- Backward compatibility for citylens 1.5.0 is broken:
+  - Parameter `api.auth.camcomToken` is replaced with `api.auth.predictorsTokens.camcom`
+  - License v2 service now required: `api.licensing.url`
+  - Parameter `map.tileserverUrl` now required
+
 ## [1.17.0]
 
 ### citylens

--- a/charts/citylens/Chart.yaml
+++ b/charts/citylens/Chart.yaml
@@ -4,7 +4,7 @@ type: application
 description: A Helm chart for Kubernetes to deploy Citylens service
 
 version: 1.19.0
-appVersion: 1.4.1
+appVersion: 1.5.0
 
 maintainers:
 - name: 2gis

--- a/charts/citylens/Chart.yaml
+++ b/charts/citylens/Chart.yaml
@@ -4,7 +4,7 @@ type: application
 description: A Helm chart for Kubernetes to deploy Citylens service
 
 version: 1.19.0
-appVersion: 1.5.0
+appVersion: 1.5.1
 
 maintainers:
 - name: 2gis

--- a/charts/citylens/Chart.yaml
+++ b/charts/citylens/Chart.yaml
@@ -4,7 +4,7 @@ type: application
 description: A Helm chart for Kubernetes to deploy Citylens service
 
 version: 1.19.0
-appVersion: 1.5.1
+appVersion: 1.6.0
 
 maintainers:
 - name: 2gis

--- a/charts/citylens/templates/api/configmap.yaml
+++ b/charts/citylens/templates/api/configmap.yaml
@@ -39,7 +39,7 @@ data:
       realm: {{ .realm | quote }}
       {{- end}}
       predictor_tokens:
-        {{- .Values.api.auth.predictorsTokens | toYaml | nindent 8 }}
+        {{- .predictorsTokens | toYaml | nindent 8 }}
       {{- end }}
     {{- end }}
     {{- with .Values.api.licensing }}

--- a/charts/citylens/templates/api/configmap.yaml
+++ b/charts/citylens/templates/api/configmap.yaml
@@ -38,10 +38,17 @@ data:
       {{- if .realm }}
       realm: {{ .realm | quote }}
       {{- end}}
-      {{- if .camcomToken }}
-      camcom_token: {{ .camcomToken | quote }}
+      predictor_tokens:
+        {{- .Values.api.auth.predictorsTokens | toYaml | nindent 8 }}
       {{- end }}
+    {{- end }}
+    {{- with .Values.api.licensing }}
+    pasportool:
+      {{- if .enabled }}
+      enabled: {{ .enabled }}
       {{- end }}
+      client_params:
+        endpoint_url: {{ required "A valid .Values.api.licensing.url entry required" .url | quote }}
     {{- end }}
     show_docs: {{ .Values.api.showDocs }}
     log_level: {{ .Values.api.logLevel }}

--- a/charts/citylens/templates/helpers.tpl
+++ b/charts/citylens/templates/helpers.tpl
@@ -33,6 +33,10 @@ Expand the name of the chart.
 {{ include "citylens.name" . }}-reporter-pro
 {{- end }}
 
+{{- define "citylens.reporter-pro-tracks.name" -}}
+{{ include "citylens.name" . }}-reporter-pro-tracks
+{{- end }}
+
 {{- define "citylens.secret.import.name" -}}
 {{ include "citylens.name" . }}-import-secret
 {{- end }}
@@ -110,6 +114,11 @@ app.kubernetes.io/name: {{ .Release.Name }}
 app.kubernetes.io/instance: {{ include "citylens.reporter-pro.name" . }}
 {{- end }}
 
+{{- define "citylens.reporter-pro-tracks.selectorLabels" -}}
+app.kubernetes.io/name: {{ .Release.Name }}
+app.kubernetes.io/instance: {{ include "citylens.reporter-pro-tracks.name" . }}
+{{- end }}
+
 {{- define "citylens.track-reloader.selectorLabels" -}}
 app.kubernetes.io/name: {{ .Release.Name }}
 app.kubernetes.io/instance: {{ include "citylens.track-reloader.name" . }}
@@ -122,6 +131,11 @@ app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 
 {{- define "citylens.reporter-pro.labels" -}}
 {{ include "citylens.reporter-pro.selectorLabels" . }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+
+{{- define "citylens.reporter-pro-tracks.labels" -}}
+{{ include "citylens.reporter-pro-tracks.selectorLabels" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 

--- a/charts/citylens/templates/web/configmap.yaml
+++ b/charts/citylens/templates/web/configmap.yaml
@@ -87,7 +87,7 @@ data:
       verify_ssl: {{ .verifySsl }}
     {{- end }}
     map:
-      tileserver_url_template: {{ required "A valid .Values.map.tileserverUrlTemplate entry required" .Values.map.tileserverUrlTemplate | squote }}
+      tileserver_url_template: {{ required "A valid .Values.map.tileserverUrl entry required" .Values.map.tileserverUrl }}/tiles?x={x}&y={y}&z={z}
       mapgl:
         host: {{ required "A valid .Values.map.mapgl.host entry required" .Values.map.mapgl.host | squote }}
         key: {{ required "A valid .Values.map.mapgl.key entry required" .Values.map.mapgl.key | squote }}

--- a/charts/citylens/templates/web/configmap.yaml
+++ b/charts/citylens/templates/web/configmap.yaml
@@ -104,6 +104,9 @@ data:
         - reload_track
         - reload_statuses
         {{- end }}
+        {{- if .Values.worker.camcomSender.enabled }}
+        - camcom
+        {{- end }}
         {{- if .Values.pro.url }}
         - pro
         {{- end }}

--- a/charts/citylens/templates/web/configmap.yaml
+++ b/charts/citylens/templates/web/configmap.yaml
@@ -87,6 +87,7 @@ data:
       verify_ssl: {{ .verifySsl }}
     {{- end }}
     map:
+      tileserver_url_template: {{ required "A valid .Values.map.tileserverUrlTemplate entry required" .Values.map.tileserverUrlTemplate | squote }}
       mapgl:
         host: {{ required "A valid .Values.map.mapgl.host entry required" .Values.map.mapgl.host | squote }}
         key: {{ required "A valid .Values.map.mapgl.key entry required" .Values.map.mapgl.key | squote }}

--- a/charts/citylens/templates/web/configmap.yaml
+++ b/charts/citylens/templates/web/configmap.yaml
@@ -105,7 +105,7 @@ data:
         - reload_statuses
         {{- end }}
         {{- if .Values.worker.camcomSender.enabled }}
-        - camcom
+        - camcom_stats
         {{- end }}
         {{- if .Values.pro.url }}
         - pro

--- a/charts/citylens/templates/worker/deployment-reporter-pro-tracks.yaml
+++ b/charts/citylens/templates/worker/deployment-reporter-pro-tracks.yaml
@@ -1,0 +1,63 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "citylens.reporter-pro-tracks.name" . }}
+  {{- if .Values.worker.reporterProTracks.annotations }}
+  annotations:
+    {{- toYaml .Values.worker.reporterProTracks.annotations | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- include "citylens.reporter-pro-tracks.labels" . | nindent 4 }}
+  {{- if .Values.worker.reporterProTracks.labels }}
+    {{- toYaml .Values.worker.reporterProTracks.labels | nindent 4 }}
+  {{- end }}
+spec:
+  replicas: {{ .Values.worker.reporterProTracks.replicas }}
+  selector:
+    matchLabels:
+      {{- include "citylens.reporter-pro-tracks.selectorLabels" . | nindent 6 }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/web/configmap.yaml") . | sha256sum }}
+      {{- with .Values.worker.reporterProTracks.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "citylens.reporter-pro-tracks.labels" . | nindent 8 }}
+    spec:
+      containers:
+        - name: {{ include "citylens.reporter-pro-tracks.name" . }}
+          image: {{ required "A valid .Values.dgctlDockerRegistry entry required" .Values.dgctlDockerRegistry }}/{{ .Values.web.image.repository }}:{{ .Values.web.image.tag }}
+          imagePullPolicy: {{ .Values.web.image.pullPolicy }}
+          command: [ "/bin/sh", "-c" ]
+          args: [ "flask reporter run-pro-tracks" ]
+          env:
+            - name: CONFIG_PATH
+              value: /opt/worker/config/dashboard_config.yaml
+          resources:
+            {{- toYaml .Values.worker.resources | nindent 12 }}
+          volumeMounts:
+            - name: config-volume
+              mountPath: /opt/worker/config
+      volumes:
+        - name: config-volume
+          configMap:
+            name: {{ include "citylens.web.name" . }}-configmap
+      {{- with .Values.worker.reporterProTracks.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.worker.reporterProTracks.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.worker.reporterProTracks.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/citylens/values.yaml
+++ b/charts/citylens/values.yaml
@@ -97,7 +97,7 @@ api:
   image:
     repository: 2gis-on-premise/citylens-api
     pullPolicy: IfNotPresent
-    tag: 1.5.0
+    tag: 1.5.1
 
   replicas: 4
 
@@ -224,7 +224,7 @@ web:
   image:
     repository: 2gis-on-premise/citylens-web
     pullPolicy: IfNotPresent
-    tag: 1.5.0
+    tag: 1.5.1
 
   replicas: 1
 

--- a/charts/citylens/values.yaml
+++ b/charts/citylens/values.yaml
@@ -655,6 +655,7 @@ locale: en
 headerLinks:
 - drivers
 - tracks
+- interest_zones
 - map
 
 reporters:

--- a/charts/citylens/values.yaml
+++ b/charts/citylens/values.yaml
@@ -74,7 +74,7 @@ dgctlStorage:
 
 # @section Licensing server settings
 
-# @param api.licensing.url Licensing server v2 URL. http://license.svc. **Required**
+# @param api.licensing.url Licensing server v2 URL. https://license.svc. **Required**
 
 # @section Custom settings
 

--- a/charts/citylens/values.yaml
+++ b/charts/citylens/values.yaml
@@ -622,7 +622,7 @@ postgres:
 
 # @section Map settings
 
-# @param map.tileserverUrlTemplate URL template for tileserver. Ex.: `http://tileserver.host/tiles?x={x}&y={y}&z={z}`
+# @param map.tileserverUrl URL template for tileserver. Ex.: `http://tileserver.host`
 # @param map.mapgl.host Hostname of mapgl server. **Required**
 # @param map.mapgl.key Key of mapgl server. **Required**
 # @param map.projects[0].name Name of project.
@@ -630,7 +630,7 @@ postgres:
 # @param map.initialProject Default project shown on Map.
 
 map:
-  tileserverUrlTemplate: ''
+  tileserverUrl: ''
   mapgl:
     host: ''
     key: ''

--- a/charts/citylens/values.yaml
+++ b/charts/citylens/values.yaml
@@ -67,7 +67,14 @@ dgctlStorage:
 # @param api.auth.authServerUrl API URL of authentication service, OIDC-compatibility expected. Ex.: `http(s)://keycloak.ingress.host/`. **Required**
 # @param api.auth.realm Authentication realm. Used for constructing openid-configuration endpoint: `/realms/realm/.well-known/openid-configuration` if realm defined, `/.well-known/openid-configuration` othervise. Ex: CityLens_app
 # @param api.auth.verifySsl Enable\Disable SSL check.
-# @param api.auth.camcomToken Bearer token, expected on CamCom callback endpoint (if integration with CamCom enabled).
+
+# @section Bearer tokens for callbacks & predictors
+
+# @param api.auth.predictorTokens.camcom Bearer token, expected on CamCom callback endpoint and CamCom prediction endpoint (if integration with CamCom enabled).
+
+# @section Licensing server settings
+
+# @param api.licensing.url Licensing server v2 URL. http://license.svc. **Required**
 
 # @section Custom settings
 
@@ -90,7 +97,7 @@ api:
   image:
     repository: 2gis-on-premise/citylens-api
     pullPolicy: IfNotPresent
-    tag: 1.4.1
+    tag: 1.5.0
 
   replicas: 4
 
@@ -130,7 +137,11 @@ api:
     authServerUrl: ''
     realm: ''
     verifySsl: true
-    camcomToken: ''
+    predictorTokens:
+      camcom: ''
+
+  licensing:
+    url: ''
 
   showDocs: false
 
@@ -213,7 +224,7 @@ web:
   image:
     repository: 2gis-on-premise/citylens-web
     pullPolicy: IfNotPresent
-    tag: 1.4.1
+    tag: 1.5.0
 
   replicas: 1
 
@@ -525,7 +536,7 @@ migrations:
   image:
     repository: 2gis-on-premise/citylens-database
     pullPolicy: IfNotPresent
-    tag: 1.2.0
+    tag: 1.5.0
 
   resources:
     requests:
@@ -611,6 +622,7 @@ postgres:
 
 # @section Map settings
 
+# @param map.tileserverUrlTemplate URL template for tileserver. Ex.: `http://tileserver.host/tiles?x={x}&y={y}&z={z}`
 # @param map.mapgl.host Hostname of mapgl server. **Required**
 # @param map.mapgl.key Key of mapgl server. **Required**
 # @param map.projects[0].name Name of project.
@@ -618,6 +630,7 @@ postgres:
 # @param map.initialProject Default project shown on Map.
 
 map:
+  tileserverUrlTemplate: ''
   mapgl:
     host: ''
     key: ''

--- a/charts/citylens/values.yaml
+++ b/charts/citylens/values.yaml
@@ -70,7 +70,7 @@ dgctlStorage:
 
 # @section Bearer tokens for callbacks & predictors
 
-# @param api.auth.predictorTokens.camcom Bearer token, expected on CamCom callback endpoint and CamCom prediction endpoint (if integration with CamCom enabled).
+# @param api.auth.predictorsTokens.camcom Bearer token, expected on CamCom callback endpoint and CamCom prediction endpoint (if integration with CamCom enabled).
 
 # @section Licensing server settings
 
@@ -137,7 +137,7 @@ api:
     authServerUrl: ''
     realm: ''
     verifySsl: true
-    predictorTokens:
+    predictorsTokens:
       camcom: ''
 
   licensing:

--- a/charts/citylens/values.yaml
+++ b/charts/citylens/values.yaml
@@ -97,7 +97,7 @@ api:
   image:
     repository: 2gis-on-premise/citylens-api
     pullPolicy: IfNotPresent
-    tag: 1.5.1
+    tag: 1.6.0
 
   replicas: 4
 
@@ -224,7 +224,7 @@ web:
   image:
     repository: 2gis-on-premise/citylens-web
     pullPolicy: IfNotPresent
-    tag: 1.5.1
+    tag: 1.6.0
 
   replicas: 1
 
@@ -425,7 +425,7 @@ worker:
     affinity: {}
     tolerations: {}
 
-# @section Citylens Reporter Pro worker's settings
+# @section Citylens Reporter Pro worker's settings (synchronization with Pro)
 
 # @param worker.reporterPro.replicas A replica count for the pod.
 
@@ -439,6 +439,31 @@ worker:
 # @param worker.reporterPro.affinity Kubernetes pod [affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity) settings.
 
   reporterPro:
+
+    replicas: 1
+
+    annotations: {}
+    labels: {}
+    podAnnotations: {}
+    podLabels: {}
+    nodeSelector: {}
+    affinity: {}
+    tolerations: {}
+
+# @section Citylens Reporter Pro Tracks worker's settings (track status actualization)
+
+# @param worker.reporterProTracks.replicas A replica count for the pod.
+
+# @param worker.reporterProTracks.annotations Kubernetes [annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/).
+# @param worker.reporterProTracks.labels Kubernetes [labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/).
+# @param worker.reporterProTracks.podAnnotations Kubernetes [annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/).
+# @param worker.reporterProTracks.podLabels Kubernetes [labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/).
+
+# @param worker.reporterProTracks.nodeSelector Kubernetes pod [node selectors](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector).
+# @param worker.reporterProTracks.tolerations Kubernetes pod [tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) settings.
+# @param worker.reporterProTracks.affinity Kubernetes pod [affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity) settings.
+
+  reporterProTracks:
 
     replicas: 1
 
@@ -536,7 +561,7 @@ migrations:
   image:
     repository: 2gis-on-premise/citylens-database
     pullPolicy: IfNotPresent
-    tag: 1.5.0
+    tag: 1.6.0
 
   resources:
     requests:


### PR DESCRIPTION
Changelog:
  - citylens-api:
      - licensing server required (`.Values.api.licensing`)
      - running as non-root user in container
  - citylens-web:
      - tile server required (`.Values.map.tileserverUrlTemplate`)
      - new reporter-pro-tracks worker (required)
  - citylens-database:
      - running as non-root user in container

min_data_verson: 2
max_data_version: 2