### PR TITLE
[chart/navi-back] chart syncup

### DIFF
--- a/charts/navi-back/Chart.yaml
+++ b/charts/navi-back/Chart.yaml
@@ -7,7 +7,7 @@ keywords:
 - back
 - backend
 version: 1.27.0
-appVersion: 7.27.0.4
+appVersion: 7.27.1.2
 dependencies:
 - name: generic-chart
   version: '*'

--- a/charts/navi-back/Chart.yaml
+++ b/charts/navi-back/Chart.yaml
@@ -7,7 +7,7 @@ keywords:
 - back
 - backend
 version: 1.27.0
-appVersion: 7.25.0.3
+appVersion: 7.27.0.4
 dependencies:
 - name: generic-chart
   version: '*'

--- a/charts/navi-back/README.md
+++ b/charts/navi-back/README.md
@@ -78,7 +78,7 @@ See the [documentation](https://docs.2gis.com/en/on-premise/navigation) to learn
 | Name               | Description | Value                       |
 | ------------------ | ----------- | --------------------------- |
 | `image.repository` | Repository  | `2gis-on-premise/navi-back` |
-| `image.tag`        | Tag         | `7.25.0.3`                  |
+| `image.tag`        | Tag         | `7.23.0.5`                  |
 | `image.pullPolicy` | Pull Policy | `IfNotPresent`              |
 
 ### Navi-Back application settings
@@ -161,8 +161,9 @@ See the [documentation](https://docs.2gis.com/en/on-premise/navigation) to learn
 | `naviback.validation.isochrone.requestSchemaName`       | Name of isochrone request validation schema                                                                                                                                                                         | `IsochroneApiRequestModel.json`          |
 | `naviback.validation.isochrone.responseSchemaName`      | Name of isochrone response validation schema                                                                                                                                                                        | `IsochroneApiResponseModel.json`         |
 | `naviback.tilesMetricsThreshold`                        | The value at which we send tiles metrics (used for internal tests)                                                                                                                                                  | `0`                                      |
-| `naviback.hierarchies.enabled`                          | If hierarchies cache available                                                                                                                                                                                      | `false`                                  |
-| `naviback.hierarchies.skipPatches`                      | Skip patches in hierarchies cache                                                                                                                                                                                   | `false`                                  |
+| `naviback.hierarchies.enabled`                          | If SN cache available                                                                                                                                                                                               | `false`                                  |
+| `naviback.hierarchies.skipPatches`                      | Skip patches in hierarchies cache, ignored if skipShortcuts set                                                                                                                                                     | `false`                                  |
+| `naviback.hierarchies.skipShortcuts`                    | Skip shortcuts in SN cache                                                                                                                                                                                          | `false`                                  |
 | `naviback.hierarchies.s3path`                           | Hierarchies cache remote location                                                                                                                                                                                   | `""`                                     |
 | `naviback.etaScheduleIndex.enabled`                     | If Schedule Index available                                                                                                                                                                                         | `false`                                  |
 | `naviback.etaScheduleIndex.url`                         | Schedule Index remote url                                                                                                                                                                                           | `""`                                     |

--- a/charts/navi-back/README.md
+++ b/charts/navi-back/README.md
@@ -78,7 +78,7 @@ See the [documentation](https://docs.2gis.com/en/on-premise/navigation) to learn
 | Name               | Description | Value                       |
 | ------------------ | ----------- | --------------------------- |
 | `image.repository` | Repository  | `2gis-on-premise/navi-back` |
-| `image.tag`        | Tag         | `7.27.0.4`                  |
+| `image.tag`        | Tag         | `7.27.1.2`                  |
 | `image.pullPolicy` | Pull Policy | `IfNotPresent`              |
 
 ### Navi-Back application settings

--- a/charts/navi-back/README.md
+++ b/charts/navi-back/README.md
@@ -78,7 +78,7 @@ See the [documentation](https://docs.2gis.com/en/on-premise/navigation) to learn
 | Name               | Description | Value                       |
 | ------------------ | ----------- | --------------------------- |
 | `image.repository` | Repository  | `2gis-on-premise/navi-back` |
-| `image.tag`        | Tag         | `7.23.0.5`                  |
+| `image.tag`        | Tag         | `7.27.0.4`                  |
 | `image.pullPolicy` | Pull Policy | `IfNotPresent`              |
 
 ### Navi-Back application settings

--- a/charts/navi-back/templates/configmap.yaml
+++ b/charts/navi-back/templates/configmap.yaml
@@ -576,11 +576,12 @@ data:
         },
         {{- end }}{{- /* if .Values.naviback.rtr.enabled */}}
         {{- if .Values.naviback.hierarchies.enabled }}
+          {{- if (not .Values.naviback.hierarchies.skipShortcuts) }}
         "hierarchies": {
           "use_hierarchy": true,
-          {{- if (not .Values.naviback.hierarchies.skipPatches) }}
+            {{- if (not .Values.naviback.hierarchies.skipPatches) }}
           "patches_file_name": "{PATCHES_PATH}",
-          {{- end }}{{- /* if (not .Values.naviback.hierarchies.skipPatches) */}}
+            {{- end }}{{- /* if (not .Values.naviback.hierarchies.skipPatches) */}}
           "graphs_file_name": "{SHORTCUT_PATH}"
         },
         "hierarchy_shortcuts": {
@@ -592,7 +593,7 @@ data:
             "count": 600
           }
         },
-        {{- if (not .Values.naviback.hierarchies.skipPatches) }}
+          {{- if (not .Values.naviback.hierarchies.skipPatches) }}
         "hierarchy_patches": {
           "update_period": {{ .Values.naviback.disableUpdates | ternary 604800 600 }},
           "nodes": [
@@ -602,7 +603,8 @@ data:
             "count": 600
           }
         },
-        {{- end }}{{- /* if (not .Values.naviback.hierarchies.skipPatches) */}}
+          {{- end }}{{- /* if (not .Values.naviback.hierarchies.skipPatches) */}}
+        {{- end }}{{- /* (not .Values.naviback.hierarchies.skipShortcuts) */}}
         "sn_import": {
           "update_period": {{ .Values.naviback.disableUpdates | ternary 604800 600 }},
           "nodes": [

--- a/charts/navi-back/values.yaml
+++ b/charts/navi-back/values.yaml
@@ -106,7 +106,7 @@ args: []
 image:
   repository: 2gis-on-premise/navi-back
   pullPolicy: IfNotPresent
-  tag: 7.27.0.4
+  tag: 7.27.1.2
 
 
 # @section Navi-Back application settings

--- a/charts/navi-back/values.yaml
+++ b/charts/navi-back/values.yaml
@@ -106,7 +106,7 @@ args: []
 image:
   repository: 2gis-on-premise/navi-back
   pullPolicy: IfNotPresent
-  tag: 7.23.0.5
+  tag: 7.27.0.4
 
 
 # @section Navi-Back application settings

--- a/charts/navi-back/values.yaml
+++ b/charts/navi-back/values.yaml
@@ -106,7 +106,7 @@ args: []
 image:
   repository: 2gis-on-premise/navi-back
   pullPolicy: IfNotPresent
-  tag: 7.25.0.3
+  tag: 7.23.0.5
 
 
 # @section Navi-Back application settings
@@ -216,8 +216,9 @@ image:
 # @param naviback.validation.isochrone.requestSchemaName Name of isochrone request validation schema
 # @param naviback.validation.isochrone.responseSchemaName Name of isochrone response validation schema
 # @param naviback.tilesMetricsThreshold The value at which we send tiles metrics (used for internal tests)
-# @param naviback.hierarchies.enabled If hierarchies cache available
-# @param naviback.hierarchies.skipPatches Skip patches in hierarchies cache
+# @param naviback.hierarchies.enabled If SN cache available
+# @param naviback.hierarchies.skipPatches Skip patches in hierarchies cache, ignored if skipShortcuts set
+# @param naviback.hierarchies.skipShortcuts Skip shortcuts in SN cache
 # @param naviback.hierarchies.s3path Hierarchies cache remote location
 # @param naviback.etaScheduleIndex.enabled If Schedule Index available
 # @param naviback.etaScheduleIndex.url Schedule Index remote url
@@ -347,6 +348,7 @@ naviback:
   hierarchies:
     enabled: false
     skipPatches: false
+    skipShortcuts: false
     s3path: ''
   etaScheduleIndex:
     enabled: false


### PR DESCRIPTION
# Pull Request description

## Changelog

- Исправлено падение Моисея при попытке обновления движков в процессе завершения работы сервиса.
- Максимальное время проезда sharing-маршрутов сохраняется в Kafka.
- Произведена небольшая очистка логов от шума.
- Исправлен баг с конфигурацией префикса при логгировании в json режиме.
- Поддержаны идентификаторы карточек для барьеров.
- Обработка онлайн скоростей полностью переведена на float тип данных.
- В Isochrone, DistanceMatrix параметр mode переименован на transport с поддержкой обратной совместимости.
- В строке запроса Pairs, а также в RoutingV7 в поле transport измененены поля: car -> driving, pedestrian -> walking с поддержкой обратной совместимости.
- В поиске с промежуточными точками теперь выбирается лучший промежуточный маршрут по стоимости, а не по времени.
- Поддержан учет сезонности подмаршрута в подклейке для ППНОТ без учёта расписания.
- Исправлен баг с изменением времени начала маршрута в ОТ, если пеший отрезок от точки А до метро отсутствует.

## Breaking changes

n/a

## Check-list. Чек-лист код-ревью

- [x] Запрос на слияние в develop.
- [x] Есть описание к PR.
- [x] Указаны блокирующие изменения. [Breaking-Changes](../Breaking-Changes.md)
- [x] Соответствие кода принятому [стилю](../styleguide.md)
  - [x] Описание настроек.
  - [x] Именование настроек.
  - [x] Дефолтные значения.
  - [x] Стиль кода.
- [x] Работоспособность. Разворачивается на своем окружении из ветки PR.
  - [x] Тест API через тесты helmfile-хуков или коллекций Postman.
- [x] Не осталось мусора от удаления каких-то параметров. Ищется поиском по проекту из ветки PR.
- [x] Отработка линтера на чарт из ветки PR. Пример: `helm lint charts/search-api`
