### PR TITLE
Update citylens chart to 1.8.0 version

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,7 +8,7 @@
 
 - `Issue-123` (Link to related issue)
 
-## Braking changes
+## Breaking changes
 
 - If there are breaking changes, they need to be added to the file [Breaking-Changes](../Breaking-Changes.md)
 

--- a/Breaking-Changes.md
+++ b/Breaking-Changes.md
@@ -3,9 +3,7 @@
 ## [NEXT-VERSION]
 
 ## citylens
-- Kafka topics `kafka.predictors[0].topic` (camcom), `kafka.predictors[1].topic` (manual) replaced with single topic `kafka.topics.predictions`.
-Extra topics can be provided via `kafka.predictorsExtraTopics`, `kafka.predictors[0].topic` (camcom) can be used as `kafka.topics.predictions`.
-- `kafka.predictors` is removed in favor of `kafka.predictorsExtraTopics`.
+- `kafka.predictors` is removed. Topics `kafka.predictors[0].topic` (`camcom` in values example), `kafka.predictors[1].topic` (`manual` in values example) replaced with single topic `kafka.topics.predictions`.
 
 ## [1.21.0]
 

--- a/Breaking-Changes.md
+++ b/Breaking-Changes.md
@@ -1,5 +1,12 @@
 # 2GIS On-Premise Breaking-Changes
 
+## [NEXT-VERSION]
+
+## citylens
+- Kafka topics `kafka.predictors[0].topic` (camcom), `kafka.predictors[1].topic` (manual) replaced with single topic `kafka.topics.predictions`.
+Extra topics can be provided via `kafka.predictorsExtraTopics`, `kafka.predictors[0].topic` (camcom) can be used as `kafka.topics.predictions`.
+- `kafka.predictors` is removed in favor of `kafka.predictorsExtraTopics`.
+
 ## [1.21.0]
 
 ### pro-api

--- a/charts/citylens/Chart.yaml
+++ b/charts/citylens/Chart.yaml
@@ -4,7 +4,7 @@ type: application
 description: A Helm chart for Kubernetes to deploy Citylens service
 
 version: 1.21.0
-appVersion: 1.7.2
+appVersion: 1.8.0
 
 maintainers:
 - name: 2gis

--- a/charts/citylens/templates/api/configmap.yaml
+++ b/charts/citylens/templates/api/configmap.yaml
@@ -16,14 +16,7 @@ data:
       frames: {{ required "A valid .Values.kafka.topics.frames entry required" .topics.frames | squote }}
       tracks: {{ required "A valid .Values.kafka.topics.tracks entry required" .topics.tracks | squote }}
       logs: {{ required "A valid .Values.kafka.topics.logs entry required" .topics.logs | squote }}
-      {{- range .predictors }}
-      {{- if eq .name "camcom" }}
-      camcom: {{ required "A valid .topic entry required" .topic| squote }}
-      {{- end }}
-      {{- if eq .name "manual" }}
-      manual: {{ required "A valid .topic entry required" .topic| squote }}
-      {{- end }}
-      {{- end }}
+      predictions: {{ required "A valid .Values.kafka.topics.predictions entry required" .topics.predictions | squote }}
     {{- end }}
     database:
     {{- with .Values.postgres }}

--- a/charts/citylens/templates/web/configmap.yaml
+++ b/charts/citylens/templates/web/configmap.yaml
@@ -132,4 +132,4 @@ data:
         {{- end }}
       {{- end }}
       predictors:
-        {{- toYaml .Values.kafka.predictors | nindent 8 }}
+        {{- toYaml .Values.kafka.predictorsExtraTopics | nindent 8 }}

--- a/charts/citylens/values.yaml
+++ b/charts/citylens/values.yaml
@@ -586,7 +586,7 @@ migrations:
 # @param kafka.topics.framesLifecycle Topic for frames lifecycle events. **Required**
 # @param kafka.topics.predictions Topic for predictions events from detectors. **Required**
 # @param kafka.consumerGroups.prefix Kafka topics prefix. **Required**
-# @param kafka.predictorsExtraTopics Additional topics to consume predictions from. List of objects with keys `name` and `topic`. **Required**
+# @param kafka.predictorsExtraTopics Additional topics to consume predictions from. List of objects with keys `name` and `topic`.
 
 kafka:
 

