### PR TITLE
GEFEST-1325: up keys-ui to 0.10.3

### DIFF
--- a/charts/keys/README.md
+++ b/charts/keys/README.md
@@ -33,7 +33,7 @@ See the [documentation](https://docs.2gis.com/en/on-premise/keys) to learn about
 | `backend.image.repository` | Backend service image repository. | `2gis-on-premise/keys-backend` |
 | `backend.image.tag`        | Backend service image tag.        | `1.89.0`                       |
 | `admin.image.repository`   | Admin service image repository.   | `2gis-on-premise/keys-ui`      |
-| `admin.image.tag`          | Admin service image tag.          | `0.8.0`                        |
+| `admin.image.tag`          | Admin service image tag.          | `0.10.3`                       |
 | `redis.image.repository`   | Redis image repository.           | `2gis-on-premise/keys-redis`   |
 | `redis.image.tag`          | Redis image tag.                  | `6.2.6-alpine3.15`             |
 

--- a/charts/keys/values.yaml
+++ b/charts/keys/values.yaml
@@ -38,7 +38,7 @@ backend:
 admin:
   image:
     repository: 2gis-on-premise/keys-ui
-    tag: 0.8.0
+    tag: 0.10.3
 
   # @param admin.replicas A replica count for the pod.
 

--- a/image_versions.txt
+++ b/image_versions.txt
@@ -24,7 +24,7 @@ keycloak
 keys
 	keys-backend:1.89.0
 	keys-redis:6.2.6-alpine3.15
-	keys-ui:0.8.0
+	keys-ui:0.10.3
 license
 	license:2.2.3
 mapgl-js-api


### PR DESCRIPTION
# Pull Request description

Релизить вместе с keys-api: https://github.com/2gis/on-premise-helm-charts/pull/537

## Changelog
https://tsup.2gis.dev/gefest/keys-admin/changelog/0.8.1..0.10.3

- Поправлен баг, при котором клик в алерт закрывал модалку
> Если открыто модальное окно, то при закрытии алерта, закрывается и модальное окно.

## Issues

- https://jira.2gis.ru/browse/GEFEST-1325

## Breaking changes

- If there are breaking changes, they need to be added to the file [Breaking-Changes](../Breaking-Changes.md)

## Check-list. Чек-лист код-ревью

- [ ] Запрос на слияние в develop.
- [ ] Есть описание к PR.
- [ ] Указаны блокирующие изменения. [Breaking-Changes](../Breaking-Changes.md)
- [ ] Соответствие кода принятому [стилю](../styleguide.md)
  - [ ] Описание настроек.
  - [ ] Именование настроек.
  - [ ] Дефолтные значения.
  - [ ] Стиль кода.
- [ ] Работоспособность. Разворачивается на своем окружении из ветки PR.
  - [ ] Тест API через тесты helmfile-хуков или коллекций Postman.
- [ ] Не осталось мусора от удаления каких-то параметров. Ищется поиском по проекту из ветки PR.
- [ ] Отработка линтера на чарт из ветки PR. Пример: `helm lint charts/search-api`
