### PR TITLE
[PRO-4789] Change PRO UI to 2.5.1 version and PRO API to 1.10.0 version

### DIFF
--- a/charts/pro-api/Chart.yaml
+++ b/charts/pro-api/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 
 
 version: 1.20.2
-appVersion: 1.6.0
+appVersion: 1.10.0
 
 maintainers:
 - name: 2gis

--- a/charts/pro-api/README.md
+++ b/charts/pro-api/README.md
@@ -72,9 +72,9 @@
 ### Deployment settings
 
 | Name               | Description | Value                     |
-| ------------------ | ----------- | ------------------------- |
+| ------------------ | ----------- |---------------------------|
 | `image.repository` | Repository  | `2gis-on-premise/pro-api` |
-| `image.tag`        | Tag         | `1.6.0`                   |
+| `image.tag`        | Tag         | `1.10.0`                   |
 | `image.pullPolicy` | Pull Policy | `IfNotPresent`            |
 
 ### 2GIS PRO Storage configuration
@@ -206,9 +206,9 @@
 ### Import job settings
 
 | Name                                       | Description                                                                                                                                              | Value                          |
-| ------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------ |
+| ------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------- |--------------------------------|
 | `assetImporter.repository`                 | Docker Repository Image.                                                                                                                                 | `2gis-on-premise/pro-importer` |
