### PR TITLE
navi back 7.33.0.5 release

### DIFF
--- a/charts/navi-back/Chart.yaml
+++ b/charts/navi-back/Chart.yaml
@@ -7,7 +7,7 @@ keywords:
 - back
 - backend
 version: 1.33.1
-appVersion: 7.29.2.2
+appVersion: 7.33.0.5
 dependencies:
 - name: generic-chart
   version: '*'

--- a/charts/navi-back/README.md
+++ b/charts/navi-back/README.md
@@ -78,7 +78,7 @@ See the [documentation](https://docs.2gis.com/en/on-premise/navigation) to learn
 | Name               | Description | Value                       |
 | ------------------ | ----------- | --------------------------- |
 | `image.repository` | Repository  | `2gis-on-premise/navi-back` |
-| `image.tag`        | Tag         | `7.29.2.2`                  |
+| `image.tag`        | Tag         | `7.33.0.5`                  |
 | `image.pullPolicy` | Pull Policy | `IfNotPresent`              |
 
 ### Navi-Back application settings
@@ -172,6 +172,7 @@ See the [documentation](https://docs.2gis.com/en/on-premise/navigation) to learn
 | `naviback.hierarchies.volume`                           | Hierarchies local cache specification. Leave empty for default emptydir.                                                                                                                                            | `{}`                                     |
 | `naviback.etaScheduleIndex.enabled`                     | If Schedule Index available                                                                                                                                                                                         | `false`                                  |
 | `naviback.etaScheduleIndex.url`                         | Schedule Index remote url                                                                                                                                                                                           | `""`                                     |
+| `naviback.etaScheduleIndex.etaScheduleNodes`            | ETA Schedule nodes                                                                                                                                                                                                  | `""`                                     |
 
 ### Envoy settings, ignored if not `transmitter.enabled`. Leave with defaults, FOR FUTURE RELEASE.
 
@@ -319,6 +320,16 @@ See the [documentation](https://docs.2gis.com/en/on-premise/navigation) to learn
 | `routesharing.topic`                | Topic to use for route sharing                                          | `sharing-kafka-topic` |
 | `routesharing.kafka.properties`     | Properties as supported by librdkafka, see `kafka` section and comments |                       |
 | `routesharing.kafka.fileProperties` | Properties stored in file, see `kafka` section and comments             | `{}`                  |
+
+### Traffic lights processing. Leave with defaults, FOR FUTURE RELEASE
+
+| Name                                 | Description                                                             | Value                  |
+| ------------------------------------ | ----------------------------------------------------------------------- | ---------------------- |
+| `trafficLights.enabled`              | If traffic lights processing enabled                                    | `false`                |
+| `trafficLights.projects`             | List of projects, for which traffic lights are processed                | `[]`                   |
+| `trafficLights.topic`                | Topic to use for traffic lights processing                              | `traffic-lights-topic` |
+| `trafficLights.kafka.properties`     | Properties as supported by librdkafka, see `kafka` section and comments |                        |
+| `trafficLights.kafka.fileProperties` | Properties stored in file, see `kafka` section and comments             | `{}`                   |
 
 ### License settings
 

--- a/charts/navi-back/README.md
+++ b/charts/navi-back/README.md
@@ -314,22 +314,22 @@ See the [documentation](https://docs.2gis.com/en/on-premise/navigation) to learn
 
 ### Route sharing properties. Leave with defaults, FOR FUTURE RELEASE
 
-| Name                                | Description                                                             | Value                 |
-| ----------------------------------- | ----------------------------------------------------------------------- | --------------------- |
-| `routesharing.enabled`              | If route sharing enabled                                                | `false`               |
-| `routesharing.topic`                | Topic to use for route sharing                                          | `sharing-kafka-topic` |
-| `routesharing.kafka.properties`     | Properties as supported by librdkafka, see `kafka` section and comments |                       |
-| `routesharing.kafka.fileProperties` | Properties stored in file, see `kafka` section and comments             | `{}`                  |
+| Name                                | Description                                                             | Value   |
+| ----------------------------------- | ----------------------------------------------------------------------- | ------- |
+| `routesharing.enabled`              | If route sharing enabled                                                | `false` |
+| `routesharing.kafka.topic`          | Topic to use for route sharing                                          | `""`    |
+| `routesharing.kafka.properties`     | Properties as supported by librdkafka, see `kafka` section and comments |         |
+| `routesharing.kafka.fileProperties` | Properties stored in file, see `kafka` section and comments             | `{}`    |
 
 ### Traffic lights processing. Leave with defaults, FOR FUTURE RELEASE
 
-| Name                                 | Description                                                             | Value                  |
-| ------------------------------------ | ----------------------------------------------------------------------- | ---------------------- |
-| `trafficLights.enabled`              | If traffic lights processing enabled                                    | `false`                |
-| `trafficLights.projects`             | List of projects, for which traffic lights are processed                | `[]`                   |
-| `trafficLights.topic`                | Topic to use for traffic lights processing                              | `traffic-lights-topic` |
-| `trafficLights.kafka.properties`     | Properties as supported by librdkafka, see `kafka` section and comments |                        |
-| `trafficLights.kafka.fileProperties` | Properties stored in file, see `kafka` section and comments             | `{}`                   |
+| Name                                 | Description                                                             | Value   |
+| ------------------------------------ | ----------------------------------------------------------------------- | ------- |
+| `trafficLights.enabled`              | If traffic lights processing enabled                                    | `false` |
+| `trafficLights.projects`             | List of projects, for which traffic lights are processed                | `[]`    |
+| `trafficLights.kafka.topic`          | Topic to use for traffic lights processing                              | `""`    |
+| `trafficLights.kafka.properties`     | Properties as supported by librdkafka, see `kafka` section and comments |         |
+| `trafficLights.kafka.fileProperties` | Properties stored in file, see `kafka` section and comments             | `{}`    |
 
 ### License settings
 

--- a/charts/navi-back/templates/configmap.yaml
+++ b/charts/navi-back/templates/configmap.yaml
@@ -468,7 +468,7 @@ data:
         {{- end }}{{- /* .Values.naviback.indices.snImport.enabled */}}
         {{- if .Values.naviback.indices.routeAsUsual.enabled }}
         "route_as_usual": {
-          "update_period": 0,
+          "update_period": 28800,
           "nodes": [
             "{{ .Values.naviback.routeAsUsualUrl }}"
           ],
@@ -649,11 +649,32 @@ data:
         },
         "eta_schedule": {
           "update_period": 0,
+          {{- if .Values.naviback.etaScheduleIndex.etaScheduleNodes }}
+          "nodes": [
+            "{{ .Values.naviback.etaScheduleIndex.etaScheduleNodes }}"
+          ],
+          {{- end }}{{/* if .Values.naviback.etaScheduleIndex.etaScheduleNodes */}}
           "timeout_seconds": {
             "count": 5
           }
         },
         {{- end }}{{- /* if .Values.naviback.etaScheduleIndex.enabled */}}
+        {{- if .Values.trafficLights.enabled }}
+        "traffic_lights_kafka": {
+          {{- $kafkaProperties := dict -}}
+          {{- range $key, $_ := .Values.trafficLights.kafka.fileProperties -}}
+          {{- $_ := set $kafkaProperties $key (printf "/etc/2gis/mosesd/secret/%s" $key) -}}
+          {{- end -}}
+          {{- $kafkaProperties := mustMerge $kafkaProperties .Values.trafficLights.kafka.properties }}
+          "kafka_properties":
+            {{- mustToPrettyJson $kafkaProperties | nindent 12 }},
+          "topic": "{{ .Values.trafficLights.topic }}",
+          {{- with .Values.trafficLights.projects }}
+          "projects":
+            {{ . | mustToPrettyJson | nindent 12 }}
+          {{- end }}
+        },
+        {{- end }}{{/* .Values.trafficLigths.enabled */}}
         {{- if .Values.naviback.additionalSections }}
           {{- include "tplvalues.render" ( dict "value" .Values.naviback.additionalSections "context" $) | nindent 8 }}
         {{- end }}

--- a/charts/navi-back/templates/configmap.yaml
+++ b/charts/navi-back/templates/configmap.yaml
@@ -565,7 +565,7 @@ data:
           {{- $kafkaProperties := mustMerge $kafkaProperties .Values.routesharing.kafka.properties }}
           "kafka_properties":
             {{- mustToPrettyJson $kafkaProperties | nindent 12 }},
-          "topic": {{ .Values.routesharing.topic | quote }}
+          "topic": {{ .Values.routesharing.kafka.topic | required "routesharing.kafka.topic is not set" | quote }}
         },
         {{- end }}{{/* .Values.routesharing.enabled */}}
         {{- if and .Values.naviback.bss.enabled .Values.naviback.bss.client.serviceRemoteAddress }}
@@ -668,7 +668,7 @@ data:
           {{- $kafkaProperties := mustMerge $kafkaProperties .Values.trafficLights.kafka.properties }}
           "kafka_properties":
             {{- mustToPrettyJson $kafkaProperties | nindent 12 }},
-          "topic": "{{ .Values.trafficLights.topic }}",
+          "topic": {{ .Values.trafficLights.kafka.topic | required "trafficLights.kafka.topic is not set" | quote }},
           {{- with .Values.trafficLights.projects }}
           "projects":
             {{ . | mustToPrettyJson | nindent 12 }}

--- a/charts/navi-back/values.yaml
+++ b/charts/navi-back/values.yaml
@@ -106,7 +106,7 @@ args: []
 image:
   repository: 2gis-on-premise/navi-back
   pullPolicy: IfNotPresent
-  tag: 7.29.2.2
+  tag: 7.33.0.5
 
 
 # @section Navi-Back application settings
@@ -229,6 +229,7 @@ image:
 # @param naviback.hierarchies.volume Hierarchies local cache specification. Leave empty for default emptydir.
 # @param naviback.etaScheduleIndex.enabled If Schedule Index available
 # @param naviback.etaScheduleIndex.url Schedule Index remote url
+# @param naviback.etaScheduleIndex.etaScheduleNodes ETA Schedule nodes
 # @skip rules
 
 naviback:
@@ -367,6 +368,7 @@ naviback:
   etaScheduleIndex:
     enabled: false
     url: ''
+    etaScheduleNodes: ''
 
 rules: []
 
@@ -640,6 +642,25 @@ dataGroup:
 routesharing:
   enabled: false
   topic: sharing-kafka-topic
+  kafka:
+    properties:
+      bootstrap.servers: kafka.host:9092
+      security.protocol: PLAINTEXT
+    fileProperties: {}
+
+# @section Traffic lights processing. Leave with defaults, FOR FUTURE RELEASE
+# @param trafficLights.enabled If traffic lights processing enabled
+# @param trafficLights.projects List of projects, for which traffic lights are processed
+# @param trafficLights.topic Topic to use for traffic lights processing
+# @extra trafficLights.kafka.properties Properties as supported by librdkafka, see `kafka` section and comments
+# @skip trafficLights.kafka.properties.bootstrap.servers
+# @skip trafficLights.kafka.properties.security.protocol
+# @param trafficLights.kafka.fileProperties Properties stored in file, see `kafka` section and comments
+
+trafficLights:
+  enabled: false
+  projects: []
+  topic: traffic-lights-topic
   kafka:
     properties:
       bootstrap.servers: kafka.host:9092

--- a/charts/navi-back/values.yaml
+++ b/charts/navi-back/values.yaml
@@ -534,7 +534,7 @@ kafka:
   groupId: navi_back
   handlersNumber: 2
   properties:
-    bootstrap.servers: kafka.host:9092
+    bootstrap.servers: ''
     security.protocol: PLAINTEXT
   fileProperties: {}
   distanceMatrix:
@@ -633,7 +633,7 @@ dataGroup:
 # @section Route sharing properties. Leave with defaults, FOR FUTURE RELEASE
 
 # @param routesharing.enabled If route sharing enabled
-# @param routesharing.topic Topic to use for route sharing
+# @param routesharing.kafka.topic Topic to use for route sharing
 # @extra routesharing.kafka.properties Properties as supported by librdkafka, see `kafka` section and comments
 # @skip routesharing.kafka.properties.bootstrap.servers
 # @skip routesharing.kafka.properties.security.protocol
@@ -641,17 +641,17 @@ dataGroup:
 
 routesharing:
   enabled: false
-  topic: sharing-kafka-topic
   kafka:
+    topic: ''
     properties:
-      bootstrap.servers: kafka.host:9092
+      bootstrap.servers: ''
       security.protocol: PLAINTEXT
     fileProperties: {}
 
 # @section Traffic lights processing. Leave with defaults, FOR FUTURE RELEASE
 # @param trafficLights.enabled If traffic lights processing enabled
 # @param trafficLights.projects List of projects, for which traffic lights are processed
-# @param trafficLights.topic Topic to use for traffic lights processing
+# @param trafficLights.kafka.topic Topic to use for traffic lights processing
 # @extra trafficLights.kafka.properties Properties as supported by librdkafka, see `kafka` section and comments
 # @skip trafficLights.kafka.properties.bootstrap.servers
 # @skip trafficLights.kafka.properties.security.protocol
@@ -660,10 +660,10 @@ routesharing:
 trafficLights:
   enabled: false
   projects: []
-  topic: traffic-lights-topic
   kafka:
+    topic: ''
     properties:
-      bootstrap.servers: kafka.host:9092
+      bootstrap.servers: ''
       security.protocol: PLAINTEXT
     fileProperties: {}
 


### PR DESCRIPTION
depends on https://github.com/2gis/on-premise-helm-charts/pull/584

# Pull Request description

## Changelog

- https://tsup.2gis.dev/navi/moses/7.33.0
- ETA schedule index parameterized
- traffic lights section for future releases added

## Issues

- `Issue-123` (Link to related issue)

## Breaking changes

- n/a

## Check-list. Чек-лист код-ревью

- [ ] Запрос на слияние в develop.
- [ ] Есть описание к PR.
- [ ] Указаны блокирующие изменения. [Breaking-Changes](../Breaking-Changes.md)
- [ ] Соответствие кода принятому [стилю](../styleguide.md)
  - [ ] Описание настроек.
  - [ ] Именование настроек.
  - [ ] Дефолтные значения.
  - [ ] Стиль кода.
- [ ] Работоспособность. Разворачивается на своем окружении из ветки PR.
  - [ ] Тест API через тесты helmfile-хуков или коллекций Postman.
- [ ] Не осталось мусора от удаления каких-то параметров. Ищется поиском по проекту из ветки PR.
- [ ] Отработка линтера на чарт из ветки PR. Пример: `helm lint charts/search-api`
