### PR TITLE
Citylens 1.7.0

### DIFF
--- a/Breaking-Changes.md
+++ b/Breaking-Changes.md
@@ -10,6 +10,9 @@
 - `api.attractor_url`, `cron.edges_url_template` and `cron.edge_attributes_url_template` are deprecated. Set `naviBackHost` and `naviCastleHost` with `api.attractorUri`, `cron.edgeAttributesUriTemplate` and `cron.maxAttributesFetcherRps` instead
 - New values required `naviBackHost`, `naviCastleHost`
 
+### citylens
+- `worker.reporterProTracks.replicas` replaced with `worker.reporterProTracks.enabled`. One replica will be deployed if enabled.
+
 ## [1.20.0]
 
 ### navi-router

--- a/charts/citylens/Chart.yaml
+++ b/charts/citylens/Chart.yaml
@@ -4,7 +4,7 @@ type: application
 description: A Helm chart for Kubernetes to deploy Citylens service
 
 version: 1.20.2
-appVersion: 1.7.1
+appVersion: 1.7.2
 
 maintainers:
 - name: 2gis

--- a/charts/citylens/Chart.yaml
+++ b/charts/citylens/Chart.yaml
@@ -4,7 +4,7 @@ type: application
 description: A Helm chart for Kubernetes to deploy Citylens service
 
 version: 1.20.2
-appVersion: 1.6.0
+appVersion: 1.7.1
 
 maintainers:
 - name: 2gis

--- a/charts/citylens/templates/web/configmap.yaml
+++ b/charts/citylens/templates/web/configmap.yaml
@@ -80,12 +80,15 @@ data:
       source_env: {{ .sourceEnv }}
     {{- end }}
     {{- end }}
-    {{- with .Values.pro }}
-    pro_client:
-      endpoint_url: {{ .url }}
-      token: {{ .key }}
-      verify_ssl: {{ .verifySsl }}
-    {{- end }}
+    pro:
+      {{- with .Values.pro }}
+      client:
+        endpoint_url: {{ .url }}
+        token: {{ .key }}
+        verify_ssl: {{ .verifySsl }}
+      {{- end }}
+      topics:
+        frames: {{ .Values.kafka.topics.pro }}
     map:
       tileserver_url_template: {{ required "A valid .Values.map.tileserverUrl entry required" .Values.map.tileserverUrl }}/tiles?x={x}&y={y}&z={z}
       mapgl:
@@ -123,7 +126,6 @@ data:
           predictors:
             {{- toYaml .predictors | nindent 12 }}
       {{- if eq .name "pro" }}
-          topic: {{ $.Values.kafka.topics.pro }}
           {{- if .trackTimeoutDays }}
           timeout: {{ .trackTimeoutDays }}
           {{- end }}

--- a/charts/citylens/templates/worker/deployment-reporter-pro-tracks.yaml
+++ b/charts/citylens/templates/worker/deployment-reporter-pro-tracks.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.worker.reporterProTracks.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -12,7 +13,7 @@ metadata:
     {{- toYaml .Values.worker.reporterProTracks.labels | nindent 4 }}
   {{- end }}
 spec:
-  replicas: {{ .Values.worker.reporterProTracks.replicas }}
+  replicas: 1
   selector:
     matchLabels:
       {{- include "citylens.reporter-pro-tracks.selectorLabels" . | nindent 6 }}
@@ -61,3 +62,4 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+{{- end }}

--- a/charts/citylens/values.yaml
+++ b/charts/citylens/values.yaml
@@ -97,7 +97,7 @@ api:
   image:
     repository: 2gis-on-premise/citylens-api
     pullPolicy: IfNotPresent
-    tag: 1.6.0
+    tag: 1.7.0
 
   replicas: 4
 
@@ -224,7 +224,7 @@ web:
   image:
     repository: 2gis-on-premise/citylens-web
     pullPolicy: IfNotPresent
-    tag: 1.6.0
+    tag: 1.7.0
 
   replicas: 1
 
@@ -561,7 +561,7 @@ migrations:
   image:
     repository: 2gis-on-premise/citylens-database
     pullPolicy: IfNotPresent
-    tag: 1.6.0
+    tag: 1.7.0
 
   resources:
     requests:
@@ -580,10 +580,10 @@ migrations:
 # @param kafka.password A Kafka password for connection. **Required**
 # @param kafka.topics.frames List of topics for Frames saver worker. **Required**
 # @param kafka.topics.tracks List of topics for Tracks metadata worker. **Required**
-# @param kafka.topics.pro List of topics for Reporter pro worker. **Required**
-# @param kafka.topics.uploader List of topics for Uploader worker. **Required**
-# @param kafka.topics.logs List of topics for API logs. **Required**
-# @param kafka.topics.framesLifecycle Topic for frames lifecycle events logs. **Required**
+# @param kafka.topics.pro Topic for frames synchronization with Pro (used by Reporter pro worker). **Required**
+# @param kafka.topics.uploader Topic for Uploader worker. **Required**
+# @param kafka.topics.logs Topic for citylens mobile app logs, uploaded via citylens-api. **Required**
+# @param kafka.topics.framesLifecycle Topic for frames lifecycle events. **Required**
 # @param kafka.consumerGroups.prefix Kafka topics prefix. **Required**
 # @param kafka.predictors[0].name Name of predictor **Required**
 # @param kafka.predictors[0].topic Topic used by predictor **Required**

--- a/charts/citylens/values.yaml
+++ b/charts/citylens/values.yaml
@@ -97,7 +97,7 @@ api:
   image:
     repository: 2gis-on-premise/citylens-api
     pullPolicy: IfNotPresent
-    tag: 1.7.1
+    tag: 1.7.2
 
   replicas: 4
 
@@ -224,7 +224,7 @@ web:
   image:
     repository: 2gis-on-premise/citylens-web
     pullPolicy: IfNotPresent
-    tag: 1.7.1
+    tag: 1.7.2
 
   replicas: 1
 

--- a/charts/citylens/values.yaml
+++ b/charts/citylens/values.yaml
@@ -452,7 +452,7 @@ worker:
 
 # @section Citylens Reporter Pro Tracks worker's settings (track status actualization)
 
-# @param worker.reporterProTracks.replicas A replica count for the pod.
+# @param worker.reporterProTracks.enabled Deploy worker or not.
 
 # @param worker.reporterProTracks.annotations Kubernetes [annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/).
 # @param worker.reporterProTracks.labels Kubernetes [labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/).
@@ -465,7 +465,7 @@ worker:
 
   reporterProTracks:
 
-    replicas: 1
+    enabled: true
 
     annotations: {}
     labels: {}

--- a/charts/citylens/values.yaml
+++ b/charts/citylens/values.yaml
@@ -97,7 +97,7 @@ api:
   image:
     repository: 2gis-on-premise/citylens-api
     pullPolicy: IfNotPresent
-    tag: 1.7.0
+    tag: 1.7.1
 
   replicas: 4
 
@@ -224,7 +224,7 @@ web:
   image:
     repository: 2gis-on-premise/citylens-web
     pullPolicy: IfNotPresent
-    tag: 1.7.0
+    tag: 1.7.1
 
   replicas: 1
 


### PR DESCRIPTION
Changelog:

* citylens-web:
  * Fix detection attributes synchronization with Pro
  * new table for Pro-related translations instead of multiple `name_localized` columns
* citylens-api:
  * better predictions validation on `/api/1.0/predictions/{predictor}` endpoint

min data version: 3
max data version: 3

Breaking changes:
worker.reporterProTracks.replicas` replaced with `worker.reporterProTracks.enabled`. One replica will be deployed if enabled.