-| `assetImporter.tag`                        | Docker image tag.                                                                                                                                        | `1.6.0`                        |
+| `assetImporter.tag`                        | Docker image tag.                                                                                                                                        | `1.10.0`                       |
 | `assetImporter.schedule`                   | Import job schedule.                                                                                                                                     | `0 18 * * *`                   |
 | `assetImporter.backoffLimit`               | The number of [retries](https://kubernetes.io/docs/concepts/workloads/controllers/job/#pod-backoff-failure-policy) before considering a Job as failed.   | `2`                            |
 | `assetImporter.successfulJobsHistoryLimit` | How many completed and failed jobs should be kept. See [docs](https://kubernetes.io/docs/tasks/job/automated-tasks-with-cron-jobs/#jobs-history-limits). | `3`                            |

--- a/charts/pro-api/templates/deployment.yaml
+++ b/charts/pro-api/templates/deployment.yaml
@@ -213,6 +213,8 @@ spec:
             {{ end }}
             - name: Kafka__AssetTopicsReaderGroupId
               value: {{ $.Values.kafka.assetTopicsReaderGroupId }}
+            - name: Kafka__EventsGroupId
+              value: {{ $.Values.kafka.eventsGroupId }}
             - name: Kafka__RefreshAssetsIntervalMinutes
               value: "{{ $.Values.kafka.refreshAssetsIntervalMinutes }}"
             - name: Kafka__ImportTasksTopicSettings__Name
@@ -221,6 +223,8 @@ spec:
               value: {{ $.Values.kafka.importTasksTopic.readerGroupId }}
             - name: Kafka__AssetDataTopicSettings__Name
               value: {{ $.Values.kafka.assetDataTopic.name }}
+            - name: Kafka__EventsTopicSettings__Name
+              value: {{ $.Values.kafka.eventsTopic.name }}
             - name: Auth__Type
               value: "{{ .Values.auth.type }}"
             - name: Auth__Url

--- a/charts/pro-api/values.yaml
+++ b/charts/pro-api/values.yaml
@@ -119,14 +119,14 @@ vpa:
 
 image:
   repository: 2gis-on-premise/pro-api
-  tag: 1.6.0
+  tag: 1.10.0
   pullPolicy: IfNotPresent
 
 # @skip permissionsApiImage
 
 permissionsApiImage:
   repository: 2gis-on-premise/pro-permissions-api
-  tag: 1.6.0
+  tag: 1.10.0
   pullPolicy: IfNotPresent
 
 # @section 2GIS PRO Storage configuration
@@ -163,8 +163,8 @@ s3:
 # @skip api.filterByZoneCodes
 # @skip api.esDataCentersCount
 # @skip Local cache settings
-# @skip api.localCache.enabled
-# @skip api.localCache.trackStatistics
+# @skip localCache.enabled
+# @skip localCache.trackStatistics
 
 api:
   serviceAccount: runner
@@ -267,6 +267,7 @@ redis:
 # @param kafka.sasl.username Kafka sasl username.
 # @param kafka.sasl.password Kafka sasl password.
 # @param kafka.assetTopicsReaderGroupId Kafka consumer group for reading streaming assets data.
+# @param kafka.eventsGroupId Kafka consumer group prefix for reading events.
 # @extra kafka.importTasksTopic Kafka topic settings to run import tasks.
 # @param kafka.importTasksTopic.name Kafka topic name.
 # @param kafka.importTasksTopic.readerGroupId Kafka consumer group for reading importing tasks.
@@ -283,10 +284,13 @@ kafka:
     username: ''
     password: ''
   assetTopicsReaderGroupId: ''
+  eventsGroupId: ''
   importTasksTopic:
     name: ''
     readerGroupId: ''
   assetDataTopic:
+    name: ''
+  eventsTopic:
     name: ''
   permissionsTopic:
     name: ''
@@ -367,8 +371,8 @@ permissionsPodSettings:
 # @skip permissionsApi.host
 # @param permissionsApi.enabled If permissionsApi is enabled for the service.
 # @skip Local cache settings
-# @skip permissionsApi.localCache.enabled
-# @skip permissionsApi.localCache.trackStatistics
+# @skip localCache.enabled
+# @skip localCache.trackStatistics
 
 permissionsApi:
   host: ''
@@ -388,6 +392,7 @@ permissionsApi:
 # @param assetImporter.maxParallelJobs How many import jobs can be run simultaneously
 # @param assetImporter.enabled If assetImporter is enabled for the service.
 # @param assetImporter.startOnDeploy Indicates that asset import should start when service installed or updated
+# @param assetImporter.startOnDeployMode Import mode: 'ScheduleManifest' - copy data from manifest and schedule import, 'ManifestData' - just copy data from manifest.
 # @param assetImporter.imageProxyUrl URL to proxy image links (including query parameters, if any, i.e. 'https://someserver.com/proxy?url=' )
 # @param assetImporter.externalLinksProxyUrl URL to proxy http links from assets data (including query parameters, if any, i.e. 'https://someserver.com/proxy?url=' )
 # @param assetImporter.externalLinksAllowedHosts Comma separated hosts, i.e. 'someserver.com,someserver2.com' )
@@ -397,7 +402,7 @@ permissionsApi:
 
 assetImporter:
   repository: 2gis-on-premise/pro-importer
-  tag: 1.6.0
+  tag: 1.10.0
   schedule: 0 18 * * *
   backoffLimit: 2
   successfulJobsHistoryLimit: 3
@@ -413,6 +418,7 @@ assetImporter:
   enabled: true
   suspended: false
   startOnDeploy: true
+  startOnDeployMode: ScheduleManifest
   files: ''
   imageProxyUrl: ''
   externalLinksProxyUrl: ''
@@ -427,7 +433,7 @@ userAssetImporter:
 
 assetPreparer:
   repository: 2gis-on-premise/pro-importer
-  tag: 1.6.0
+  tag: 1.10.0
   schedule: 0 16 * * 6
   backoffLimit: 2
   successfulJobsHistoryLimit: 1
@@ -478,10 +484,10 @@ ingress:
   enabled: false
   className: nginx
   hosts:
-  - host: pro-api.example.com
-    paths:
-    - path: /
-      pathType: Prefix
+    - host: pro-api.example.com
+      paths:
+        - path: /
+          pathType: Prefix
   tls: []
   # - hosts:
   #   - pro-api.example.com
@@ -498,11 +504,12 @@ permissionsApiIngress:
   enabled: false
   className: nginx
   hosts:
-  - host: pro-permissions-api.example.com
-    paths:
-    - path: /
-      pathType: Prefix
+    - host: pro-permissions-api.example.com
+      paths:
+        - path: /
+          pathType: Prefix
   tls: []
   # - hosts:
   #   - pro-permissions-api.example.com
   #   secretName: secret.tls
+

--- a/charts/pro-ui/Chart.yaml
+++ b/charts/pro-ui/Chart.yaml
@@ -4,7 +4,7 @@ type: application
 description: A Helm chart for Kubernetes to deploy 2GIS Pro UI service
 
 version: 1.20.2
-appVersion: 2.1.1
+appVersion: 2.5.1
 
 maintainers:
 - name: 2gis

--- a/charts/pro-ui/README.md
+++ b/charts/pro-ui/README.md
@@ -38,9 +38,9 @@ Use this Helm chart to deploy 2GIS Pro UI service, which is a part of 2GIS's [On
 ### Deployment settings
 
 | Name                  | Description | Value                    |
-| --------------------- | ----------- | ------------------------ |
+| --------------------- | ----------- |--------------------------|
 | `ui.image.repository` | Repository  | `2gis-on-premise/pro-ui` |
-| `ui.image.tag`        | Tag         | `2.1.1`                  |
+| `ui.image.tag`        | Tag         | `2.5.1`                  |
 
 ### UI service settings
 
@@ -168,10 +168,10 @@ Use this Helm chart to deploy 2GIS Pro UI service, which is a part of 2GIS's [On
 ### Import job settings
 
 | Name                                        | Description                                                                                                                                              | Value                          |
-| ------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------ |
+| ------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |--------------------------------|
 | `stylesImporter.serviceAccount`             | Kubernetes service account                                                                                                                               | `runner`                       |
 | `stylesImporter.image.repository`           | Docker Repository Image.                                                                                                                                 | `2gis-on-premise/pro-importer` |
-| `stylesImporter.image.tag`                  | Docker image tag.                                                                                                                                        | `1.6.0`                        |
+| `stylesImporter.image.tag`                  | Docker image tag.                                                                                                                                        | `1.10.0`                       |
 | `stylesImporter.backoffLimit`               | The number of [retries](https://kubernetes.io/docs/concepts/workloads/controllers/job/#pod-backoff-failure-policy) before considering a Job as failed.   | `2`                            |
 | `stylesImporter.successfulJobsHistoryLimit` | How many completed and failed jobs should be kept. See [docs](https://kubernetes.io/docs/tasks/job/automated-tasks-with-cron-jobs/#jobs-history-limits). | `3`                            |
 | `stylesImporter.nodeSelector`               | Kubernetes [node selectors](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector).                                      | `{}`                           |

--- a/charts/pro-ui/values.yaml
+++ b/charts/pro-ui/values.yaml
@@ -50,7 +50,7 @@ ui:
   # @param ui.image.tag Tag
   image:
     repository: 2gis-on-premise/pro-ui
-    tag: 2.1.1
+    tag: 2.5.1
 
   # @section UI service settings
 
@@ -281,7 +281,7 @@ stylesImporter:
   serviceAccount: runner
   image:
     repository: 2gis-on-premise/pro-importer
-    tag: 1.6.0
+    tag: 1.10.0
   backoffLimit: 2
   successfulJobsHistoryLimit: 3
   nodeSelector: {}

--- a/image_versions.txt
+++ b/image_versions.txt
@@ -52,13 +52,13 @@ navi-splitter
 platform
 	platform-ui:0.8.1
 pro-api
-	pro-api:1.6.0
-	pro-importer:1.6.0
-	pro-importer:1.6.0
-	pro-permissions-api:1.6.0
+	pro-api:1.10.0
+	pro-importer:1.10.0
+	pro-importer:1.10.0
+	pro-permissions-api:1.10.0
 pro-ui
-	pro-importer:1.6.0
-	pro-ui:2.1.1
+	pro-importer:1.10.0
+	pro-ui:2.5.1
 search-api
 	search-api:7.74.0
 	search-nginx:1.21.6


### PR DESCRIPTION
**PRO-UI**
https://jira.2gis.ru/browse/PRO-2764 - Переработка модальных окон удаления сущностей
Как проверить:
1. Удалить любую сущность
ОР: Появляется модальное окно без ошибок в текстах и с корректной версткой

Доработки загрузки стилей:
https://jira.2gis.ru/browse/PRO-4610
https://jira.2gis.ru/browse/PRO-4596 
Как проверить: так же как описано здесь https://github.com/2gis/on-premise-helm-charts/pull/405

https://jira.2gis.ru/browse/PRO-4665 - Пофикшен неправильный выбор текста ошибки в бэка
Как проверить:
1. Открыть форму загрузки нового ассета в Ассет-менеджере
2. Выбрать и загрузить невалидный файл (например, с неправильными координатами)
3. Нажать "Загрузить" и получить ошибку от бэка в окне загрузки
ОР: Текст ошибки, пришедший с бэка - на языке интерфейса

https://jira.2gis.ru/browse/PRO-4888 - Пофишкен баг привязки легенды о слое к нижнему блоку виджетов на дашборде
Как проверить:
1. Открыть дашборд
2. Сделать нижний блок виджетов меньше чем экран рабочего компьютера
3. Открыть легенду о слое
ОР: Легенда о слое открывается только в правой стороне экрана и всегда находится там

Changelog: https://tsup.2gis.dev/pro/pro-ui/changelog/2.2.0..2.5.1

**PRO-API**
https://jira.2gis.ru/browse/PRO-3151 - добавлена настройка для конфигурации запуска импортов

https://jira.2gis.ru/browse/PRO-4164 - для джобы asset-import-starter всегда будет уникальное имя

https://jira.2gis.ru/browse/PRO-4463 - ошибки 401 и 403 всегда логируются с телом

https://jira.2gis.ru/browse/PRO-4661 - пофикшен баг с потерей сообщений от CityLens из-за нехватки памяти в эластике

https://jira.2gis.ru/browse/PRO-4583 - пофикшен баг с выбором названия фирмы в фильтрах


Changelog: https://tsup.2gis.dev/pro/pro-api/changelog/1.7.0..1.10.0