--- a/charts/citylens/values.yaml
+++ b/charts/citylens/values.yaml
@@ -586,7 +586,6 @@ migrations:
 # @param kafka.topics.framesLifecycle Topic for frames lifecycle events. **Required**
 # @param kafka.topics.predictions Topic for predictions events from detectors. **Required**
 # @param kafka.consumerGroups.prefix Kafka topics prefix. **Required**
-# @param kafka.predictorsExtraTopics Additional topics to consume predictions from. List of objects with keys `name` and `topic`.
 
 kafka:
 
@@ -603,7 +602,6 @@ kafka:
     predictions: ''
   consumerGroups:
     prefix: ''
-  predictorsExtraTopics: {}
 
 # @section S3 settings
 # @param s3.verifySsl Verify SSL certificate when connecting to s3.endpoint.

--- a/charts/citylens/values.yaml
+++ b/charts/citylens/values.yaml
@@ -97,7 +97,7 @@ api:
   image:
     repository: 2gis-on-premise/citylens-api
     pullPolicy: IfNotPresent
-    tag: 1.7.2
+    tag: 1.8.0
 
   replicas: 4
 
@@ -224,7 +224,7 @@ web:
   image:
     repository: 2gis-on-premise/citylens-web
     pullPolicy: IfNotPresent
-    tag: 1.7.2
+    tag: 1.8.0
 
   replicas: 1
 
@@ -561,7 +561,7 @@ migrations:
   image:
     repository: 2gis-on-premise/citylens-database
     pullPolicy: IfNotPresent
-    tag: 1.7.0
+    tag: 1.8.0
 
   resources:
     requests:
@@ -584,11 +584,9 @@ migrations:
 # @param kafka.topics.uploader Topic for Uploader worker. **Required**
 # @param kafka.topics.logs Topic for citylens mobile app logs, uploaded via citylens-api. **Required**
 # @param kafka.topics.framesLifecycle Topic for frames lifecycle events. **Required**
+# @param kafka.topics.predictions Topic for predictions events from detectors. **Required**
 # @param kafka.consumerGroups.prefix Kafka topics prefix. **Required**
-# @param kafka.predictors[0].name Name of predictor **Required**
-# @param kafka.predictors[0].topic Topic used by predictor **Required**
-# @param kafka.predictors[1].name Name of manual predictor **Required**
-# @param kafka.predictors[1].topic Topic used by manual predictor **Required**
+# @param kafka.predictorsExtraTopics Additional topics to consume predictions from. List of objects with keys `name` and `topic`. **Required**
 
 kafka:
 
@@ -602,13 +600,10 @@ kafka:
     logs: ''
     uploader: ''
     framesLifecycle: ''
+    predictions: ''
   consumerGroups:
     prefix: ''
-  predictors:
-  - name: camcom
-    topic: ''
-  - name: manual
-    topic: ''
+  predictorsExtraTopics: {}
 
 # @section S3 settings
 # @param s3.verifySsl Verify SSL certificate when connecting to s3.endpoint.


### PR DESCRIPTION
# Citylens 1.8.0

## Changelog

- citylens-api:
  - Use same topic for manual and camcom predictions
- citylens-web:
  - Fix problem with excess connections and reconnections to Kafka in citylens-web and some of the workers
  - Misc UI enhancements (e.g. better filters on /frames page)

## Issies
- FR-30, FR-31 (CR 29.02.24)

## Breaking changes

- Please see changes in [Breaking-Changes](../Breaking-Changes.md)

## Check-list. Чек-лист код-ревью

- [ ] Запрос на слияние в develop.
- [ ] Есть описание к PR.
- [ ] Указаны блокирующие изменения. [Breaking-Changes](../Breaking-Changes.md)
- [ ] Соответствие кода принятому [стилю](../styleguide.md)
  - [ ] Описание настроек.
  - [ ] Именование настроек.
  - [ ] Дефолтные значения.
  - [ ] Стиль кода.
- [ ] Работоспособность. Разворачивается на своем окружении из ветки PR.
  - [ ] Тест API через тесты helmfile-хуков или коллекций Postman.
- [ ] Не осталось мусора от удаления каких-то параметров. Ищется поиском по проекту из ветки PR.
- [ ] Отработка линтера на чарт из ветки PR. Пример: `helm lint charts/search-api`
