### PR TITLE
Platform 0.15.0

### DIFF
--- a/charts/platform/Chart.yaml
+++ b/charts/platform/Chart.yaml
@@ -3,8 +3,8 @@ name: platform
 type: application
 description: A Helm chart for Kubernetes to deploy Platform
 
-version: 1.26.0
-appVersion: 0.8.1
+version: 1.27.0
+appVersion: 0.15.0
 
 maintainers:
 - name: 2gis

--- a/charts/platform/README.md
+++ b/charts/platform/README.md
@@ -34,7 +34,7 @@ Use this Helm chart to deploy Platform service, which is a part of 2GIS's [On-Pr
 | Name                  | Description                    | Value                         |
 | --------------------- | ------------------------------ | ----------------------------- |
 | `ui.image.repository` | Repository                     | `2gis-on-premise/platform-ui` |
-| `ui.image.tag`        | Tag                            | `0.8.1`                       |
+| `ui.image.tag`        | Tag                            | `0.15.0`                      |
 | `imagePullSecrets`    | Kubernetes image pull secrets. | `[]`                          |
 
 ### UI service settings
@@ -64,6 +64,12 @@ Use this Helm chart to deploy Platform service, which is a part of 2GIS's [On-Pr
 | `ui.mapgl.scriptPath` | URL path to [MapGL JS API](https://docs.2gis.com/en/on-premise/map) init script relative to `ui.mapgl.url`.                                                   | `/api.js` |
 | `ui.mapgl.key`        | A key to the [MapGL JS API](https://docs.2gis.com/en/on-premise/map) service.                                                                                 | `""`      |
 | `ui.mapgl.initCenter` | Optional default map coordinates. Contains of two numbers in an array: `[lon,lat]` (e.g., `"[55.27,25.2]"` stands for Dubai, `"[37.64,55.74]"` — for Moscow). | `""`      |
+
+### Map styles API settings
+
+| Name               | Description            | Value |
+| ------------------ | ---------------------- | ----- |
+| `ui.mapStyles.url` | URL to Map Styles API. | `""`  |
 
 ### Search API settings
 

--- a/charts/platform/README.md
+++ b/charts/platform/README.md
@@ -39,11 +39,11 @@ Use this Helm chart to deploy Platform service, which is a part of 2GIS's [On-Pr
 
 ### UI service settings
 
-| Name         | Description                                                                                                                                                                                                                                          | Value  |
-| ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------ |
-| `ui.appPort` | Service port.                                                                                                                                                                                                                                        | `3000` |
-| `ui.brand`   | Branding inside the app. Possible values: `"2gis"` or `"urbi"`.                                                                                                                                                                                      | `""`   |
-| `ui.pages`   | A list of pages available in application. Values must be written with a comma. Possible values: `"status"`, `"playground"`. E.g. "status, playground". The first page in a list is the one a user's going to be redirected to from deactivated ones. | `""`   |
+| Name         | Description                                                                                                                                                                                                                                                        | Value  |
+| ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------ |
+| `ui.appPort` | Service port.                                                                                                                                                                                                                                                      | `3000` |
+| `ui.brand`   | Branding inside the app. Possible values: `"2gis"` or `"urbi"`.                                                                                                                                                                                                    | `""`   |
+| `ui.pages`   | A list of pages available in application. Values must be written with a comma. Possible values: `"status"`, `"playground", "map_styles"`. E.g. "status, playground". The first page in a list is the one a user's going to be redirected to from deactivated ones. | `""`   |
 
 ### Statuses for services. A value is a string containing pairs of label and healthcheck URL for a service. Pairs must be divided with a comma. Each pair must be connected with a symbol "=", e.g. `mapgl: 'MapGL JS=https://example.com/healthcheck'`. URL must be an absolute. You can specify only one URL, e.g. `mapgl: 'https://example.com/healthcheck'`.
 

--- a/charts/platform/templates/ui/deployment.yaml
+++ b/charts/platform/templates/ui/deployment.yaml
@@ -75,6 +75,8 @@ spec:
               value: {{ .Values.ui.navi.url | quote }}
             - name: NAVI_API_KEY
               value: {{ .Values.ui.navi.key | quote }}
+            - name: MAP_STYLES_API_URL
+              value: {{ .Values.ui.mapStyles.url | quote }}
             - name: MAPGL_URL
               value: {{ .Values.ui.mapgl.url | quote }}
             - name: MAPGL_SCRIPT_PATH

--- a/charts/platform/values.yaml
+++ b/charts/platform/values.yaml
@@ -39,7 +39,7 @@ ui:
 
   image:
     repository: 2gis-on-premise/platform-ui
-    tag: 0.8.1
+    tag: 0.15.0
 
   # @section UI service settings
 
@@ -88,6 +88,13 @@ ui:
     scriptPath: /api.js
     key: ''
     initCenter: ''
+
+  # @section Map styles API settings
+
+  # @param ui.mapStyles.url URL to Map Styles API.
+
+  mapStyles:
+    url: ''
 
   # @section Search API settings
 

--- a/charts/platform/values.yaml
+++ b/charts/platform/values.yaml
@@ -49,7 +49,7 @@ ui:
 
   # @param ui.brand Branding inside the app. Possible values: `"2gis"` or `"urbi"`.
   # @skip ui.defaultLocale
-  # @param ui.pages A list of pages available in application. Values must be written with a comma. Possible values: `"status"`, `"playground"`. E.g. "status, playground". The first page in a list is the one a user's going to be redirected to from deactivated ones.
+  # @param ui.pages A list of pages available in application. Values must be written with a comma. Possible values: `"status"`, `"playground", "map_styles"`. E.g. "status, playground". The first page in a list is the one a user's going to be redirected to from deactivated ones.
   # @skip ui.googleAnalyticsId
   # @skip ui.googleTagManagerId
 


### PR DESCRIPTION
# Pull Request description

Образ [тут](https://docker-hub.2gis.ru/harbor/projects/163/repositories/platform-ui/artifacts-tab/artifacts/sha256:0f42de58fcb404d7c3f369fed0346f1f5c3bb667fc7a2a4e36c2a87b54db59b6?sbomDigest=)

## Changelog
https://tsup.2gis.dev/gefest/gefest/changelog/0.9.0..0.15.0
- Исправлена ошибка с пропадающим маркером в песочнице Geocoder API (https://jira.2gis.ru/browse/GEFEST-230)
<details><summary>Details</summary>
<p>

1. восстановиться https://platform-2gis.web-staging.2gis.ru/playground/geocoder
2. ввести поисковой запрос cafe
3. переключить вкладку на Reverse
4. клик в первый пункт в поисковой выдаче
ОР: показали на карте маркер, сдвинули карту
5. клик в карту
ОР: в месте клика появился маркер, сдвинули карту, новая список айтемов
ФР: в месте клика нет маркера, сдвинули карту, новая список айтемов
</p>
</details> 

- Подняли минимальную версию node.js до 20.0.0 (https://jira.2gis.ru/browse/GEFEST-252)
- На страницу песочницы добавлена ссылка на документацию соответствующего сервиса (https://jira.2gis.ru/browse/GEFEST-107)

<details><summary>Details</summary>
<img width="1005" alt="Screenshot 2024-08-22 at 15 49 09" src="https://github.com/user-attachments/assets/35ae613d-de1a-4507-a95a-daba664714c3">
</details> 

- Актуализированы английские тексты под правило Title Case (https://jira.2gis.ru/browse/GEFEST-129)

<details><summary>Details</summary>
<img width="1025" alt="image" src="https://github.com/user-attachments/assets/a398be90-f237-46ba-a052-ec00acc68492">
</details> 

- Исправлена ошибка, при которой адрес запроса в песочнице Geocoder API мог формироваться некорректно (https://jira.2gis.ru/browse/GEFEST-293)

<details><summary>Details</summary>
<p>

1. Восстановиться https://platform-2gis.web-staging.2gis.ru/playground/geocoder
2. Кликнуть на все Geo-object type, чтобы в конечном счёте ни один чекбокс не был выбран

ОР: Формируется запрос без параметра в query ?type= в UI и в нетворке
ФР: Формируется запрос c параметром в query ?type= в UI и в нетворке
</p>
</details> 


- Добавлены новые страницы: список стилей карты, импорт архивов со стилями карты (https://jira.2gis.ru/browse/GEFEST-82)

<details><summary>Details</summary>
<p>

2 новые страницы: 
- https://platform-onprem.web-staging.2gis.ru/map-styles
- https://platform-onprem.web-staging.2gis.ru/map-styles/import

</p>

<img width="1728" alt="Screenshot 2024-08-22 at 15 53 15" src="https://github.com/user-attachments/assets/f4b5ca76-9f40-4cad-a8e1-5d859996d371">

<img width="1728" alt="Screenshot 2024-08-22 at 15 53 28" src="https://github.com/user-attachments/assets/4c942ea4-7adc-461c-b20f-034b42218953">

</details> 

- В Mapgl-песочнице добавлено поле ввода ID стиля (https://jira.2gis.ru/browse/GEFEST-82)

<details><summary>Details</summary>

<img width="1728" alt="image" src="https://github.com/user-attachments/assets/bec41d0a-f96a-4fc3-b68f-e8157b212b40">

</details> 

- В Helm-чарт добавлен параметр “mapStyles” (https://jira.2gis.ru/browse/GEFEST-82)


## Issues

- [GEFEST-1003](https://jira.2gis.ru/browse/GEFEST-1003)

## Breaking changes

- If there are breaking changes, they need to be added to the file [Breaking-Changes](../Breaking-Changes.md)

## Check-list. Чек-лист код-ревью

- [ ] Запрос на слияние в develop.
- [ ] Есть описание к PR.
- [ ] Указаны блокирующие изменения. [Breaking-Changes](../Breaking-Changes.md)
- [ ] Соответствие кода принятому [стилю](../styleguide.md)
  - [ ] Описание настроек.
  - [ ] Именование настроек.
  - [ ] Дефолтные значения.
  - [ ] Стиль кода.
- [ ] Работоспособность. Разворачивается на своем окружении из ветки PR.
  - [ ] Тест API через тесты helmfile-хуков или коллекций Postman.
- [ ] Не осталось мусора от удаления каких-то параметров. Ищется поиском по проекту из ветки PR.
- [ ] Отработка линтера на чарт из ветки PR. Пример: `helm lint charts/search-api`
