### PR TITLE
[KEYS-API] kafka TLS settings

### DIFF
--- a/charts/keys/Chart.yaml
+++ b/charts/keys/Chart.yaml
@@ -4,7 +4,7 @@ type: application
 description: A Helm chart for Kubernetes to deploy API Keys service
 
 version: 1.33.1
-appVersion: 1.89.0
+appVersion: 1.105.0
 
 maintainers:
 - name: 2gis

--- a/charts/keys/README.md
+++ b/charts/keys/README.md
@@ -31,7 +31,7 @@ See the [documentation](https://docs.2gis.com/en/on-premise/keys) to learn about
 | `imagePullSecrets`         | Kubernetes image pull secrets.    | `[]`                           |
 | `imagePullPolicy`          | Pull policy.                      | `IfNotPresent`                 |
 | `backend.image.repository` | Backend service image repository. | `2gis-on-premise/keys-backend` |
-| `backend.image.tag`        | Backend service image tag.        | `1.89.0`                       |
+| `backend.image.tag`        | Backend service image tag.        | `1.105.0`                      |
 | `admin.image.repository`   | Admin service image repository.   | `2gis-on-premise/keys-ui`      |
 | `admin.image.tag`          | Admin service image tag.          | `0.10.3`                       |
 | `redis.image.repository`   | Redis image repository.           | `2gis-on-premise/keys-redis`   |
@@ -234,15 +234,21 @@ See the [documentation](https://docs.2gis.com/en/on-premise/keys) to learn about
 
 ### Kafka settings
 
-| Name                                  | Description                                                                                                                                                | Value  |
-| ------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- | ------ |
-| `kafka.audit`                         | **Settings for sending audit messages.**                                                                                                                   |        |
-| `kafka.audit.bootstrapServers`        | Comma-separated list of host and port pairs that are the addresses of the Kafka brokers (e.g. 'localhost:9092,localhost:9093').                            | `""`   |
-| `kafka.audit.username`                | Username for authorization (SASL/PLAINTEXT SHA-512).                                                                                                       | `""`   |
-| `kafka.audit.password`                | Password for authorization (SASL/PLAINTEXT SHA-512).                                                                                                       | `""`   |
-| `kafka.audit.topic`                   | Topic to produce audit messages.                                                                                                                           | `""`   |
-| `kafka.audit.produce.retryCount`      | Number of retries to produce a message.                                                                                                                    | `5`    |
-| `kafka.audit.produce.idempotentWrite` | Flag to enable/disable [idempotent write](https://docs.confluent.io/platform/current/installation/configuration/producer-configs.html#enable-idempotence). | `true` |
+| Name                                    | Description                                                                                                                                                | Value       |
+| --------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| `kafka.bootstrapServers`                | Comma-separated list of host and port pairs that are the addresses of the Kafka brokers (e.g. 'localhost:9092,localhost:9093'). **Required**               | `""`        |
+| `kafka.securityProtocol`                | Protocol used to communicate with brokers. Valid values are: PLAINTEXT, SSL, SASL_PLAINTEXT, SASL_SSL. Default: PLAINTEXT.                                 | `PLAINTEXT` |
+| `kafka.saslMechanism`                   | Authentication mechanism when security_protocol is configured for SASL_PLAINTEXT or SASL_SSL. Valid values are: PLAIN, SCRAM-SHA-256, SCRAM-SHA-512.       | `PLAIN`     |
+| `kafka.username`                        | Username for authorization (SASL).                                                                                                                         | `""`        |
+| `kafka.password`                        | Password for authorization (SASL).                                                                                                                         | `""`        |
+| `kafka.tls.skipServerCertificateVerify` | Controls whether a client verifies the server's certificate chain and host name.                                                                           | `false`     |
+| `kafka.tls.serverCA`                    | Server's root certificate.                                                                                                                                 | `""`        |
+| `kafka.tls.clientCert`                  | Client certificate.                                                                                                                                        | `""`        |
+| `kafka.tls.clientKey`                   | Client key.                                                                                                                                                | `""`        |
+| `kafka.audit`                           | **Settings for sending audit messages.**                                                                                                                   |             |
+| `kafka.audit.topic`                     | Topic to produce audit messages. **Required**                                                                                                              | `""`        |
+| `kafka.audit.produce.retryCount`        | Number of retries to produce a message.                                                                                                                    | `5`         |
+| `kafka.audit.produce.idempotentWrite`   | Flag to enable/disable [idempotent write](https://docs.confluent.io/platform/current/installation/configuration/producer-configs.html#enable-idempotence). | `true`      |
 
 ### LDAP connection settings
 

--- a/charts/keys/templates/dispatcher/deployment.yaml
+++ b/charts/keys/templates/dispatcher/deployment.yaml
@@ -36,7 +36,7 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
-      {{- with include "keys.psql.initTLS" . }}
+      {{- with include "keys.initTLS" . }}
       initContainers:
       {{- . | nindent 8 }}
       {{- end }}
@@ -60,11 +60,13 @@ spec:
           {{- include "keys.custom.ca.volumeMounts" . | nindent 12 }}
           {{- end }}
           {{- include "keys.psql.volumeMount" . | nindent 12 }}
+          {{- include "keys.tls.kafka.volumeMount" . | nindent 12 }}
       volumes:
       {{- if .Values.customCAs.bundle }}
       {{- include "keys.custom.ca.deploys.volumes" . | nindent 8 }}
       {{- end }}
       {{- include "keys.psql.volume" . | nindent 8 }}
+      {{- include "keys.tls.kafka.volume" . | nindent 8 }}
       {{- with .Values.dispatcher.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/keys/templates/helpers.tpl
+++ b/charts/keys/templates/helpers.tpl
@@ -382,13 +382,32 @@ app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 
 {{- define "keys.env.kafka.audit" -}}
 - name: KEYS_KAFKA_AUDIT_BROKERS
-  value: "{{ .Values.kafka.audit.bootstrapServers }}"
+  value: "{{ required "A valid .Values.kafka.bootstrapServers entry required" .Values.kafka.bootstrapServers }}"
 - name: KEYS_KAFKA_AUDIT_USERNAME
-  value: "{{ .Values.kafka.audit.username }}"
+  value: "{{ .Values.kafka.username }}"
+{{- if .Values.kafka.password }}
 - name: KEYS_KAFKA_AUDIT_PASSWORD
-  value: "{{ .Values.kafka.audit.password }}"
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "keys.kafka.name" . }}
+      key: password
+{{- end }}
+- name: KEYS_KAFKA_AUDIT_SECURITY_PROTOCOL
+  value: "{{ .Values.kafka.securityProtocol }}"
+- name: KEYS_KAFKA_AUDIT_SASL_MECHANISM
+  value: "{{ .Values.kafka.saslMechanism }}"
+{{- if has .Values.kafka.securityProtocol (list "SSL" "SASL_SSL") }}
+- name: KEYS_KAFKA_AUDIT_TLS_SKIP_SERVER_CERTIFICATE_VERIFY
+  value: "{{ .Values.kafka.tls.skipServerCertificateVerify }}"
+- name: KEYS_KAFKA_AUDIT_TLS_CLIENT_CERTIFICATE_PATH
+  value: "/etc/ssl/private/kafka-client.crt"
+- name: KEYS_KAFKA_AUDIT_TLS_CLIENT_KEY_PATH
+  value: "/etc/ssl/private/kafka-client.key"
+- name: KEYS_KAFKA_AUDIT_TLS_CA_CERT_PATH
+  value: "/etc/ssl/private/kafka-ca.crt"
+{{- end }}
 - name: KEYS_KAFKA_AUDIT_TOPIC
-  value: "{{ .Values.kafka.audit.topic }}"
+  value: "{{ required "A valid .Values.kafka.audit.topic entry required" .Values.kafka.audit.topic }}"
 - name: KEYS_KAFKA_AUDIT_PRODUCE_RETRY_COUNT
   value: "{{ .Values.kafka.audit.produce.retryCount }}"
 - name: KEYS_KAFKA_AUDIT_PRODUCE_IDEMPOTENT_WRITE
@@ -534,6 +553,44 @@ Return the appropriate apiVersion for Horizontal Pod Autoscaler.
 {{- end }}
 {{- end -}}
 
+{{- define "keys.tls.kafka.checks" -}}
+{{- if has .Values.kafka.securityProtocol (list "SSL" "SASL_SSL") }}
+{{ $testVar := required "You should set .Values.kafka.tls.serverCA for selected mode" .Values.kafka.tls.serverCA }}
+{{ $testVar := required "You should set .Values.kafka.tls.clientCert for selected mode" .Values.kafka.tls.clientCert }}
+{{ $testVar := required "You should set .Values.kafka.tls.clientKey for selected mode" .Values.kafka.tls.clientKey }}
+{{- end }}
+{{- end -}}
+
+{{- define "keys.tls.kafka.volumeMount" -}}
+{{- if has .Values.kafka.securityProtocol (list "SSL" "SASL_SSL") -}}
+- name: tls-kafka
+  mountPath: /etc/ssl/private
+{{- end }}
+{{- end -}}
+
+{{- define "keys.tls.kafka.volume" -}}
+{{- if has .Values.kafka.securityProtocol (list "SSL" "SASL_SSL") -}}
+- name: tls-kafka-raw
+  secret:
+    secretName: {{ include "keys.name" . }}-tls-kafka
+    items:
+    {{- if .Values.kafka.tls.serverCA }}
+      - key: kafka-ca.crt
+        path: kafka-ca.crt
+    {{- end }}
+    {{- if .Values.kafka.tls.clientKey }}
+      - key: kafka-client.key
+        path: kafka-client.key
+    {{- end }}
+    {{- if .Values.kafka.tls.clientCert }}
+      - key: kafka-client.crt
+        path: kafka-client.crt
+    {{- end }}
+- name: tls-kafka
+  emptyDir: {}
+{{- end }}
+{{- end -}}
+
 {{- define "keys.psql.initTLS" -}}
 {{- if or 
   (has .Values.postgres.ro.tls.mode (list "verify-ca" "verify-full"))
@@ -561,4 +618,41 @@ Return the appropriate apiVersion for Horizontal Pod Autoscaler.
     - name: tls
       mountPath: /etc/ssl/psql
 {{- end -}}
+{{- end -}}
+
+{{- define "keys.initTLS" -}}
+- name: copy-certs
+  image: {{ .Values.dgctlDockerRegistry }}/{{ .Values.backend.image.repository }}:{{ .Values.backend.image.tag }}
+  command:
+    - /bin/sh
+    - -c
+    - |-
+      cp /tls/psql/* /etc/ssl/psql/ || true
+      cp /tls/kafka/* /etc/ssl/private || true
+      chmod 0400 /etc/ssl/psql/psql-ro-client.key || true
+      chmod 0400 /etc/ssl/psql/psql-rw-client.key || true
+      chmod 0400 /etc/ssl/private/kafka-client.key || true
+  resources:
+    requests:
+      cpu: 20m
+      memory: 16Mi
+    limits:
+      cpu: 20m
+      memory: 16Mi
+  volumeMounts:
+  {{ if or
+      (has .Values.postgres.ro.tls.mode (list "verify-ca" "verify-full"))
+      (has .Values.postgres.rw.tls.mode (list "verify-ca" "verify-full"))
+  }}
+    - name: tls-raw
+      mountPath: /tls/psql
+    - name: tls
+      mountPath: /etc/ssl/psql
+  {{- end }}
+  {{ if (has .Values.kafka.securityProtocol (list "SSL" "SASL_SSL")) }}
+    - name: tls-kafka-raw
+      mountPath: /tls/kafka
+    - name: tls-kafka
+      mountPath: /etc/ssl/private
+  {{- end }}
 {{- end -}}

--- a/charts/keys/templates/secret-kafka-tls.yaml
+++ b/charts/keys/templates/secret-kafka-tls.yaml
@@ -1,0 +1,25 @@
+{{- if has .Values.kafka.securityProtocol (list "SSL" "SASL_SSL") }}
+{{ include "keys.tls.kafka.checks" . }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "keys.name" . }}-tls-kafka
+  labels:
+    {{- include "keys.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-20"
+type: Opaque
+data:
+  {{- if has .Values.kafka.securityProtocol (list "SSL" "SASL_SSL") }}
+  {{- with .Values.kafka.tls.serverCA }}
+  kafka-ca.crt: {{ . | b64enc }}
+  {{- end }}
+  {{- with .Values.kafka.tls.clientKey }}
+  kafka-client.key: {{ . | b64enc }}
+  {{- end }}
+  {{- with .Values.kafka.tls.clientCert }}
+  kafka-client.crt: {{ . | b64enc }}
+  {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/keys/templates/secret-psql-tls.yaml
+++ b/charts/keys/templates/secret-psql-tls.yaml
@@ -16,9 +16,9 @@ type: Opaque
 data:
   {{- if has .Values.postgres.ro.tls.mode (list "verify-ca" "verify-full") }}
   {{- with .Values.postgres.ro.tls.serverCA }}
-  psql-ro-server-ca.crt: {{ . | b64enc}}
+  psql-ro-server-ca.crt: {{ . | b64enc }}
   {{- end }}
-  {{- if has .Values.postgres.ro.tls.mode (list "verify-full")}}
+  {{- if has .Values.postgres.ro.tls.mode (list "verify-full") }}
   {{- with .Values.postgres.ro.tls.clientKey }}
   psql-ro-client.key: {{ . | b64enc }}
   {{- end }}
@@ -29,7 +29,7 @@ data:
   {{- end }}
   {{- if has .Values.postgres.rw.tls.mode (list "verify-ca" "verify-full") }}
   {{- with .Values.postgres.rw.tls.serverCA }}
-  psql-rw-server-ca.crt: {{ . | b64enc}}
+  psql-rw-server-ca.crt: {{ . | b64enc }}
   {{- end }}
   {{- if has .Values.postgres.rw.tls.mode (list "verify-full") }}
   {{- with .Values.postgres.rw.tls.clientKey }}

--- a/charts/keys/values.yaml
+++ b/charts/keys/values.yaml
@@ -31,7 +31,7 @@ featureFlags:
 backend:
   image:
     repository: 2gis-on-premise/keys-backend
-    tag: 1.89.0
+    tag: 1.105.0
 
 # @section Admin service settings
 
@@ -555,19 +555,34 @@ postgres:
 
 kafka:
 
+  # @param kafka.bootstrapServers Comma-separated list of host and port pairs that are the addresses of the Kafka brokers (e.g. 'localhost:9092,localhost:9093'). **Required**
+  # @param kafka.securityProtocol Protocol used to communicate with brokers. Valid values are: PLAINTEXT, SSL, SASL_PLAINTEXT, SASL_SSL. Default: PLAINTEXT.
+  # @param kafka.saslMechanism Authentication mechanism when security_protocol is configured for SASL_PLAINTEXT or SASL_SSL. Valid values are: PLAIN, SCRAM-SHA-256, SCRAM-SHA-512.
+  # @param kafka.username Username for authorization (SASL).
+  # @param kafka.password Password for authorization (SASL).
+  # @param kafka.tls.skipServerCertificateVerify Controls whether a client verifies the server's certificate chain and host name.
+  # @param kafka.tls.serverCA Server's root certificate.
+  # @param kafka.tls.clientCert Client certificate.
+  # @param kafka.tls.clientKey Client key.
+
+  bootstrapServers: ''
+  securityProtocol: PLAINTEXT
+  saslMechanism: PLAIN
+  username: ''
+  password: ''
+  tls:
+    skipServerCertificateVerify: false
+    serverCA: ''
+    clientCert: ''
+    clientKey: ''
+
   # @extra kafka.audit **Settings for sending audit messages.**
 
-  # @param kafka.audit.bootstrapServers Comma-separated list of host and port pairs that are the addresses of the Kafka brokers (e.g. 'localhost:9092,localhost:9093').
-  # @param kafka.audit.username Username for authorization (SASL/PLAINTEXT SHA-512).
-  # @param kafka.audit.password Password for authorization (SASL/PLAINTEXT SHA-512).
-  # @param kafka.audit.topic Topic to produce audit messages.
+  # @param kafka.audit.topic Topic to produce audit messages. **Required**
   # @param kafka.audit.produce.retryCount Number of retries to produce a message.
   # @param kafka.audit.produce.idempotentWrite Flag to enable/disable [idempotent write](https://docs.confluent.io/platform/current/installation/configuration/producer-configs.html#enable-idempotence).
 
   audit:
-    bootstrapServers: ''
-    username: ''
-    password: ''
     topic: ''
     produce:
       retryCount: 5


### PR DESCRIPTION
# Pull Request description

## Changelog

- добавлена поддержка tls для коннектов к kafka в keys для api и counter (можно указать разные kafka), сертификаты и ключ подкладываются в смонтированный в контейнер volume из secret
- добавлено конфигурирование security protocol и sasl mechanism
- обновлен образ бекэнда до версии 1.105.0; теперь требуется вторая мажорная версия данных

## Issues

- GEFEST-856 (https://jira.2gis.ru/browse/GEFEST-856)
- GEFEST-1377 (https://jira.2gis.ru/browse/GEFEST-1377)

## Breaking changes

- If there are breaking changes, they need to be added to the file [Breaking-Changes](../Breaking-Changes.md)

## Check-list. Чек-лист код-ревью

- [ ] Запрос на слияние в develop.
- [ ] Есть описание к PR.
- [ ] Указаны блокирующие изменения. [Breaking-Changes](../Breaking-Changes.md)
- [ ] Соответствие кода принятому [стилю](../styleguide.md)
  - [ ] Описание настроек.
  - [ ] Именование настроек.
  - [ ] Дефолтные значения.
  - [ ] Стиль кода.
- [ ] Работоспособность. Разворачивается на своем окружении из ветки PR.
  - [ ] Тест API через тесты helmfile-хуков или коллекций Postman.
- [ ] Не осталось мусора от удаления каких-то параметров. Ищется поиском по проекту из ветки PR.
- [ ] Отработка линтера на чарт из ветки PR. Пример: `helm lint charts/search-api`
