### PR TITLE
[navi-router] rename router.keyManagementServices to keys

### DIFF
--- a/Breaking-Changes.md
+++ b/Breaking-Changes.md
@@ -1,5 +1,11 @@
 # 2GIS On-Premise Breaking-Changes
 
+## [NEXT-VERSION]
+
+### navi-router
+- `router.keyManagementService.host` renamed to `router.keyManagementService.url`
+- `router.keyManagementService` renamed to `keys`
+
 ## [1.17.0]
 
 ### citylens

--- a/Breaking-Changes.md
+++ b/Breaking-Changes.md
@@ -5,6 +5,7 @@
 ### navi-router
 - `router.keyManagementService.host` renamed to `router.keyManagementService.url`
 - `router.keyManagementService` renamed to `keys`
+- `router.castleHost` renamed to `router.castleUrl`
 
 ## [1.17.0]
 

--- a/charts/navi-router/README.md
+++ b/charts/navi-router/README.md
@@ -56,7 +56,7 @@ See the [documentation](https://docs.2gis.com/en/on-premise/navigation) to learn
 | `router.appPort`            | Navi-Router service HTTP port                                                                                                               | `8080`      |
 | `router.logLevel`           | Logging level, one of: Verbose, Info, Warning, Error, Fatal. Default: `Warning`                                                             | `Warning`   |
 | `router.additionalSections` | Additional configurations sections for the Navi-Router service                                                                              | `""`        |
-| `router.castleHost`         | URL of Navi-Castle service, ex: http://navi-castle.svc. <br> This URL should be accessible from all the pods within your Kubernetes cluster | `""`        |
+| `router.castleUrl`          | URL of Navi-Castle service, ex: http://navi-castle.svc. <br> This URL should be accessible from all the pods within your Kubernetes cluster | `""`        |
 | `keys.enabled`              | Disable or enable key management service                                                                                                    | `false`     |
 | `keys.url`                  | key management service server URL                                                                                                           | `""`        |
 | `keys.refreshIntervalSec`   | Keys refresh interval in seconds                                                                                                            | `30`        |

--- a/charts/navi-router/README.md
+++ b/charts/navi-router/README.md
@@ -51,18 +51,18 @@ See the [documentation](https://docs.2gis.com/en/on-premise/navigation) to learn
 
 ### Navi-Router service settings
 
-| Name                                             | Description                                                                                                                                 | Value                         |
-| ------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------- |
-| `router.appPort`                                 | Navi-Router service HTTP port                                                                                                               | `8080`                        |
-| `router.logLevel`                                | Logging level, one of: Verbose, Info, Warning, Error, Fatal. Default: `Warning`                                                             | `Warning`                     |
-| `router.additionalSections`                      | Additional configurations sections for the Navi-Router service                                                                              | `""`                          |
-| `router.castleHost`                              | URL of Navi-Castle service, ex: http://navi-castle.svc. <br> This URL should be accessible from all the pods within your Kubernetes cluster | `""`                          |
-| `router.keyManagementService.enabled`            | Disable or enable key management service                                                                                                    | `false`                       |
-| `router.keyManagementService.host`               | Address if key management service server                                                                                                    | `http://keys.api.example.com` |
-| `router.keyManagementService.refreshIntervalSec` | Keys refresh interval in seconds                                                                                                            | `30`                          |
-| `router.keyManagementService.downloadTimeoutSec` | Keys download timeout in seconds                                                                                                            | `30`                          |
-| `router.keyManagementService.commonToken`        | Mater key to retrieve all per-service API keys, router.keyManagementService.apis ignored, if commonToken set                                | `""`                          |
-| `router.keyManagementService.apis`               | Used API types and their tokens. Format: `type: token`                                                                                      | `undefined`                   |
+| Name                        | Description                                                                                                                                 | Value       |
+| --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| `router.appPort`            | Navi-Router service HTTP port                                                                                                               | `8080`      |
+| `router.logLevel`           | Logging level, one of: Verbose, Info, Warning, Error, Fatal. Default: `Warning`                                                             | `Warning`   |
+| `router.additionalSections` | Additional configurations sections for the Navi-Router service                                                                              | `""`        |
+| `router.castleHost`         | URL of Navi-Castle service, ex: http://navi-castle.svc. <br> This URL should be accessible from all the pods within your Kubernetes cluster | `""`        |
+| `keys.enabled`              | Disable or enable key management service                                                                                                    | `false`     |
+| `keys.url`                  | key management service server URL                                                                                                           | `""`        |
+| `keys.refreshIntervalSec`   | Keys refresh interval in seconds                                                                                                            | `30`        |
+| `keys.downloadTimeoutSec`   | Keys download timeout in seconds                                                                                                            | `30`        |
+| `keys.commonToken`          | Mater key to retrieve all per-service API keys, keys.apis ignored, if commonToken set                                                       | `""`        |
+| `keys.apis`                 | Used API types and their tokens. Format: `type: token`                                                                                      | `undefined` |
 
 ### Service account settings
 

--- a/charts/navi-router/README.md
+++ b/charts/navi-router/README.md
@@ -22,24 +22,24 @@ See the [documentation](https://docs.2gis.com/en/on-premise/navigation) to learn
 
 ### Docker Registry settings
 
-| Name                  | Description                                                                             | Value |
-| --------------------- | --------------------------------------------------------------------------------------- | ----- |
-| `dgctlDockerRegistry` | Docker Registry endpoint where On-Premise services' images reside. Format: `host:port`. | `""`  |
+| Name                  | Description                                                                            | Value |
+| --------------------- | -------------------------------------------------------------------------------------- | ----- |
+| `dgctlDockerRegistry` | Docker Registry endpoint where On-Premise services' images reside. Format: `host:port` | `""`  |
 
 ### Common settings
 
-| Name                 | Description                                                                                                                 | Value |
-| -------------------- | --------------------------------------------------------------------------------------------------------------------------- | ----- |
-| `replicaCount`       | A replica count for the pod.                                                                                                | `1`   |
-| `imagePullSecrets`   | Kubernetes image pull secrets.                                                                                              | `[]`  |
-| `nameOverride`       | Base name to use in all the Kubernetes entities deployed by this chart.                                                     | `""`  |
-| `fullnameOverride`   | Base fullname to use in all the Kubernetes entities deployed by this chart.                                                 | `""`  |
-| `podAnnotations`     | Kubernetes [pod annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/).               | `{}`  |
-| `podSecurityContext` | Kubernetes [pod security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/).              | `{}`  |
-| `securityContext`    | Kubernetes [security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/).                  | `{}`  |
-| `nodeSelector`       | Kubernetes [node selectors](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector).         | `{}`  |
-| `tolerations`        | Kubernetes [tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) settings.           | `[]`  |
-| `affinity`           | Kubernetes pod [affinity settings](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity). | `{}`  |
+| Name                 | Description                                                                                                                | Value |
+| -------------------- | -------------------------------------------------------------------------------------------------------------------------- | ----- |
+| `replicaCount`       | A replica count for the pod                                                                                                | `1`   |
+| `imagePullSecrets`   | Kubernetes image pull secrets                                                                                              | `[]`  |
+| `nameOverride`       | Base name to use in all the Kubernetes entities deployed by this chart                                                     | `""`  |
+| `fullnameOverride`   | Base fullname to use in all the Kubernetes entities deployed by this chart                                                 | `""`  |
+| `podAnnotations`     | Kubernetes [pod annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/)               | `{}`  |
+| `podSecurityContext` | Kubernetes [pod security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/)              | `{}`  |
+| `securityContext`    | Kubernetes [security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/)                  | `{}`  |
+| `nodeSelector`       | Kubernetes [node selectors](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector)         | `{}`  |
+| `tolerations`        | Kubernetes [tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) settings           | `[]`  |
+| `affinity`           | Kubernetes pod [affinity settings](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity) | `{}`  |
 
 ### Deployment settings
 
@@ -51,95 +51,95 @@ See the [documentation](https://docs.2gis.com/en/on-premise/navigation) to learn
 
 ### Navi-Router service settings
 
-| Name                                             | Description                                                                                                                                  | Value                         |
-| ------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------- |
-| `router.appPort`                                 | Navi-Router service HTTP port.                                                                                                               | `8080`                        |
-| `router.logLevel`                                | Logging level, one of: Verbose, Info, Warning, Error, Fatal. Default: `Warning`                                                              | `Warning`                     |
-| `router.additionalSections`                      | Additional configurations sections for the Navi-Router service.                                                                              | `""`                          |
-| `router.castleHost`                              | URL of Navi-Castle service, ex: http://navi-castle.svc. <br> This URL should be accessible from all the pods within your Kubernetes cluster. | `""`                          |
-| `router.keyManagementService.enabled`            | Disable or enable key management service                                                                                                     | `false`                       |
-| `router.keyManagementService.host`               | Address if key management service server                                                                                                     | `http://keys.api.example.com` |
-| `router.keyManagementService.refreshIntervalSec` | Keys refresh interval in seconds                                                                                                             | `30`                          |
-| `router.keyManagementService.downloadTimeoutSec` | Keys download timeout in seconds                                                                                                             | `30`                          |
-| `router.keyManagementService.commonToken`        | Mater key to retrieve all per-service API keys, router.keyManagementService.apis ignored, if commonToken set                                 | `""`                          |
-| `router.keyManagementService.apis`               | Used API types and their tokens. Format: `type: token`                                                                                       | `undefined`                   |
+| Name                                             | Description                                                                                                                                 | Value                         |
+| ------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------- |
+| `router.appPort`                                 | Navi-Router service HTTP port                                                                                                               | `8080`                        |
+| `router.logLevel`                                | Logging level, one of: Verbose, Info, Warning, Error, Fatal. Default: `Warning`                                                             | `Warning`                     |
+| `router.additionalSections`                      | Additional configurations sections for the Navi-Router service                                                                              | `""`                          |
+| `router.castleHost`                              | URL of Navi-Castle service, ex: http://navi-castle.svc. <br> This URL should be accessible from all the pods within your Kubernetes cluster | `""`                          |
+| `router.keyManagementService.enabled`            | Disable or enable key management service                                                                                                    | `false`                       |
+| `router.keyManagementService.host`               | Address if key management service server                                                                                                    | `http://keys.api.example.com` |
+| `router.keyManagementService.refreshIntervalSec` | Keys refresh interval in seconds                                                                                                            | `30`                          |
+| `router.keyManagementService.downloadTimeoutSec` | Keys download timeout in seconds                                                                                                            | `30`                          |
+| `router.keyManagementService.commonToken`        | Mater key to retrieve all per-service API keys, router.keyManagementService.apis ignored, if commonToken set                                | `""`                          |
+| `router.keyManagementService.apis`               | Used API types and their tokens. Format: `type: token`                                                                                      | `undefined`                   |
 
 ### Service account settings
 
-| Name                         | Description                                                                                                             | Value   |
-| ---------------------------- | ----------------------------------------------------------------------------------------------------------------------- | ------- |
-| `serviceAccount.create`      | Specifies whether a service account should be created.                                                                  | `false` |
-| `serviceAccount.annotations` | Annotations to add to the service account.                                                                              | `{}`    |
-| `serviceAccount.name`        | The name of the service account to use. If not set and create is true, a name is generated using the fullname template. | `""`    |
+| Name                         | Description                                                                                                            | Value   |
+| ---------------------------- | ---------------------------------------------------------------------------------------------------------------------- | ------- |
+| `serviceAccount.create`      | Specifies whether a service account should be created                                                                  | `false` |
+| `serviceAccount.annotations` | Annotations to add to the service account                                                                              | `{}`    |
+| `serviceAccount.name`        | The name of the service account to use. If not set and create is true, a name is generated using the fullname template | `""`    |
 
 ### Strategy settings
 
-| Name                                    | Description                                                                                                                                                                                              | Value           |
-| --------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------- |
-| `strategy.type`                         | Type of Kubernetes deployment. Can be `Recreate` or `RollingUpdate`.                                                                                                                                     | `RollingUpdate` |
-| `strategy.rollingUpdate.maxUnavailable` | Maximum number of pods that can be created over the desired number of pods when doing [rolling update](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#rolling-update-deployment). | `0`             |
-| `strategy.rollingUpdate.maxSurge`       | Maximum number of pods that can be unavailable during the [rolling update](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#rolling-update-deployment) process.                     | `1`             |
+| Name                                    | Description                                                                                                                                                                                             | Value           |
+| --------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------- |
+| `strategy.type`                         | Type of Kubernetes deployment. Can be `Recreate` or `RollingUpdate`                                                                                                                                     | `RollingUpdate` |
+| `strategy.rollingUpdate.maxUnavailable` | Maximum number of pods that can be created over the desired number of pods when doing [rolling update](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#rolling-update-deployment) | `0`             |
+| `strategy.rollingUpdate.maxSurge`       | Maximum number of pods that can be unavailable during the [rolling update](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#rolling-update-deployment) process                     | `1`             |
 
 ### Service settings
 
-| Name                  | Description                                                                                                                    | Value       |
-| --------------------- | ------------------------------------------------------------------------------------------------------------------------------ | ----------- |
-| `service.type`        | Kubernetes [service type](https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types). | `ClusterIP` |
-| `service.port`        | Service port.                                                                                                                  | `80`        |
-| `service.annotations` | Kubernetes [service annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/).              | `{}`        |
-| `service.labels`      | Kubernetes [service labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/).                        | `nil`       |
+| Name                  | Description                                                                                                                   | Value       |
+| --------------------- | ----------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| `service.type`        | Kubernetes [service type](https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types) | `ClusterIP` |
+| `service.port`        | Service port                                                                                                                  | `80`        |
+| `service.annotations` | Kubernetes [service annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/)              | `{}`        |
+| `service.labels`      | Kubernetes [service labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/)                        | `nil`       |
 
 ### Kubernetes [Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) settings
 
-| Name                                 | Description                               | Value                     |
-| ------------------------------------ | ----------------------------------------- | ------------------------- |
-| `ingress.enabled`                    | If Ingress is enabled for the service.    | `false`                   |
-| `ingress.className`                  | Name of the Ingress controller class.     | `nginx`                   |
-| `ingress.hosts[0].host`              | Hostname for the Ingress service.         | `navi-router.example.com` |
-| `ingress.hosts[0].paths[0].path`     | Path of the host for the Ingress service. | `/`                       |
-| `ingress.hosts[0].paths[0].pathType` | Type of the path for the Ingress service. | `Prefix`                  |
-| `ingress.tls`                        | TLS configuration                         | `[]`                      |
+| Name                                 | Description                              | Value                     |
+| ------------------------------------ | ---------------------------------------- | ------------------------- |
+| `ingress.enabled`                    | If Ingress is enabled for the service    | `false`                   |
+| `ingress.className`                  | Name of the Ingress controller class     | `nginx`                   |
+| `ingress.hosts[0].host`              | Hostname for the Ingress service         | `navi-router.example.com` |
+| `ingress.hosts[0].paths[0].path`     | Path of the host for the Ingress service | `/`                       |
+| `ingress.hosts[0].paths[0].pathType` | Type of the path for the Ingress service | `Prefix`                  |
+| `ingress.tls`                        | TLS configuration                        | `[]`                      |
 
 ### Limits
 
-| Name                        | Description                                 | Value       |
-| --------------------------- | ------------------------------------------- | ----------- |
-| `resources`                 | Container resources requirements structure. | `{}`        |
-| `resources.requests.cpu`    | CPU request, recommended value `500m`.      | `undefined` |
-| `resources.requests.memory` | Memory request, recommended value `384Mi`.  | `undefined` |
-| `resources.limits.cpu`      | CPU limit, recommended value `1000m`.       | `undefined` |
-| `resources.limits.memory`   | Memory limit, recommended value `768Mi`.    | `undefined` |
+| Name                        | Description                                | Value       |
+| --------------------------- | ------------------------------------------ | ----------- |
+| `resources`                 | Container resources requirements structure | `{}`        |
+| `resources.requests.cpu`    | CPU request, recommended value `500m`      | `undefined` |
+| `resources.requests.memory` | Memory request, recommended value `384Mi`  | `undefined` |
+| `resources.limits.cpu`      | CPU limit, recommended value `1000m`       | `undefined` |
+| `resources.limits.memory`   | Memory limit, recommended value `768Mi`    | `undefined` |
 
 ### Kubernetes [Horizontal Pod Autoscaling](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/) settings
 
-| Name                                      | Description                                                                                                                                                          | Value   |
-| ----------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
-| `hpa.enabled`                             | If HPA is enabled for the service.                                                                                                                                   | `false` |
-| `hpa.minReplicas`                         | Lower limit for the number of replicas to which the autoscaler can scale down.                                                                                       | `1`     |
-| `hpa.maxReplicas`                         | Upper limit for the number of replicas to which the autoscaler can scale up.                                                                                         | `100`   |
-| `hpa.scaleDownStabilizationWindowSeconds` | Scale-down window.                                                                                                                                                   | `""`    |
-| `hpa.scaleUpStabilizationWindowSeconds`   | Scale-up window.                                                                                                                                                     | `""`    |
-| `hpa.targetCPUUtilizationPercentage`      | Target average CPU utilization (represented as a percentage of requested CPU) over all the pods; if not specified the default autoscaling policy will be used.       | `80`    |
-| `hpa.targetMemoryUtilizationPercentage`   | Target average memory utilization (represented as a percentage of requested memory) over all the pods; if not specified the default autoscaling policy will be used. | `""`    |
+| Name                                      | Description                                                                                                                                                         | Value   |
+| ----------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| `hpa.enabled`                             | If HPA is enabled for the service                                                                                                                                   | `false` |
+| `hpa.minReplicas`                         | Lower limit for the number of replicas to which the autoscaler can scale down                                                                                       | `1`     |
+| `hpa.maxReplicas`                         | Upper limit for the number of replicas to which the autoscaler can scale up                                                                                         | `100`   |
+| `hpa.scaleDownStabilizationWindowSeconds` | Scale-down window                                                                                                                                                   | `""`    |
+| `hpa.scaleUpStabilizationWindowSeconds`   | Scale-up window                                                                                                                                                     | `""`    |
+| `hpa.targetCPUUtilizationPercentage`      | Target average CPU utilization (represented as a percentage of requested CPU) over all the pods; if not specified the default autoscaling policy will be used       | `80`    |
+| `hpa.targetMemoryUtilizationPercentage`   | Target average memory utilization (represented as a percentage of requested memory) over all the pods; if not specified the default autoscaling policy will be used | `""`    |
 
 ### Kubernetes [Pod Disruption Budget](https://kubernetes.io/docs/concepts/workloads/pods/disruptions/#pod-disruption-budgets) settings
 
-| Name                 | Description                                          | Value   |
-| -------------------- | ---------------------------------------------------- | ------- |
-| `pdb.enabled`        | If PDB is enabled for the service.                   | `false` |
-| `pdb.minAvailable`   | How many pods must be available after the eviction.  | `""`    |
-| `pdb.maxUnavailable` | How many pods can be unavailable after the eviction. | `1`     |
+| Name                 | Description                                         | Value   |
+| -------------------- | --------------------------------------------------- | ------- |
+| `pdb.enabled`        | If PDB is enabled for the service                   | `false` |
+| `pdb.minAvailable`   | How many pods must be available after the eviction  | `""`    |
+| `pdb.maxUnavailable` | How many pods can be unavailable after the eviction | `1`     |
 
 ### Kubernetes [Vertical Pod Autoscaling](https://github.com/kubernetes/autoscaler/blob/master/vertical-pod-autoscaler/README.md) settings
 
-| Name                    | Description                                                                                                  | Value   |
-| ----------------------- | ------------------------------------------------------------------------------------------------------------ | ------- |
-| `vpa.enabled`           | If VPA is enabled for the service.                                                                           | `false` |
-| `vpa.updateMode`        | VPA [update mode](https://github.com/kubernetes/autoscaler/tree/master/vertical-pod-autoscaler#quick-start). | `Auto`  |
-| `vpa.minAllowed.cpu`    | Lower limit for the number of CPUs to which the autoscaler can scale down.                                   | `500m`  |
-| `vpa.minAllowed.memory` | Lower limit for the RAM size to which the autoscaler can scale down.                                         | `128Mi` |
-| `vpa.maxAllowed.cpu`    | Upper limit for the number of CPUs to which the autoscaler can scale up.                                     | `2000`  |
-| `vpa.maxAllowed.memory` | Upper limit for the RAM size to which the autoscaler can scale up.                                           | `512Mi` |
+| Name                    | Description                                                                                                 | Value   |
+| ----------------------- | ----------------------------------------------------------------------------------------------------------- | ------- |
+| `vpa.enabled`           | If VPA is enabled for the service                                                                           | `false` |
+| `vpa.updateMode`        | VPA [update mode](https://github.com/kubernetes/autoscaler/tree/master/vertical-pod-autoscaler#quick-start) | `Auto`  |
+| `vpa.minAllowed.cpu`    | Lower limit for the number of CPUs to which the autoscaler can scale down                                   | `500m`  |
+| `vpa.minAllowed.memory` | Lower limit for the RAM size to which the autoscaler can scale down                                         | `128Mi` |
+| `vpa.maxAllowed.cpu`    | Upper limit for the number of CPUs to which the autoscaler can scale up                                     | `2000`  |
+| `vpa.maxAllowed.memory` | Upper limit for the RAM size to which the autoscaler can scale up                                           | `512Mi` |
 
 
 ## Maintainers

--- a/charts/navi-router/templates/_helpers.tpl
+++ b/charts/navi-router/templates/_helpers.tpl
@@ -130,5 +130,6 @@ Check for deprecated values
 {{- if not ("1.19.0" | get ((.Values.debug).disableDeprecationChecks | default dict) ) }}
 {{- if .Values.router.keyManagementService -}}{{ fail "[after 1.19.0] .Values.router.keyManagementService renamed to .Values.keys" }}{{- end }}
 {{- if .Values.keys.host -}}{{ fail "[after 1.19.0] .Values.router.keys.host renamed to .Values.keys.url" }}{{- end }}
+{{- if .Values.router.castleHost -}}{{ fail "[after 1.19.0] .Values.castleHost renamed to .Values.castleUrl" }}{{- end }}
 {{- end }} {{/* 1.19.0 */}}
 {{- end }}

--- a/charts/navi-router/templates/_helpers.tpl
+++ b/charts/navi-router/templates/_helpers.tpl
@@ -122,3 +122,13 @@ Return the appropriate apiVersion for Horizontal Pod Autoscaler.
 {{- print "autoscaling/v2" -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Check for deprecated values
+*/}}
+{{- define "check.deprecated.values" -}}
+{{- if not ("1.19.0" | get ((.Values.debug).disableDeprecationChecks | default dict) ) }}
+{{- if .Values.router.keyManagementService -}}{{ fail "[after 1.19.0] .Values.router.keyManagementService renamed to .Values.keys" }}{{- end }}
+{{- if .Values.keys.host -}}{{ fail "[after 1.19.0] .Values.router.keys.host renamed to .Values.keys.url" }}{{- end }}
+{{- end }} {{/* 1.19.0 */}}
+{{- end }}

--- a/charts/navi-router/templates/configmap.yaml
+++ b/charts/navi-router/templates/configmap.yaml
@@ -65,12 +65,12 @@ data:
                 {"type" : "pairs-directions-api", "value" : 50}
             ]
         }
-        {{- with .Values.router.keyManagementService }}
+        {{- with .Values.keys }}
         {{- if .enabled }}
         {{ println "," }}
         "key_management_service" :
         {
-          "service_remote_address" : {{ .host | quote }},
+          "service_remote_address" : {{ required "A valid .Values.keys.url entry required" .url | quote }},
           "keys_refresh_interval_sec" : {{ .refreshIntervalSec | int }},
           "keys_download_timeout_sec" : {{ .downloadTimeoutSec | int }}
         }

--- a/charts/navi-router/templates/configmap.yaml
+++ b/charts/navi-router/templates/configmap.yaml
@@ -34,13 +34,13 @@ data:
       "context": {
         "variables": {
           "LOCAL_ETC": "/src/etc",
-          "REMOTE_PATH": "{{ required "A valid .Values.router.castleHost  entry required!" .Values.router.castleHost }}",
+          "REMOTE_PATH": "{{ required "A valid .Values.router.castleUrl  entry required!" .Values.router.castleUrl }}",
           "LOCAL_PATH": "/var/lib/2gis/castle/"
         },
         "cities": {
           "update_period": 600,
           "nodes": [
-            "http://{REMOTE_PATH}/cities.conf.zip"
+            "{REMOTE_PATH}/cities.conf.zip"
           ],
           "timeout_seconds": {
             "count": 60

--- a/charts/navi-router/templates/deployment.yaml
+++ b/charts/navi-router/templates/deployment.yaml
@@ -74,7 +74,7 @@ spec:
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           env:
-            {{- range $type, $token := (.Values.router.keyManagementService).apis }}
+            {{- range $type, $token := (.Values.keys).apis }}
             {{- if $token }}
             - name: {{ $type | replace "-" "_" | upper | quote }}
               valueFrom:
@@ -83,7 +83,7 @@ spec:
                   key: {{ $type | quote }}
             {{- end }}{{- /* if $token */}}
             {{- end }}{{- /* range $type, $token */}}
-            {{- if (.Values.router.keyManagementService).commonToken }}
+            {{- if (.Values.keys).commonToken }}
             - name: COMMON_TOKEN
               valueFrom:
                 secretKeyRef:

--- a/charts/navi-router/templates/secret.yaml
+++ b/charts/navi-router/templates/secret.yaml
@@ -1,3 +1,4 @@
+{{- include "check.deprecated.values" . }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -9,7 +10,7 @@ metadata:
     {{- end }}
 type: Opaque
 data:
-  {{- range $type, $token := (.Values.router.keyManagementService).apis }}
+  {{- range $type, $token := (.Values.keys).apis }}
   {{ $type | quote }}: {{ $token | b64enc | quote }}
   {{- end }}
-  common_token: {{ (.Values.router.keyManagementService).commonToken | default "" | b64enc | quote }}
+  common_token: {{ (.Values.keys).commonToken | default "" | b64enc | quote }}

--- a/charts/navi-router/values.yaml
+++ b/charts/navi-router/values.yaml
@@ -48,36 +48,37 @@ image:
 # @param router.logLevel Logging level, one of: Verbose, Info, Warning, Error, Fatal. Default: `Warning`
 # @param router.additionalSections Additional configurations sections for the Navi-Router service
 # @param router.castleHost URL of Navi-Castle service, ex: http://navi-castle.svc. <br> This URL should be accessible from all the pods within your Kubernetes cluster
-# @param router.keyManagementService.enabled Disable or enable key management service
-# @param router.keyManagementService.host Address if key management service server
-# @param router.keyManagementService.refreshIntervalSec Keys refresh interval in seconds
-# @param router.keyManagementService.downloadTimeoutSec Keys download timeout in seconds
-# @param router.keyManagementService.commonToken Mater key to retrieve all per-service API keys, router.keyManagementService.apis ignored, if commonToken set
-# @param router.keyManagementService.apis [nullable] Used API types and their tokens. Format: `type: token`
 
 router:
   appPort: 8080
   logLevel: Warning
   additionalSections: ''
   castleHost: ''
-  keyManagementService:
-    enabled: false
-    host: http://keys.api.example.com
-    refreshIntervalSec: 30
-    downloadTimeoutSec: 30
-    commonToken: ''
-    apis:
-      comboroutes-api: ''
-      directions-api: ''
-      distance-matrix-api: ''
-      freeroam-api: ''
-      isochrone-api: ''
-      map-matching-api: ''
-      pairs-directions-api: ''
-      ppnot-api: ''
-      public-transport-api: ''
-      truck-directions-api: ''
-      truck-distance-matrix-api: ''
+
+# @param keys.enabled Disable or enable key management service
+# @param keys.url key management service server URL
+# @param keys.refreshIntervalSec Keys refresh interval in seconds
+# @param keys.downloadTimeoutSec Keys download timeout in seconds
+# @param keys.commonToken Mater key to retrieve all per-service API keys, keys.apis ignored, if commonToken set
+# @param keys.apis [nullable] Used API types and their tokens. Format: `type: token`
+keys:
+  enabled: false
+  url: ''
+  refreshIntervalSec: 30
+  downloadTimeoutSec: 30
+  commonToken: ''
+  apis:
+    comboroutes-api: ''
+    directions-api: ''
+    distance-matrix-api: ''
+    freeroam-api: ''
+    isochrone-api: ''
+    map-matching-api: ''
+    pairs-directions-api: ''
+    ppnot-api: ''
+    public-transport-api: ''
+    truck-directions-api: ''
+    truck-distance-matrix-api: ''
 
 
 # @section Service account settings

--- a/charts/navi-router/values.yaml
+++ b/charts/navi-router/values.yaml
@@ -1,22 +1,22 @@
 # @section Docker Registry settings
 
-# @param dgctlDockerRegistry Docker Registry endpoint where On-Premise services' images reside. Format: `host:port`.
+# @param dgctlDockerRegistry Docker Registry endpoint where On-Premise services' images reside. Format: `host:port`
 
 dgctlDockerRegistry: ''
 
 
 # @section Common settings
 
-# @param replicaCount A replica count for the pod.
-# @param imagePullSecrets Kubernetes image pull secrets.
-# @param nameOverride Base name to use in all the Kubernetes entities deployed by this chart.
-# @param fullnameOverride Base fullname to use in all the Kubernetes entities deployed by this chart.
-# @param podAnnotations Kubernetes [pod annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/).
-# @param podSecurityContext Kubernetes [pod security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/).
-# @param securityContext Kubernetes [security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/).
-# @param nodeSelector Kubernetes [node selectors](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector).
-# @param tolerations Kubernetes [tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) settings.
-# @param affinity Kubernetes pod [affinity settings](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity).
+# @param replicaCount A replica count for the pod
+# @param imagePullSecrets Kubernetes image pull secrets
+# @param nameOverride Base name to use in all the Kubernetes entities deployed by this chart
+# @param fullnameOverride Base fullname to use in all the Kubernetes entities deployed by this chart
+# @param podAnnotations Kubernetes [pod annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/)
+# @param podSecurityContext Kubernetes [pod security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/)
+# @param securityContext Kubernetes [security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/)
+# @param nodeSelector Kubernetes [node selectors](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector)
+# @param tolerations Kubernetes [tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) settings
+# @param affinity Kubernetes pod [affinity settings](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity)
 
 replicaCount: 1
 imagePullSecrets: []
@@ -44,10 +44,10 @@ image:
 
 # @section Navi-Router service settings
 
-# @param router.appPort Navi-Router service HTTP port.
+# @param router.appPort Navi-Router service HTTP port
 # @param router.logLevel Logging level, one of: Verbose, Info, Warning, Error, Fatal. Default: `Warning`
-# @param router.additionalSections Additional configurations sections for the Navi-Router service.
-# @param router.castleHost URL of Navi-Castle service, ex: http://navi-castle.svc. <br> This URL should be accessible from all the pods within your Kubernetes cluster.
+# @param router.additionalSections Additional configurations sections for the Navi-Router service
+# @param router.castleHost URL of Navi-Castle service, ex: http://navi-castle.svc. <br> This URL should be accessible from all the pods within your Kubernetes cluster
 # @param router.keyManagementService.enabled Disable or enable key management service
 # @param router.keyManagementService.host Address if key management service server
 # @param router.keyManagementService.refreshIntervalSec Keys refresh interval in seconds
@@ -82,9 +82,9 @@ router:
 
 # @section Service account settings
 
-# @param serviceAccount.create Specifies whether a service account should be created.
-# @param serviceAccount.annotations Annotations to add to the service account.
-# @param serviceAccount.name The name of the service account to use. If not set and create is true, a name is generated using the fullname template.
+# @param serviceAccount.create Specifies whether a service account should be created
+# @param serviceAccount.annotations Annotations to add to the service account
+# @param serviceAccount.name The name of the service account to use. If not set and create is true, a name is generated using the fullname template
 
 serviceAccount:
   create: false
@@ -94,9 +94,9 @@ serviceAccount:
 
 # @section Strategy settings
 
-# @param strategy.type Type of Kubernetes deployment. Can be `Recreate` or `RollingUpdate`.
-# @param strategy.rollingUpdate.maxUnavailable Maximum number of pods that can be created over the desired number of pods when doing [rolling update](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#rolling-update-deployment).
-# @param strategy.rollingUpdate.maxSurge Maximum number of pods that can be unavailable during the [rolling update](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#rolling-update-deployment) process.
+# @param strategy.type Type of Kubernetes deployment. Can be `Recreate` or `RollingUpdate`
+# @param strategy.rollingUpdate.maxUnavailable Maximum number of pods that can be created over the desired number of pods when doing [rolling update](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#rolling-update-deployment)
+# @param strategy.rollingUpdate.maxSurge Maximum number of pods that can be unavailable during the [rolling update](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#rolling-update-deployment) process
 
 strategy:
   type: RollingUpdate
@@ -107,10 +107,10 @@ strategy:
 
 # @section Service settings
 
-# @param service.type Kubernetes [service type](https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types).
-# @param service.port Service port.
-# @param service.annotations Kubernetes [service annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/).
-# @param service.labels Kubernetes [service labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/).
+# @param service.type Kubernetes [service type](https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types)
+# @param service.port Service port
+# @param service.annotations Kubernetes [service annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/)
+# @param service.labels Kubernetes [service labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/)
 
 service:
   type: ClusterIP
@@ -121,11 +121,11 @@ service:
 
 # @section Kubernetes [Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) settings
 
-# @param ingress.enabled If Ingress is enabled for the service.
-# @param ingress.className Name of the Ingress controller class.
-# @param ingress.hosts[0].host Hostname for the Ingress service.
-# @param ingress.hosts[0].paths[0].path Path of the host for the Ingress service.
-# @param ingress.hosts[0].paths[0].pathType Type of the path for the Ingress service.
+# @param ingress.enabled If Ingress is enabled for the service
+# @param ingress.className Name of the Ingress controller class
+# @param ingress.hosts[0].host Hostname for the Ingress service
+# @param ingress.hosts[0].paths[0].path Path of the host for the Ingress service
+# @param ingress.hosts[0].paths[0].pathType Type of the path for the Ingress service
 # @param ingress.tls TLS configuration
 
 ingress:
@@ -145,24 +145,24 @@ ingress:
 # @section Limits
 
 
-# @param resources [nullable] Container resources requirements structure.
-# @param resources.requests.cpu [nullable] CPU request, recommended value `500m`.
-# @param resources.requests.memory [nullable] Memory request, recommended value `384Mi`.
-# @param resources.limits.cpu [nullable] CPU limit, recommended value `1000m`.
-# @param resources.limits.memory [nullable] Memory limit, recommended value `768Mi`.
+# @param resources [nullable] Container resources requirements structure
+# @param resources.requests.cpu [nullable] CPU request, recommended value `500m`
+# @param resources.requests.memory [nullable] Memory request, recommended value `384Mi`
+# @param resources.limits.cpu [nullable] CPU limit, recommended value `1000m`
+# @param resources.limits.memory [nullable] Memory limit, recommended value `768Mi`
 
 resources: {}
 
 
 # @section Kubernetes [Horizontal Pod Autoscaling](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/) settings
 
-# @param hpa.enabled If HPA is enabled for the service.
-# @param hpa.minReplicas Lower limit for the number of replicas to which the autoscaler can scale down.
-# @param hpa.maxReplicas Upper limit for the number of replicas to which the autoscaler can scale up.
-# @param hpa.scaleDownStabilizationWindowSeconds Scale-down window.
-# @param hpa.scaleUpStabilizationWindowSeconds Scale-up window.
-# @param hpa.targetCPUUtilizationPercentage Target average CPU utilization (represented as a percentage of requested CPU) over all the pods; if not specified the default autoscaling policy will be used.
-# @param hpa.targetMemoryUtilizationPercentage Target average memory utilization (represented as a percentage of requested memory) over all the pods; if not specified the default autoscaling policy will be used.
+# @param hpa.enabled If HPA is enabled for the service
+# @param hpa.minReplicas Lower limit for the number of replicas to which the autoscaler can scale down
+# @param hpa.maxReplicas Upper limit for the number of replicas to which the autoscaler can scale up
+# @param hpa.scaleDownStabilizationWindowSeconds Scale-down window
+# @param hpa.scaleUpStabilizationWindowSeconds Scale-up window
+# @param hpa.targetCPUUtilizationPercentage Target average CPU utilization (represented as a percentage of requested CPU) over all the pods; if not specified the default autoscaling policy will be used
+# @param hpa.targetMemoryUtilizationPercentage Target average memory utilization (represented as a percentage of requested memory) over all the pods; if not specified the default autoscaling policy will be used
 
 hpa:
   enabled: false
@@ -176,9 +176,9 @@ hpa:
 
 # @section Kubernetes [Pod Disruption Budget](https://kubernetes.io/docs/concepts/workloads/pods/disruptions/#pod-disruption-budgets) settings
 
-# @param pdb.enabled If PDB is enabled for the service.
-# @param pdb.minAvailable How many pods must be available after the eviction.
-# @param pdb.maxUnavailable How many pods can be unavailable after the eviction.
+# @param pdb.enabled If PDB is enabled for the service
+# @param pdb.minAvailable How many pods must be available after the eviction
+# @param pdb.maxUnavailable How many pods can be unavailable after the eviction
 
 pdb:
   enabled: false
@@ -188,12 +188,12 @@ pdb:
 
 # @section Kubernetes [Vertical Pod Autoscaling](https://github.com/kubernetes/autoscaler/blob/master/vertical-pod-autoscaler/README.md) settings
 
-# @param vpa.enabled If VPA is enabled for the service.
-# @param vpa.updateMode VPA [update mode](https://github.com/kubernetes/autoscaler/tree/master/vertical-pod-autoscaler#quick-start).
-# @param vpa.minAllowed.cpu Lower limit for the number of CPUs to which the autoscaler can scale down.
-# @param vpa.minAllowed.memory Lower limit for the RAM size to which the autoscaler can scale down.
-# @param vpa.maxAllowed.cpu Upper limit for the number of CPUs to which the autoscaler can scale up.
-# @param vpa.maxAllowed.memory Upper limit for the RAM size to which the autoscaler can scale up.
+# @param vpa.enabled If VPA is enabled for the service
+# @param vpa.updateMode VPA [update mode](https://github.com/kubernetes/autoscaler/tree/master/vertical-pod-autoscaler#quick-start)
+# @param vpa.minAllowed.cpu Lower limit for the number of CPUs to which the autoscaler can scale down
+# @param vpa.minAllowed.memory Lower limit for the RAM size to which the autoscaler can scale down
+# @param vpa.maxAllowed.cpu Upper limit for the number of CPUs to which the autoscaler can scale up
+# @param vpa.maxAllowed.memory Upper limit for the RAM size to which the autoscaler can scale up
 
 vpa:
   enabled: false

--- a/charts/navi-router/values.yaml
+++ b/charts/navi-router/values.yaml
@@ -47,13 +47,13 @@ image:
 # @param router.appPort Navi-Router service HTTP port
 # @param router.logLevel Logging level, one of: Verbose, Info, Warning, Error, Fatal. Default: `Warning`
 # @param router.additionalSections Additional configurations sections for the Navi-Router service
-# @param router.castleHost URL of Navi-Castle service, ex: http://navi-castle.svc. <br> This URL should be accessible from all the pods within your Kubernetes cluster
+# @param router.castleUrl URL of Navi-Castle service, ex: http://navi-castle.svc. <br> This URL should be accessible from all the pods within your Kubernetes cluster
 
 router:
   appPort: 8080
   logLevel: Warning
   additionalSections: ''
-  castleHost: ''
+  castleUrl: ''
 
 # @param keys.enabled Disable or enable key management service
 # @param keys.url key management service server URL


### PR DESCRIPTION
**Changelog**:

Приведение чарта в соответсвие со стайлгайдом

- Секция `router.keyManagementService` переименована в `keys`
- То, что раньше было `router.keyManagementService.host` теперь называется `keys.url`
- Параметр `router.castleHost` переименован в `router.castleUrl`

**Issues**:
    https://jira.2gis.ru/browse/DEVOPS-1042

**Для девопсов онпрема**: в чарте добавлена проверка на старые параметры в values. Если это будет срелять в onprem-deploy, то можно отключить, добавив (незадокументированный) параметр
```yaml
debug:
  disableDeprecationChecks:
    1.19.0: true
```