### PR TITLE
WAPI-23770 поддержка securityContext в catalog api

### DIFF
--- a/charts/catalog-api/README.md
+++ b/charts/catalog-api/README.md
@@ -28,15 +28,16 @@ See the [documentation](https://docs.2gis.com/en/on-premise/search) to learn abo
 
 ### Common settings
 
-| Name               | Description                                                                                                                                         | Value |
-| ------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------- | ----- |
-| `nodeSelector`     | Kubernetes [node selectors](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector)                                  | `{}`  |
-| `affinity`         | Kubernetes [pod affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity)                                   | `{}`  |
-| `tolerations`      | Kubernetes [tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) settings                                    | `[]`  |
-| `annotations`      | Kubernetes [annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/).                                           | `{}`  |
-| `podAnnotations`   | Kubernetes [pod annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/)                                        | `{}`  |
-| `podLabels`        | Kubernetes [pod labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/)                                                  | `{}`  |
-| `imagePullSecrets` | Kubernetes [secrets for pulling the image from the registry](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/) | `[]`  |
+| Name                 | Description                                                                                                                                         | Value |
+| -------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- | ----- |
+| `nodeSelector`       | Kubernetes [node selectors](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector)                                  | `{}`  |
+| `affinity`           | Kubernetes [pod affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity)                                   | `{}`  |
+| `tolerations`        | Kubernetes [tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) settings                                    | `[]`  |
+| `annotations`        | Kubernetes [annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/).                                           | `{}`  |
+| `podAnnotations`     | Kubernetes [pod annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/)                                        | `{}`  |
+| `podLabels`          | Kubernetes [pod labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/)                                                  | `{}`  |
+| `podSecurityContext` | Kubernetes [pod security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/)                                       | `{}`  |
+| `imagePullSecrets`   | Kubernetes [secrets for pulling the image from the registry](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/) | `[]`  |
 
 ### Kubernetes [Pod Disruption Budget](https://kubernetes.io/docs/concepts/workloads/pods/disruptions/#pod-disruption-budgets) settings
 

--- a/charts/catalog-api/templates/api/deployment.yaml
+++ b/charts/catalog-api/templates/api/deployment.yaml
@@ -40,8 +40,10 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
+      {{- with .Values.podSecurityContext }}
       securityContext:
-        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- if .Values.api.postgres.tls.enabled }}
       initContainers:
       - name: copy-certs

--- a/charts/catalog-api/templates/api/deployment.yaml
+++ b/charts/catalog-api/templates/api/deployment.yaml
@@ -40,6 +40,8 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
       {{- if .Values.api.postgres.tls.enabled }}
       initContainers:
       - name: copy-certs

--- a/charts/catalog-api/templates/importer/cleaner/job.yaml
+++ b/charts/catalog-api/templates/importer/cleaner/job.yaml
@@ -16,6 +16,8 @@ spec:
       labels:
         {{- include "catalog.importer.labels" . | nindent 8 }}
     spec:
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
       restartPolicy: Never
       {{- if .Values.importer.postgres.tls.enabled }}
       initContainers:

--- a/charts/catalog-api/templates/importer/cleaner/job.yaml
+++ b/charts/catalog-api/templates/importer/cleaner/job.yaml
@@ -16,8 +16,10 @@ spec:
       labels:
         {{- include "catalog.importer.labels" . | nindent 8 }}
     spec:
+      {{- with .Values.podSecurityContext }}
       securityContext:
-        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       restartPolicy: Never
       {{- if .Values.importer.postgres.tls.enabled }}
       initContainers:

--- a/charts/catalog-api/templates/importer/job.yaml
+++ b/charts/catalog-api/templates/importer/job.yaml
@@ -16,6 +16,8 @@ spec:
       labels:
         {{- include "catalog.importer.labels" . | nindent 8 }}
     spec:
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
       restartPolicy: Never
       {{- if or .Values.importer.initialDelaySeconds .Values.importer.postgres.tls.enabled }}
       initContainers:

--- a/charts/catalog-api/templates/importer/job.yaml
+++ b/charts/catalog-api/templates/importer/job.yaml
@@ -16,8 +16,10 @@ spec:
       labels:
         {{- include "catalog.importer.labels" . | nindent 8 }}
     spec:
+      {{- with .Values.podSecurityContext }}
       securityContext:
-        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       restartPolicy: Never
       {{- if or .Values.importer.initialDelaySeconds .Values.importer.postgres.tls.enabled }}
       initContainers:

--- a/charts/catalog-api/values.yaml
+++ b/charts/catalog-api/values.yaml
@@ -13,6 +13,7 @@ dgctlDockerRegistry: ''
 # @param annotations Kubernetes [annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/).
 # @param podAnnotations Kubernetes [pod annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/)
 # @param podLabels Kubernetes [pod labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/)
+# @param podSecurityContext Kubernetes [pod security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/)
 # @param imagePullSecrets Kubernetes [secrets for pulling the image from the registry](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/)
 
 nodeSelector: {}
@@ -21,6 +22,7 @@ tolerations: []
 annotations: {}
 podAnnotations: {}
 podLabels: {}
+podSecurityContext: {}
 imagePullSecrets: []
 
 


### PR DESCRIPTION
# Pull Request description

## Changelog

- `Добавлен проброс поля securityContext в chart catalog-api`

## Issues

- `WAPI-23770` (https://jira.2gis.ru/browse/WAPI-23770)

## Check-list. Чек-лист код-ревью

- [x] Запрос на слияние в develop.
- [x] Есть описание к PR.
- [x] Указаны блокирующие изменения. [Breaking-Changes](../Breaking-Changes.md)
- [x] Соответствие кода принятому [стилю](../styleguide.md)
  - [x] Описание настроек.
  - [x] Именование настроек.
  - [x] Дефолтные значения.
  - [x] Стиль кода.
- [x] Работоспособность. Разворачивается на своем окружении из ветки PR.
  - [x] Тест API через тесты helmfile-хуков или коллекций Postman.
- [x] Не осталось мусора от удаления каких-то параметров. Ищется поиском по проекту из ветки PR.
- [x] Отработка линтера на чарт из ветки PR. Пример: `helm lint charts/search-api`
