### PR TITLE
WAPI-23482 Add configuration for Public API sign

### DIFF
--- a/charts/keys/Chart.yaml
+++ b/charts/keys/Chart.yaml
@@ -3,7 +3,7 @@ name: keys
 type: application
 description: A Helm chart for Kubernetes to deploy API Keys service
 
-version: 1.24.0
+version: 1.23.0
 appVersion: 1.85.2
 
 maintainers:

--- a/charts/keys/Chart.yaml
+++ b/charts/keys/Chart.yaml
@@ -3,8 +3,8 @@ name: keys
 type: application
 description: A Helm chart for Kubernetes to deploy API Keys service
 
-version: 1.23.0
-appVersion: 1.79.0
+version: 1.24.0
+appVersion: 1.85.2
 
 maintainers:
 - name: 2gis

--- a/charts/keys/README.md
+++ b/charts/keys/README.md
@@ -42,7 +42,7 @@ See the [documentation](https://docs.2gis.com/en/on-premise/keys) to learn about
 | Name                               | Description                             | Value   |
 | ---------------------------------- | --------------------------------------- | ------- |
 | `featureFlags.enableAudit`         | Enable audit logging.                   | `false` |
-| `featureFlags.enablePublicAPISign` | Enable signing responses in Public API. | `true`  |
+| `featureFlags.enablePublicAPISign` | Enable signing responses in Public API. | `false` |
 
 ### Admin service settings
 

--- a/charts/keys/README.md
+++ b/charts/keys/README.md
@@ -31,7 +31,7 @@ See the [documentation](https://docs.2gis.com/en/on-premise/keys) to learn about
 | `imagePullSecrets`         | Kubernetes image pull secrets.    | `[]`                           |
 | `imagePullPolicy`          | Pull policy.                      | `IfNotPresent`                 |
 | `backend.image.repository` | Backend service image repository. | `2gis-on-premise/keys-backend` |
-| `backend.image.tag`        | Backend service image tag.        | `1.79.0`                       |
+| `backend.image.tag`        | Backend service image tag.        | `1.85.2`                       |
 | `admin.image.repository`   | Admin service image repository.   | `2gis-on-premise/keys-ui`      |
 | `admin.image.tag`          | Admin service image tag.          | `0.8.0`                        |
 | `redis.image.repository`   | Redis image repository.           | `2gis-on-premise/keys-redis`   |

--- a/charts/keys/README.md
+++ b/charts/keys/README.md
@@ -39,9 +39,10 @@ See the [documentation](https://docs.2gis.com/en/on-premise/keys) to learn about
 
 ### Flags for enabling/disabling certain features.
 
-| Name                       | Description           | Value   |
-| -------------------------- | --------------------- | ------- |
-| `featureFlags.enableAudit` | Enable audit logging. | `false` |
+| Name                               | Description                              | Value   |
+| ---------------------------------- | ---------------------------------------- | ------- |
+| `featureFlags.enableAudit`         | Enable audit logging.                    | `false` |
+| `featureFlags.enablePublicAPISign` | Enable signing responses in Public API.. | `true`  |
 
 ### Admin service settings
 
@@ -85,6 +86,7 @@ See the [documentation](https://docs.2gis.com/en/on-premise/keys) to learn about
 | `api.adminUsers`                            | Usernames and passwords of admin users. Format: `username1:password1,username2:password2`.                                                                                                                                 | `""`            |
 | `api.adminSessionTTL`                       | TTL of the admin users sessions. Duration string is a sequence of decimal numbers with optional fraction and unit suffix, like `100ms`, `2.3h` or `4h35m`. Valid time units are `ns`, `us` (or `µs`), `ms`, `s`, `m`, `h`. | `336h`          |
 | `api.logLevel`                              | Log level for the service. Can be: `trace`, `debug`, `info`, `warning`, `error`, `fatal`.                                                                                                                                  | `warning`       |
+| `api.signPrivateKey`                        | RSA-PSS 2048 private key (in PKCS#1 format) for signing responses in Public API.                                                                                                                                           | `""`            |
 | `api.replicas`                              | A replica count for the pod.                                                                                                                                                                                               | `1`             |
 | `api.strategy.type`                         | Type of Kubernetes deployment. Can be `Recreate` or `RollingUpdate`.                                                                                                                                                       | `RollingUpdate` |
 | `api.strategy.rollingUpdate.maxUnavailable` | Maximum number of pods that can be created over the desired number of pods when doing [rolling update](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#rolling-update-deployment).                   | `0`             |

--- a/charts/keys/README.md
+++ b/charts/keys/README.md
@@ -39,10 +39,10 @@ See the [documentation](https://docs.2gis.com/en/on-premise/keys) to learn about
 
 ### Flags for enabling/disabling certain features.
 
-| Name                               | Description                              | Value   |
-| ---------------------------------- | ---------------------------------------- | ------- |
-| `featureFlags.enableAudit`         | Enable audit logging.                    | `false` |
-| `featureFlags.enablePublicAPISign` | Enable signing responses in Public API.. | `true`  |
+| Name                               | Description                             | Value   |
+| ---------------------------------- | --------------------------------------- | ------- |
+| `featureFlags.enableAudit`         | Enable audit logging.                   | `false` |
+| `featureFlags.enablePublicAPISign` | Enable signing responses in Public API. | `true`  |
 
 ### Admin service settings
 

--- a/charts/keys/templates/helpers.tpl
+++ b/charts/keys/templates/helpers.tpl
@@ -99,11 +99,18 @@ app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- define "keys.env.featureFlags" -}}
 - name: KEYS_FEATURE_FLAGS_AUDIT
   value: "{{ .Values.featureFlags.enableAudit }}"
+- name: KEYS_FEATURE_FLAGS_PUBLIC_API_SIGN
+  value: "{{ .Values.featureFlags.enablePublicAPISign }}"
 {{- end }}
 
 {{- define "keys.env.api" -}}
 - name: KEYS_LOG_LEVEL
   value: "{{ .Values.api.logLevel }}"
+- name: KEYS_SIGN_PRIVATE_KEY
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "keys.secret.deploys.name" . }}
+      key: signPrivateKey
 {{- end }}
 
 {{- define "keys.env.import" -}}

--- a/charts/keys/templates/helpers.tpl
+++ b/charts/keys/templates/helpers.tpl
@@ -106,11 +106,13 @@ app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- define "keys.env.api" -}}
 - name: KEYS_LOG_LEVEL
   value: "{{ .Values.api.logLevel }}"
+{{- if .Values.featureFlags.enablePublicAPISign }}
 - name: KEYS_SIGN_PRIVATE_KEY
   valueFrom:
     secretKeyRef:
       name: {{ include "keys.secret.deploys.name" . }}
       key: signPrivateKey
+{{- end }}
 {{- end }}
 
 {{- define "keys.env.import" -}}

--- a/charts/keys/templates/secret-deploys.yaml
+++ b/charts/keys/templates/secret-deploys.yaml
@@ -12,6 +12,7 @@ data:
   dbROPassword:  {{ required "A valid .Values.postgres.ro.password required" .Values.postgres.ro.password | b64enc }}
   dbRWPassword:  {{ required "A valid .Values.postgres.rw.password required" .Values.postgres.rw.password | b64enc }}
   ldapBindPassword: {{ .Values.ldap.bind.password | b64enc }}
+  signPrivateKey: {{ .Values.api.signPrivateKey | b64enc }}
   {{- if .Values.redis.password }}
   redisPassword: {{ .Values.redis.password | b64enc }}
   {{- end }}

--- a/charts/keys/templates/secret-deploys.yaml
+++ b/charts/keys/templates/secret-deploys.yaml
@@ -12,7 +12,9 @@ data:
   dbROPassword:  {{ required "A valid .Values.postgres.ro.password required" .Values.postgres.ro.password | b64enc }}
   dbRWPassword:  {{ required "A valid .Values.postgres.rw.password required" .Values.postgres.rw.password | b64enc }}
   ldapBindPassword: {{ .Values.ldap.bind.password | b64enc }}
-  signPrivateKey: {{ .Values.api.signPrivateKey | b64enc }}
+  {{- if .Values.featureFlags.enablePublicAPISign }}
+  signPrivateKey: {{ required "A valid .Values.api.signPrivateKey required" .Values.api.signPrivateKey | b64enc }}
+  {{- end }}
   {{- if .Values.redis.password }}
   redisPassword: {{ .Values.redis.password | b64enc }}
   {{- end }}

--- a/charts/keys/values.yaml
+++ b/charts/keys/values.yaml
@@ -23,8 +23,10 @@ imagePullPolicy: IfNotPresent
 
 featureFlags:
   # @param featureFlags.enableAudit Enable audit logging.
+  # @param featureFlags.enablePublicAPISign Enable signing responses in Public API..
 
   enableAudit: false
+  enablePublicAPISign: true
 
 backend:
   image:
@@ -140,7 +142,16 @@ api:
   adminSessionTTL: 336h
 
   # @param api.logLevel Log level for the service. Can be: `trace`, `debug`, `info`, `warning`, `error`, `fatal`.
+  #
   logLevel: warning
+
+  # @param api.signPrivateKey RSA-PSS 2048 private key (in PKCS#1 format) for signing responses in Public API.
+
+  signPrivateKey: ''
+  # signPrivateKey: |
+      # -----BEGIN CERTIFICATE-----
+      # ...
+      # -----END CERTIFICATE-----
 
   # @param api.replicas A replica count for the pod.
 

--- a/charts/keys/values.yaml
+++ b/charts/keys/values.yaml
@@ -31,7 +31,7 @@ featureFlags:
 backend:
   image:
     repository: 2gis-on-premise/keys-backend
-    tag: 1.79.0
+    tag: 1.85.2
 
 # @section Admin service settings
 

--- a/charts/keys/values.yaml
+++ b/charts/keys/values.yaml
@@ -26,7 +26,7 @@ featureFlags:
   # @param featureFlags.enablePublicAPISign Enable signing responses in Public API.
 
   enableAudit: false
-  enablePublicAPISign: true
+  enablePublicAPISign: false
 
 backend:
   image:

--- a/charts/keys/values.yaml
+++ b/charts/keys/values.yaml
@@ -23,7 +23,7 @@ imagePullPolicy: IfNotPresent
 
 featureFlags:
   # @param featureFlags.enableAudit Enable audit logging.
-  # @param featureFlags.enablePublicAPISign Enable signing responses in Public API..
+  # @param featureFlags.enablePublicAPISign Enable signing responses in Public API.
 
   enableAudit: false
   enablePublicAPISign: true
@@ -142,7 +142,6 @@ api:
   adminSessionTTL: 336h
 
   # @param api.logLevel Log level for the service. Can be: `trace`, `debug`, `info`, `warning`, `error`, `fatal`.
-  #
   logLevel: warning
 
   # @param api.signPrivateKey RSA-PSS 2048 private key (in PKCS#1 format) for signing responses in Public API.


### PR DESCRIPTION
# Pull Request description

## Changelog

Добавлены новые параметры:
- `featureFlags.enablePublicAPISign` - управляем наличием подписи ответа в методах Public API.
- `api.signPrivateKey` - сам приватный ключ, которым будет подписываться ответ.

## Issues

- [WAPI-23482](https://jira.2gis.ru/browse/WAPI-23482)

## Breaking changes

## Check-list. Чек-лист код-ревью

- [x] Запрос на слияние в develop.
- [x] Есть описание к PR.
- [x] Указаны блокирующие изменения. [Breaking-Changes](../Breaking-Changes.md)
- [x] Соответствие кода принятому [стилю](../styleguide.md)
  - [x] Описание настроек.
  - [x] Именование настроек.
  - [x] Дефолтные значения.
  - [x] Стиль кода.
- [x] Работоспособность. Разворачивается на своем окружении из ветки PR.
  - [ ] Тест API через тесты helmfile-хуков или коллекций Postman.
- [x] Не осталось мусора от удаления каких-то параметров. Ищется поиском по проекту из ветки PR.
- [x] Отработка линтера на чарт из ветки PR. Пример: `helm lint charts/search-api`
