### PR TITLE
pro-ui: New external style manager config

### DIFF
--- a/charts/pro-ui/README.md
+++ b/charts/pro-ui/README.md
@@ -84,6 +84,18 @@ Use this Helm chart to deploy 2GIS Pro UI service, which is a part of 2GIS's [On
 | `ui.mapgl.stylePreview`   | URL to image for ui.mapgl.styleUrl or ui.mapgl.styleId. It needs for preview in manager styles.                                                                                                      | `""`             |
 | `ui.mapgl.styleModelsUrl` | Optional URL for [MapGL Style](https://docs.2gis.com/en/mapgl/styles/overview/editor) models folder, e.g., '//mapgl.ingress.host/style/models'                                                       | `""`             |
 
+### Mapbox style config settings
+
+| Name                   | Description                                                           | Value |
+| ---------------------- | --------------------------------------------------------------------- | ----- |
+| `ui.mapbox.styleToken` | Optional [Mapbox Token](https://docs.mapbox.com/api/accounts/tokens/) | `""`  |
+
+### External style manager configuration.
+
+| Name                              | Description                                            | Value   |
+| --------------------------------- | ------------------------------------------------------ | ------- |
+| `ui.externalStyleManager.enabled` | - Set "true" to enable External Style Manager features | `false` |
+
 ### Map styles config settings
 
 | Name                  | Description                                                     | Value |

--- a/charts/pro-ui/templates/_env.tpl
+++ b/charts/pro-ui/templates/_env.tpl
@@ -71,6 +71,10 @@
   value: "/tmp"
 - name: SERVER_PORT
   value: "{{ .Values.ui.containerPort }}"
+- name: MAPBOX_STYLE_TOKEN
+  value: "{{ .Values.ui.mapbox.styleToken }}"
+- name: FEATURE_EXTERNAL_STYLE_MANAGER_IS_ENABLED
+  value: "{{ .Values.ui.externalStyleManager.enabled }}"
 - name: PUBLIC_S3_HOST
   value: "{{ .Values.ui.publicS3Url }}"
 - name: PUBLIC_S3_URL

--- a/charts/pro-ui/values.schema.json
+++ b/charts/pro-ui/values.schema.json
@@ -162,6 +162,22 @@
             }
           }
         },
+        "mapbox": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "styleToken": {
+              "type": "string"
+            }
+          }
+        },
+        "externalStyleManager": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": { "type": "boolean" }
+          }
+        },
         "styles": {
           "type": "object",
           "additionalProperties": false,

--- a/charts/pro-ui/values.yaml
+++ b/charts/pro-ui/values.yaml
@@ -139,6 +139,21 @@ ui:
     stylePreview: ''
     styleModelsUrl: ''
 
+  # @section Mapbox style config settings
+  #
+  # Fill that parameters if your app has connection to Global Internet.
+  # @param ui.mapbox.styleToken Optional [Mapbox Token](https://docs.mapbox.com/api/accounts/tokens/)
+  mapbox:
+    styleToken: ''
+
+  # @section External style manager configuration.
+  # External style manager allows managing WMS- and WMTS-maps from external sources.
+  # Access to public (internet) or private (intranet) WM(T)S services is required for this feature to work.
+  #
+  # @param ui.externalStyleManager.enabled - Set "true" to enable External Style Manager features
+  externalStyleManager:
+    enabled: false
+
   # @section Map styles config settings
   #
   # @param ui.styles.s3Bucket Optional S3 bucket name for style files. Bucket must be public.


### PR DESCRIPTION
Changelog:

- Pro-UI: External Style Manager feature flag configuration option added
- Pro-UI: Mapbox external style public key configuration option added

Issues:

- PRO-4272
- PRO-4270

Old PR (closed): https://github.com/2gis/on-premise-helm-charts/pull/413