### PR TITLE
BASIS-2: Добавлена проба для проверки готовности пода

### DIFF
--- a/charts/tiles-api/templates/deployment.yaml
+++ b/charts/tiles-api/templates/deployment.yaml
@@ -135,6 +135,14 @@ spec:
           image: {{ required "A valid .Values.dgctlDockerRegistry entry required" .Values.dgctlDockerRegistry }}/{{ .Values.api.image.repository }}:{{ .Values.api.image.tag }}
           imagePullPolicy: {{ .Values.api.image.pullPolicy }}
 
+          readinessProbe:
+            httpGet:
+              path: /healthcheck
+              port: {{ .Values.api.containerPort }}
+            initialDelaySeconds: 30
+            timeoutSeconds: 10
+            failureThreshold: 3
+
           livenessProbe:
             httpGet:
               path: /healthcheck


### PR DESCRIPTION
# Pull Request description

## Changelog

- добавлена readiness проба для сервиса Tiles API, чтобы в случае падения под выходил из upstream
