### PR TITLE
PRO-4936: upgrade keys-ui to 0.7.0

### DIFF
--- a/charts/keys/README.md
+++ b/charts/keys/README.md
@@ -33,7 +33,7 @@ See the [documentation](https://docs.2gis.com/en/on-premise/keys) to learn about
 | `backend.image.repository` | Backend service image repository. | `2gis-on-premise/keys-backend` |
 | `backend.image.tag`        | Backend service image tag.        | `1.79.0`                       |
 | `admin.image.repository`   | Admin service image repository.   | `2gis-on-premise/keys-ui`      |
-| `admin.image.tag`          | Admin service image tag.          | `0.6.0`                        |
+| `admin.image.tag`          | Admin service image tag.          | `0.7.0`                        |
 | `redis.image.repository`   | Redis image repository.           | `2gis-on-premise/keys-redis`   |
 | `redis.image.tag`          | Redis image tag.                  | `6.2.6-alpine3.15`             |
 

--- a/charts/keys/values.yaml
+++ b/charts/keys/values.yaml
@@ -36,7 +36,7 @@ backend:
 admin:
   image:
     repository: 2gis-on-premise/keys-ui
-    tag: 0.6.0
+    tag: 0.7.0
 
   # @param admin.replicas A replica count for the pod.
 

--- a/image_versions.txt
+++ b/image_versions.txt
@@ -23,7 +23,7 @@ keycloak
 keys
 	keys-backend:1.79.0
 	keys-redis:6.2.6-alpine3.15
-	keys-ui:0.6.0
+	keys-ui:0.7.0
 license
 	license:2.2.1
 mapgl-js-api


### PR DESCRIPTION
# Pull Request description

## Changelog

- Реализован обратный редирект после авторизации на /auth https://jira.2gis.ru/browse/PRO-4384
- Отказ от понятий: "Страна" и "Проект" — внутри ограничений ключа и замена их на "Группа сегментов" и "Сегмент" https://jira.2gis.ru/browse/PRO-3141
- Исправлен баг, когда в модальном окне редактирования данных о партнере подставлялся неправильный номер телефона https://jira.2gis.ru/browse/PRO-3420
- Иправлена ошибка, при которой иконка переключения видимости пароля не отображалась корректно в Safari https://jira.2gis.ru/browse/PRO-4487
- Поправлен баг формы авторизации в случае, задержки загрузки скриптов https://jira.2gis.ru/browse/PRO-4993

https://gitlab.2gis.ru/doka/keys-admin/-/releases/0.7.0

## Issues

- `Issue-123` (Link to related issue)

## Braking changes

- If there are breaking changes, they need to be added to the file [Breaking-Changes](../Breaking-Changes.md)

## Check-list. Чек-лист код-ревью

- [ ] Запрос на слияние в develop.
- [ ] Есть описание к PR.
- [ ] Указаны блокирующие изменения. [Breaking-Changes](../Breaking-Changes.md)
- [ ] Соответствие кода принятому [стилю](../styleguide.md)
  - [ ] Описание настроек.
  - [ ] Именование настроек.
  - [ ] Дефолтные значения.
  - [ ] Стиль кода.
- [ ] Работоспособность. Разворачивается на своем окружении из ветки PR.
  - [ ] Тест API через тесты helmfile-хуков или коллекций Postman.
- [ ] Не осталось мусора от удаления каких-то параметров. Ищется поиском по проекту из ветки PR.
- [ ] Отработка линтера на чарт из ветки PR. Пример: `helm lint charts/search-api`
