### PR TITLE
[DEVOPS-1025] Новый castle для новых перекрытий

### DIFF
--- a/charts/navi-castle/README.md
+++ b/charts/navi-castle/README.md
@@ -32,7 +32,7 @@ See the [documentation](https://docs.2gis.com/en/on-premise/navigation) to learn
 | ------------------------- | ------------------------------------- | ----------------------------- |
 | `castle.image.repository` | Navi-Castle service image repository. | `2gis-on-premise/navi-castle` |
 | `castle.image.pullPolicy` | Navi-Castle service pull policy.      | `IfNotPresent`                |
-| `castle.image.tag`        | Navi-Castle service image tag.        | `1.7.0`                       |
+| `castle.image.tag`        | Navi-Castle service image tag.        | `1.9.2`                       |
 | `nginx.image.repository`  | Navi-Front image repository.          | `2gis-on-premise/navi-front`  |
 | `nginx.image.tag`         | Navi-Front image tag.                 | `1.24.1`                      |
 

--- a/charts/navi-castle/templates/configmapbuilder.yaml
+++ b/charts/navi-castle/templates/configmapbuilder.yaml
@@ -45,10 +45,10 @@ data:
     manifest:
     {
         pattern: '{{ default "/manifests/" .Values.dgctlStorage.manifest }}',
-        service: ['navi','navi-restrictions'],
-        mapping: {
-            'navi': 'import_package',
-            'navi-restrictions': 'import_restriction'
+        service: ['navi'],
+        type_mapping: {
+            '': 'import_package',
+            'restrictions': 'import_restriction'
         }
     }
     # --------------------------------------------

--- a/charts/navi-castle/values.yaml
+++ b/charts/navi-castle/values.yaml
@@ -131,7 +131,7 @@ castle:
   image:
     repository: 2gis-on-premise/navi-castle
     pullPolicy: IfNotPresent
-    tag: 1.7.0
+    tag: 1.9.2
   castleDataPath: /opt/castle/data/
   restrictions:
     host: http://restrictions-api.host


### PR DESCRIPTION
Changelog:

- Новая версия navi-castle

Раньше данные для `navi-restrictions` выгружались в датагейтвей как данные отдельного сервиса, теперь мы их публикуем как тип данных `resttrictions` в сервисе `navi`.