### PR TITLE
Add ability to add extra env vars to citylens-web deployment

### DIFF
--- a/charts/citylens/templates/web/deployment.yaml
+++ b/charts/citylens/templates/web/deployment.yaml
@@ -67,6 +67,11 @@ spec:
             - name: SSL_CERT_DIR
               value: {{ include "citylens.customCA.mountPath" $ }}
             {{- end }}
+            {{- if .Values.web.extraEnvVars }}
+            {{- range $env_name, $env_value := .Values.web.extraEnvVars }}
+            - name: {{ $env_name }}
+              value: {{ $env_value | squote }}
+            {{- end }}
           resources:
             {{- toYaml .Values.web.resources | nindent 12 }}
           volumeMounts:

--- a/charts/citylens/templates/web/deployment.yaml
+++ b/charts/citylens/templates/web/deployment.yaml
@@ -72,6 +72,7 @@ spec:
             - name: {{ $env_name }}
               value: {{ $env_value | squote }}
             {{- end }}
+            {{- end }}
           resources:
             {{- toYaml .Values.web.resources | nindent 12 }}
           volumeMounts:


### PR DESCRIPTION
# Pull Request description

## Changelog

- Add ability to add extra env vars to citylens-web deployment

## Check-list. Чек-лист код-ревью

- [ ] Запрос на слияние в develop.
- [ ] Есть описание к PR.
- [ ] Указаны блокирующие изменения. [Breaking-Changes](../Breaking-Changes.md)
- [ ] Соответствие кода принятому [стилю](../styleguide.md)
  - [ ] Описание настроек.
  - [ ] Именование настроек.
  - [ ] Дефолтные значения.
  - [ ] Стиль кода.
- [ ] Работоспособность. Разворачивается на своем окружении из ветки PR.
  - [ ] Тест API через тесты helmfile-хуков или коллекций Postman.
- [ ] Не осталось мусора от удаления каких-то параметров. Ищется поиском по проекту из ветки PR.
- [ ] Отработка линтера на чарт из ветки PR. Пример: `helm lint charts/search-api`
