### PR TITLE
WAPI-23469 Add configuration for audit logging

### DIFF
--- a/charts/keys/Chart.yaml
+++ b/charts/keys/Chart.yaml
@@ -4,7 +4,7 @@ type: application
 description: A Helm chart for Kubernetes to deploy API Keys service
 
 version: 1.20.0
-appVersion: 1.76.0
+appVersion: 1.78.0
 
 maintainers:
 - name: 2gis

--- a/charts/keys/README.md
+++ b/charts/keys/README.md
@@ -37,6 +37,12 @@ See the [documentation](https://docs.2gis.com/en/on-premise/keys) to learn about
 | `redis.image.repository`   | Redis image repository.           | `2gis-on-premise/keys-redis`   |
 | `redis.image.tag`          | Redis image tag.                  | `6.2.6-alpine3.15`             |
 
+### Flags for enabling/disabling certain features.
+
+| Name                       | Description           | Value   |
+| -------------------------- | --------------------- | ------- |
+| `featureFlags.enableAudit` | Enable audit logging. | `false` |
+
 ### Admin service settings
 
 | Name                                          | Description                                                                                                                                                                                              | Value           |
@@ -184,6 +190,18 @@ See the [documentation](https://docs.2gis.com/en/on-premise/keys) to learn about
 | `postgres.rw.schema`   | PostgreSQL database schema. If not specified, schema from SEARCH_PATH will be used. | `""`   |
 | `postgres.rw.username` | PostgreSQL username. **Required**                                                   | `""`   |
 | `postgres.rw.password` | PostgreSQL password. **Required**                                                   | `""`   |
+
+### Kafka settings
+
+| Name                                  | Description                                                                                                                                                | Value  |
+| ------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- | ------ |
+| `kafka.audit`                         | **Settings for sending audit messages.**                                                                                                                   |        |
+| `kafka.audit.brokers`                 | List of Kafka brokers separated by comma (e.g. 'localhost:9092,localhost:9093').                                                                           | `""`   |
+| `kafka.audit.username`                | Username for authorization (SASL/PLAINTEXT SHA-512).                                                                                                       | `""`   |
+| `kafka.audit.password`                | Password for authorization (SASL/PLAINTEXT SHA-512).                                                                                                       | `""`   |
+| `kafka.audit.topic`                   | Topic to produce audit messages.                                                                                                                           | `""`   |
+| `kafka.audit.produce.retryCount`      | Number of retries to produce a message.                                                                                                                    | `5`    |
+| `kafka.audit.produce.idempotentWrite` | Flag to enable/disable [idempotent write](https://docs.confluent.io/platform/current/installation/configuration/producer-configs.html#enable-idempotence). | `true` |
 
 ### LDAP connection settings
 

--- a/charts/keys/README.md
+++ b/charts/keys/README.md
@@ -196,7 +196,7 @@ See the [documentation](https://docs.2gis.com/en/on-premise/keys) to learn about
 | Name                                  | Description                                                                                                                                                | Value  |
 | ------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- | ------ |
 | `kafka.audit`                         | **Settings for sending audit messages.**                                                                                                                   |        |
-| `kafka.audit.brokers`                 | List of Kafka brokers separated by comma (e.g. 'localhost:9092,localhost:9093').                                                                           | `""`   |
+| `kafka.audit.bootstrapServers`        | Comma-separated list of host and port pairs that are the addresses of the Kafka brokers (e.g. 'localhost:9092,localhost:9093').                            | `""`   |
 | `kafka.audit.username`                | Username for authorization (SASL/PLAINTEXT SHA-512).                                                                                                       | `""`   |
 | `kafka.audit.password`                | Password for authorization (SASL/PLAINTEXT SHA-512).                                                                                                       | `""`   |
 | `kafka.audit.topic`                   | Topic to produce audit messages.                                                                                                                           | `""`   |

--- a/charts/keys/templates/api/deployment.yaml
+++ b/charts/keys/templates/api/deployment.yaml
@@ -47,10 +47,12 @@ spec:
           resources:
             {{- toYaml .Values.api.resources | nindent 12 }}
           env:
+            {{- include "keys.env.featureFlags" . | nindent 12 }}
             {{- include "keys.env.api" . | nindent 12 }}
             {{- include "keys.env.db.deploys" . | nindent 12 }}
             {{- include "keys.env.redis" . | nindent 12 }}
             {{- include "keys.env.auth" . | nindent 12 }}
+            {{- include "keys.env.kafka.audit" . | nindent 12 }}
       {{- with .Values.api.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/keys/templates/helpers.tpl
+++ b/charts/keys/templates/helpers.tpl
@@ -289,7 +289,7 @@ app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 
 {{- define "keys.env.kafka.audit" -}}
 - name: KEYS_KAFKA_AUDIT_BROKERS
-  value: "{{ .Values.kafka.audit.brokers }}"
+  value: "{{ .Values.kafka.audit.bootstrapServers }}"
 - name: KEYS_KAFKA_AUDIT_USERNAME
   value: "{{ .Values.kafka.audit.username }}"
 - name: KEYS_KAFKA_AUDIT_PASSWORD

--- a/charts/keys/templates/helpers.tpl
+++ b/charts/keys/templates/helpers.tpl
@@ -96,6 +96,11 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 
+{{- define "keys.env.featureFlags" -}}
+- name: KEYS_FEATURE_FLAGS_AUDIT
+  value: "{{ .Values.featureFlags.enableAudit }}"
+{{- end }}
+
 {{- define "keys.env.api" -}}
 - name: KEYS_LOG_LEVEL
   value: "{{ .Values.api.logLevel }}"
@@ -280,6 +285,21 @@ app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
       key: dgctlStorageSecretKey
 - name: KEYS_MANIFEST_PATH
   value: "{{ required "A valid .Values.dgctlStorage.manifest entry required" .Values.dgctlStorage.manifest }}"
+{{- end }}
+
+{{- define "keys.env.kafka.audit" -}}
+- name: KEYS_KAFKA_AUDIT_BROKERS
+  value: "{{ .Values.kafka.audit.brokers }}"
+- name: KEYS_KAFKA_AUDIT_USERNAME
+  value: "{{ .Values.kafka.audit.username }}"
+- name: KEYS_KAFKA_AUDIT_PASSWORD
+  value: "{{ .Values.kafka.audit.password }}"
+- name: KEYS_KAFKA_AUDIT_TOPIC
+  value: "{{ .Values.kafka.audit.topic }}"
+- name: KEYS_KAFKA_AUDIT_PRODUCE_RETRY_COUNT
+  value: "{{ .Values.kafka.audit.produce.retryCount }}"
+- name: KEYS_KAFKA_AUDIT_PRODUCE_IDEMPOTENT_WRITE
+  value: "{{ .Values.kafka.audit.produce.idempotentWrite }}"
 {{- end }}
 
 {{/*

--- a/charts/keys/values.yaml
+++ b/charts/keys/values.yaml
@@ -24,6 +24,13 @@ backend:
     repository: 2gis-on-premise/keys-backend
     tag: 1.76.0
 
+# @section Flags for enabling/disabling certain features.
+
+featureFlags:
+  # @param featureFlags.enableAudit Enable audit logging.
+
+  enableAudit: false
+
 # @section Admin service settings
 
 admin:
@@ -409,6 +416,28 @@ postgres:
     username: ''
     password: ''
 
+
+# @section Kafka settings
+
+kafka:
+
+  # @extra kafka.audit **Settings for sending audit messages.**
+
+  # @param kafka.audit.brokers List of Kafka brokers separated by comma (e.g. 'localhost:9092,localhost:9093').
+  # @param kafka.audit.username Username for authorization (SASL/PLAINTEXT SHA-512).
+  # @param kafka.audit.password Password for authorization (SASL/PLAINTEXT SHA-512).
+  # @param kafka.audit.topic Topic to produce audit messages.
+  # @param kafka.audit.produce.retryCount Number of retries to produce a message.
+  # @param kafka.audit.produce.idempotentWrite Flag to enable/disable [idempotent write](https://docs.confluent.io/platform/current/installation/configuration/producer-configs.html#enable-idempotence).
+
+  audit:
+    brokers: ''
+    username: ''
+    password: ''
+    topic: ''
+    produce:
+      retryCount: 5
+      idempotentWrite: true
 
 # @section LDAP connection settings
 

--- a/charts/keys/values.yaml
+++ b/charts/keys/values.yaml
@@ -423,7 +423,7 @@ kafka:
 
   # @extra kafka.audit **Settings for sending audit messages.**
 
-  # @param kafka.audit.brokers List of Kafka brokers separated by comma (e.g. 'localhost:9092,localhost:9093').
+  # @param kafka.audit.bootstrapServers Comma-separated list of host and port pairs that are the addresses of the Kafka brokers (e.g. 'localhost:9092,localhost:9093').
   # @param kafka.audit.username Username for authorization (SASL/PLAINTEXT SHA-512).
   # @param kafka.audit.password Password for authorization (SASL/PLAINTEXT SHA-512).
   # @param kafka.audit.topic Topic to produce audit messages.
@@ -431,7 +431,7 @@ kafka:
   # @param kafka.audit.produce.idempotentWrite Flag to enable/disable [idempotent write](https://docs.confluent.io/platform/current/installation/configuration/producer-configs.html#enable-idempotence).
 
   audit:
-    brokers: ''
+    bootstrapServers: ''
     username: ''
     password: ''
     topic: ''


### PR DESCRIPTION
Changelog:

- Добавлена конфигурация для включения аудит логгирования (фича-флаг, настройки клиента кафки)

Issues:

- [WAPI-23317](https://jira.2gis.ru/browse/WAPI-23317)
- [WAPI-23469](https://jira.2gis.ru/browse/WAPI-23469)

Steps for check:

- Включить аудит флагом `featureFlags.enableAudit`, заполнить настройки клиента `kafka.audit`
- В админке ключей пройти аутентификацию, создать ключ
- Проверить, что в топик кафки пришли два сообщения: об аутентификации и о создании ключа соответственно

[Breaking-Changes](../Breaking-Changes.md)