### PR TITLE
[EVERGIS] websocket-services должен указывать на backend.service.name. Required defaults

### DIFF
--- a/charts/gis-platform/README.md
+++ b/charts/gis-platform/README.md
@@ -84,11 +84,11 @@ See the [documentation](https://docs.2gis.com/en/on-premise/gis-platform) to lea
 | `spcore.postgres.name`                      | PostgreSQL database name **Required**                                                               | `""`                |
 | `spcore.postgres.poolsize`                  | PostgreSQL connection pool size.                                                                    | `25`                |
 | `spcore.admin`                              | **Admin access settings.**                                                                          |                     |
-| `spcore.admin.email`                        | Admin email **Required**                                                                            | `admin@example.com` |
-| `spcore.admin.password`                     | Admin password **Required**                                                                         | `123456`            |
+| `spcore.admin.email`                        | Admin email **Required** Example: admin@example.com                                                 | `""`                |
+| `spcore.admin.password`                     | Admin password **Required**                                                                         | `""`                |
 | `spcore.jwt`                                | **JSON Web Token (JWT) settings.**                                                                  |                     |
-| `spcore.jwt.tokenKey`                       | JWT default user token **Required**                                                                 | `supersecrettoken`  |
-| `spcore.jwt.tokenAdmin`                     | JWT admin user token **Required**                                                                   | `supersecrettoken`  |
+| `spcore.jwt.tokenKey`                       | JWT default user token **Required**                                                                 | `""`                |
+| `spcore.jwt.tokenAdmin`                     | JWT admin user token **Required**                                                                   | `""`                |
 | `spcore.catalog`                            | **Catalog settings.**                                                                               |                     |
 | `spcore.catalog.url`                        | Catalog service URL **Required** Example: `http://catalog-api`                                      | `""`                |
 | `spcore.catalog.key`                        | Catalog access key **Required**                                                                     | `""`                |

--- a/charts/gis-platform/templates/gis-platform-websocket-ingress.yaml
+++ b/charts/gis-platform/templates/gis-platform-websocket-ingress.yaml
@@ -11,7 +11,7 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-connect-timeout: {{ .Values.portal.websocket.timeout | quote }}
     nginx.ingress.kubernetes.io/proxy-read-timeout: {{ .Values.portal.websocket.timeout | quote }}
     nginx.ingress.kubernetes.io/proxy-send-timeout: {{ .Values.portal.websocket.timeout | quote }}
-    nginx.org/websocket-services: websocket
+    nginx.org/websocket-services: {{ $fullName }}
   {{- if .Values.ingress.annotations }}
     {{- with .Values.ingress.annotations }}
     {{- toYaml . | nindent 4 }}

--- a/charts/gis-platform/values.yaml
+++ b/charts/gis-platform/values.yaml
@@ -126,20 +126,20 @@ spcore:
     poolsize: 25
 
   # @extra spcore.admin **Admin access settings.**
-  # @param spcore.admin.email Admin email **Required**
+  # @param spcore.admin.email Admin email **Required** Example: admin@example.com
   # @param spcore.admin.password Admin password **Required**
 
   admin:
-    email: admin@example.com
-    password: '123456'
+    email: ''
+    password: ''
 
   # @extra spcore.jwt **JSON Web Token (JWT) settings.**
   # @param spcore.jwt.tokenKey JWT default user token **Required**
   # @param spcore.jwt.tokenAdmin JWT admin user token **Required**
 
   jwt:
-    tokenKey: supersecrettoken
-    tokenAdmin: supersecrettoken
+    tokenKey: ''
+    tokenAdmin: ''
 
   # @extra spcore.catalog **Catalog settings.**
   # @param spcore.catalog.url Catalog service URL **Required** Example: `http://catalog-api`


### PR DESCRIPTION
# Pull Request description

## Changelog

- websocket-services должен указывать на backend.service.name
  Надо проверить что валидация ingress проходит без ошибок и что веб-сокет работает.

- Обязательные дефолтные значения в пустую строку согласно styleguide

## Issues

## Breaking changes

- If there are breaking changes, they need to be added to the file [Breaking-Changes](../Breaking-Changes.md)

## Check-list. Чек-лист код-ревью

- [ ] Запрос на слияние в develop.
- [ ] Есть описание к PR.
- [ ] Указаны блокирующие изменения. [Breaking-Changes](../Breaking-Changes.md)
- [ ] Соответствие кода принятому [стилю](../styleguide.md)
  - [ ] Описание настроек.
  - [ ] Именование настроек.
  - [ ] Дефолтные значения.
  - [ ] Стиль кода.
- [ ] Работоспособность. Разворачивается на своем окружении из ветки PR.
  - [ ] Тест API через тесты helmfile-хуков или коллекций Postman.
- [ ] Не осталось мусора от удаления каких-то параметров. Ищется поиском по проекту из ветки PR.
- [ ] Отработка линтера на чарт из ветки PR. Пример: `helm lint charts/search-api`
