### PR TITLE
GEFEST-1341 В чарт Keys в джобу импорта добавлен временный флаг для дата-миграции

### DIFF
--- a/Breaking-Changes.md
+++ b/Breaking-Changes.md
@@ -1,9 +1,15 @@
 # 2GIS On-Premise Breaking-Changes
 
+## [1.34.0]
+
+### keys
+- A temporary flag, `--migrate-data`, has been added for this release. This flag triggers the data migration required for the Routing API data in the service.
+- Ensure that `keys` service is upgraded prior to upgrading any of the `navi` services.
+
 ## [1.33.0]
 
 ### pro-api
-- permissions.settings.enabled was removed, permissions api is now always mandatory 
+- permissions.settings.enabled was removed, permissions api is now always mandatory
 - postgres.connectionString, postgres.connectionStringReadonly, postgres.password were changed to postgres.api.rw / postgres.api.ro settings
 
 

--- a/charts/keys/templates/import/job.yaml
+++ b/charts/keys/templates/import/job.yaml
@@ -25,7 +25,7 @@ spec:
         - name: migrate
           image: {{ required "A valid .Values.dgctlDockerRegistry entry required" .Values.dgctlDockerRegistry }}/{{ .Values.backend.image.repository }}:{{ .Values.backend.image.tag }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
-          command: [ "keysctl", "import" ]
+          command: [ "keysctl", "import", "--migrate-data" ]
           resources:
             {{- toYaml .Values.import.resources | nindent 12 }}
           env:


### PR DESCRIPTION
# Pull Request description

## Changelog

- В джобу импорта временно добавлено использование флага `--migrate-data`
- Версия образа остаётся из другого МР (на него смотрит текущий) 1.108.2

## Issues

- https://jira.2gis.ru/browse/GEFEST-1341

## Breaking changes

- Добавлена информация про флаг и необходимость обновления Сервиса Ключей перед обновлением сервисов Navi. 

## Check-list. Чек-лист код-ревью

- [ ] Запрос на слияние в develop.
- [ ] Есть описание к PR.
- [ ] Указаны блокирующие изменения. [Breaking-Changes](../Breaking-Changes.md)
- [ ] Соответствие кода принятому [стилю](../styleguide.md)
  - [ ] Описание настроек.
  - [ ] Именование настроек.
  - [ ] Дефолтные значения.
  - [ ] Стиль кода.
- [ ] Работоспособность. Разворачивается на своем окружении из ветки PR.
  - [ ] Тест API через тесты helmfile-хуков или коллекций Postman.
- [ ] Не осталось мусора от удаления каких-то параметров. Ищется поиском по проекту из ветки PR.
- [ ] Отработка линтера на чарт из ветки PR. Пример: `helm lint charts/search-api`
