### PR TITLE
GEFEST-1481 Добавил preStop хук для api в чарте Keys

### DIFF
--- a/charts/keys/templates/api/deployment.yaml
+++ b/charts/keys/templates/api/deployment.yaml
@@ -38,6 +38,7 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
+      terminationGracePeriodSeconds: 60
       {{- with include "keys.psql.initTLS" . }}
       initContainers:
       {{- . | nindent 8 }}
@@ -54,6 +55,10 @@ spec:
             httpGet:
               path: /healthcheck
               port: http
+          lifecycle:
+            preStop:
+              exec:
+                command: [ "/bin/sh", "-c", "sleep 30s" ]
           resources:
             {{- toYaml .Values.api.resources | nindent 12 }}
           env:


### PR DESCRIPTION
# Pull Request description

## Changelog

- Добавил preStop хук для API, чтобы был у нас graceful shutdown (дообрабатывались все текущие запросы и только потом под терминировался). На стороне приложения поддержать эту логику дорого, поэтому делаем так.
- Так же выставил terminationGracePeriodSeconds в 60 секунд, чтобы было с запасом (по дефолту 30).

## Issues

- [GEFEST-1481](https://jira.2gis.ru/browse/GEFEST-1481)

## Breaking changes

## Check-list. Чек-лист код-ревью

- [ ] Запрос на слияние в develop.
- [ ] Есть описание к PR.
- [ ] Указаны блокирующие изменения. [Breaking-Changes](../Breaking-Changes.md)
- [ ] Соответствие кода принятому [стилю](../styleguide.md)
  - [ ] Описание настроек.
  - [ ] Именование настроек.
  - [ ] Дефолтные значения.
  - [ ] Стиль кода.
- [ ] Работоспособность. Разворачивается на своем окружении из ветки PR.
  - [ ] Тест API через тесты helmfile-хуков или коллекций Postman.
- [ ] Не осталось мусора от удаления каких-то параметров. Ищется поиском по проекту из ветки PR.
- [ ] Отработка линтера на чарт из ветки PR. Пример: `helm lint charts/search-api`
