### PR TITLE
[navi-async-matrix] netloc must start with scheme

### DIFF
--- a/Breaking-Changes.md
+++ b/Breaking-Changes.md
@@ -1,5 +1,11 @@
 # 2GIS On-Premise Breaking-Changes
 
+## [#.#.#]
+
+### navi-async-matric
+
+- `s3.publicNetloc` now MUST start with `http://` or `https://` scheme
+
 ## [1.27.0]
 
 ### catalog-api

--- a/charts/navi-async-matrix/README.md
+++ b/charts/navi-async-matrix/README.md
@@ -52,7 +52,7 @@ See the [documentation](https://docs.2gis.com/en/on-premise/navigation/distance-
 | Name               | Description | Value                               |
 | ------------------ | ----------- | ----------------------------------- |
 | `image.repository` | Repository  | `2gis-on-premise/navi-async-matrix` |
-| `image.tag`        | Tag         | `1.10.3`                            |
+| `image.tag`        | Tag         | `1.11.2`                            |
 | `image.pullPolicy` | Pull Policy | `IfNotPresent`                      |
 
 ### Service account settings
@@ -187,13 +187,13 @@ See the [documentation](https://docs.2gis.com/en/on-premise/navigation/distance-
 
 ### S3-compatible storage settings
 
-| Name              | Description                                                       | Value |
-| ----------------- | ----------------------------------------------------------------- | ----- |
-| `s3.host`         | S3 endpoint URL, ex: http://async-matrix-s3.host. **Required**    | `""`  |
-| `s3.bucket`       | S3 bucket name. **Required**                                      | `""`  |
-| `s3.accessKey`    | S3 access key for accessing the bucket. **Required**              | `""`  |
-| `s3.secretKey`    | S3 secret key for accessing the bucket. **Required**              | `""`  |
-| `s3.publicNetloc` | Announce proxy URL for S3 results instead of s3.url if not empty. | `nil` |
+| Name              | Description                                                                                    | Value |
+| ----------------- | ---------------------------------------------------------------------------------------------- | ----- |
+| `s3.host`         | S3 endpoint URL, ex: http://async-matrix-s3.host. **Required**                                 | `""`  |
+| `s3.bucket`       | S3 bucket name. **Required**                                                                   | `""`  |
+| `s3.accessKey`    | S3 access key for accessing the bucket. **Required**                                           | `""`  |
+| `s3.secretKey`    | S3 secret key for accessing the bucket. **Required**                                           | `""`  |
+| `s3.publicNetloc` | Announce proxy URL for S3 results instead of s3.url if not empty. Must start with `http(s)://` | `""`  |
 
 ### API keys service
 

--- a/charts/navi-async-matrix/templates/statefulset.yaml
+++ b/charts/navi-async-matrix/templates/statefulset.yaml
@@ -177,7 +177,14 @@ spec:
             - name: DM_ASYNC_SERVICE_LOGGER_SETTING__LEVEL
               value: {{ .Values.dm.logLevel | quote }}
             {{- if .Values.s3.publicNetloc }}
+            # DM_ASYNC_SERVICE_STORAGE_SETTING__S3_PUBLIC_NETLOC for < 1.11.0
+            # DM_ASYNC_SERVICE_STORAGE_SETTING__S3_PUBLIC_NETLOC_URL for >= 1.11.0
             - name: DM_ASYNC_SERVICE_STORAGE_SETTING__S3_PUBLIC_NETLOC
+              value: {{ regexReplaceAllLiteral "^https?://" .Values.s3.publicNetloc "" | quote }}
+              {{- if not (regexMatch "^https?://" .Values.s3.publicNetloc) }}
+                {{- fail "s3.publicNetLoc must start with the scheme: `<scheme>://<netloc>[/]`" }}
+              {{- end }}
+            - name: DM_ASYNC_SERVICE_STORAGE_SETTING__S3_PUBLIC_NETLOC_URL
               value: {{ .Values.s3.publicNetloc | quote }}
             {{- end }}
             - name: DM_ASYNC_SERVICE_KAFKA_CONSUMER_SETTING__KAFKA_CONSUMER_TASK_TOPIC

--- a/charts/navi-async-matrix/values.yaml
+++ b/charts/navi-async-matrix/values.yaml
@@ -51,7 +51,7 @@ prometheusEnabled: true
 image:
   repository: 2gis-on-premise/navi-async-matrix
   pullPolicy: IfNotPresent
-  tag: 1.10.3
+  tag: 1.11.2
 
 
 # @section Service account settings
@@ -363,14 +363,14 @@ kafka:
 # @param s3.bucket S3 bucket name. **Required**
 # @param s3.accessKey S3 access key for accessing the bucket. **Required**
 # @param s3.secretKey S3 secret key for accessing the bucket. **Required**
-# @param s3.publicNetloc Announce proxy URL for S3 results instead of s3.url if not empty.
+# @param s3.publicNetloc Announce proxy URL for S3 results instead of s3.url if not empty. Must start with `http(s)://`
 
 s3:
   host: ''
   bucket: ''
   accessKey: ''
   secretKey: ''
-  publicNetloc:
+  publicNetloc: ''
 
 # @skip bss.enabled
 # @skip bss.url


### PR DESCRIPTION
# Pull Request description

Заготовка ПР под релиз navi-async-matrix 1.11

## Changelog

- Появилась возможность задавать схему для `s3.publicNetloc`
- Фикс подключения к кафке с использованием mTLS

## Issues

- TRAFFIC-17621
- DEVOPS-663

## Breaking changes

- Параметр `s3.publicNetloc` теперь обязан содержать схему, `http://` или `https://`

## Check-list. Чек-лист код-ревью

- [x] Запрос на слияние в develop.
- [x] Есть описание к PR.
- [x] Указаны блокирующие изменения. [Breaking-Changes](../Breaking-Changes.md)
- [x] Соответствие кода принятому [стилю](../styleguide.md)
  - [x] Описание настроек.
  - [x] Именование настроек.
  - [x] Дефолтные значения.
  - [x] Стиль кода.
- [x] Работоспособность. Разворачивается на своем окружении из ветки PR.
  - [x] Тест API через тесты helmfile-хуков или коллекций Postman.
- [x] Не осталось мусора от удаления каких-то параметров. Ищется поиском по проекту из ветки PR.
- [x] Отработка линтера на чарт из ветки PR. Пример: `helm lint charts/search-api`
