### PR TITLE
Add missing default for enabled_modules->predictors in citylens-web configmap

### DIFF
--- a/charts/citylens/templates/web/configmap.yaml
+++ b/charts/citylens/templates/web/configmap.yaml
@@ -132,4 +132,4 @@ data:
         {{- end }}
       {{- end }}
       predictors:
-        {{- toYaml .Values.kafka.predictorsExtraTopics | nindent 8 }}
+        {{- toYaml (.Values.kafka.predictorsExtraTopics | default list) | nindent 8 }}


### PR DESCRIPTION
# Pull Request description

## Changelog

- citylens-web
  - Add missing default value for `.Values.kafka.predictorsExtraTopics` to config template (in configmap)

## Check-list. Чек-лист код-ревью

- [ ] Запрос на слияние в develop.
- [ ] Есть описание к PR.
- [ ] Указаны блокирующие изменения. [Breaking-Changes](../Breaking-Changes.md)
- [ ] Соответствие кода принятому [стилю](../styleguide.md)
  - [ ] Описание настроек.
  - [ ] Именование настроек.
  - [ ] Дефолтные значения.
  - [ ] Стиль кода.
- [ ] Работоспособность. Разворачивается на своем окружении из ветки PR.
  - [ ] Тест API через тесты helmfile-хуков или коллекций Postman.
- [ ] Не осталось мусора от удаления каких-то параметров. Ищется поиском по проекту из ветки PR.
- [ ] Отработка линтера на чарт из ветки PR. Пример: `helm lint charts/search-api`
