### PR TITLE
[DEVOPS-1773] add dataGateway location

### DIFF
--- a/charts/traffic-proxy/Chart.yaml
+++ b/charts/traffic-proxy/Chart.yaml
@@ -7,6 +7,11 @@ type: application
 version: 1.38.0
 appVersion: 1.25.5
 
+dependencies:
+  - name: generic-chart
+    version: '*'
+    repository: file://../generic-chart
+
 maintainers:
 - name: 2gis
   url: https://github.com/2gis

--- a/charts/traffic-proxy/templates/_helpers.tpl
+++ b/charts/traffic-proxy/templates/_helpers.tpl
@@ -23,7 +23,9 @@
     proxy_ssl_server_name on;
     proxy_ssl_name     {{ $urlParts.host }};
   {{- end }}
-    proxy_set_header   X-API-Key {{ $.Values.proxy.apiKey }};
+  {{- if and .Values.proxy.apiKey .Values.proxy.locationDG }}
+    proxy_set_header   X-API-Key {{ .Values.proxy.apiKey }};
+  {{- end }}
     proxy_set_header   Upgrade $http_upgrade;
     proxy_set_header   Connection keep-alive;
     proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -72,7 +74,7 @@ location ~ ^/long-forecast/([^/]+)/forecasted_speeds_v2\.zip$ {
 
 {{/*4. Navi-castle endpoints*/}}
 location = /navi-castle/restrictions_index.json.zip {
-  rewrite ^ /api/v1/proxy/navi/navi-castle-index/restrictions_index.json.zip break;
+  rewrite ^ /api/v1/proxy/navi/restrictions-index/restrictions_index.json.zip break;
   {{- include "proxyParams" . }}
 }
 
@@ -81,44 +83,44 @@ location ~ ^/navi-castle/restrictions/([^/]+)/.*-restriction\.json$ {
   {{- include "proxyParams" . }}
 }
 
-{{/*5. navi-castle endpoints*/}}
-location = /navi-castle/index.json.zip {
-  rewrite ^ /api/v1/proxy/navi/navi-castle-index/index.json.zip break;
+{{/*5. navi-castle-cache endpoints*/}}
+location = /navi-castle-cache/index.json.zip {
+  rewrite ^ /api/v1/proxy/navi/restrictions-index/index.json.zip break;
   {{- include "proxyParams" . }}
 }
 
-location ~ ^/navi-castle/eta_correction/ {
-    rewrite ^/navi-castle(/eta_correction/.*)$ /api/v1/proxy/navi$1 break;
-    proxy_pass http://localhost;
+location ~ ^/navi-castle-cache/eta_correction/ {
+    rewrite ^/navi-castle-cache(/eta_correction/.*)$ /api/v1/proxy/navi/eta-correction$1 break;
+    {{- include "proxyParams" . }}
 }
 
-location ~ ^/navi-castle/smatrix/ {
-  rewrite ^/navi-castle(/smatrix/.*)$ /api/v1/proxy/navi$1 break;
+location ~ ^/navi-castle-cache/smatrix/ {
+  rewrite ^/navi-castle-cache(/smatrix/.*)$ /api/v1/proxy/navi/smatrix$1 break;
   {{- include "proxyParams" . }}
 }
 
-location ~ ^/navi-castle/probability_matrix/ {
-  rewrite ^/navi-castle(/probability_matrix/.*)$ /api/v1/proxy/navi$1 break;
+location ~ ^/navi-castle-cache/probability_matrix/ {
+  rewrite ^/navi-castle-cache(/probability_matrix/.*)$ /api/v1/proxy/navi/probability-matrix$1 break;
   {{- include "proxyParams" . }}
 }
 
-location ~ ^/navi-castle/turn_penalties/([^/]+)/([^/]+)\.zip$ {
-  rewrite ^/navi-castle/turn_penalties/(.*)\.zip$ /api/v1/proxy/navi/turn_penalties/$1.json break;
+location ~ ^/navi-castle-cache/turn_penalties/ {
+  rewrite ^/navi-castle-cache(/turn_penalties/.*)$ /api/v1/proxy/navi/turn-penalties$1 break;
   {{- include "proxyParams" . }}
 }
 
-location = /navi-castle/restricted_transport.json.zip {
-  rewrite ^ /api/v1/proxy/navi/restricted_transport-index/restricted_transport.json.zip break;
+location = /navi-castle-cache/restricted_transport.json.zip {
+  rewrite ^ /api/v1/proxy/navi/restricted-transport-index/restricted_transport.json.zip break;
   {{- include "proxyParams" . }}
 }
 
-location ~ ^/navi-castle/restricted_transport/([^/]+)/restricted_transport_platforms\.csv$ {
-  rewrite ^/navi-castle/restricted_transport/(.*)$ /api/v1/proxy/navi/restricted_transport/$1 break;
+location ~ ^/navi-castle-cache/restricted_transport/([^/]+)/restricted_transport_platforms\.csv$ {
+  rewrite ^navi-castle-cache/restricted_transport/(.*)$ /api/v1/proxy/navi/restricted-transport-platforms/restricted_transport/$1 break;
   {{- include "proxyParams" . }}
 }
 
-location ~ ^/navi-castle/restricted_transport/([^/]+)/restricted_transport_routes\.csv$ {
-  rewrite ^/navi-castle/restricted_transport/(.*)$ /api/v1/proxy/navi/restricted_transport/$1 break;
+location ~ ^/navi-castle-cache/restricted_transport/([^/]+)/restricted_transport_routes\.csv$ {
+  rewrite ^/navi-castle-cache/restricted_transport/(.*)$ /api/v1/proxy/navi/restricted-transport-routes/restricted_transport/$1 break;
   {{- include "proxyParams" . }}
 }
 location = /eta/eta-predictions/index.json {
@@ -126,7 +128,7 @@ location = /eta/eta-predictions/index.json {
   {{- include "proxyParams" . }}
 }
 location ~ ^/eta/eta-predictions/eta-predictor-([0-9])\.eta-predictor/([^/]+)/eta_prediction\.zip$ {
-  rewrite ^/eta/eta-predictions/(.*)$ /api/v1/proxy/eta-predictions/$1 break;
+  rewrite ^/eta/eta-predictions/(.*)$ /api/v1/proxy/eta-predictions/eta-predictions/$1 break;
   {{- include "proxyParams" . }}
 }
 {{- end }}

--- a/charts/traffic-proxy/templates/_helpers.tpl
+++ b/charts/traffic-proxy/templates/_helpers.tpl
@@ -1,34 +1,132 @@
-{{- define "traffic-proxy.name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-
-{{- define "traffic-proxy.fullname" -}}
-{{- if .Values.fullnameOverride -}}
-{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- if contains $name .Release.Name -}}
-{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-{{- end -}}
-{{- end -}}
-
-{{- define "traffic-proxy.chart" -}}
-{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-
-{{- define "traffic-proxy.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "traffic-proxy.name" . }}
-app.kubernetes.io/instance: {{ .Release.Name }}
-{{- end -}}
-
-{{- define "traffic-proxy.labels" -}}
-helm.sh/chart: {{ include "traffic-proxy.chart" . }}
-{{ include "traffic-proxy.selectorLabels" . }}
-{{- if .Chart.AppVersion }}
-app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- define "urlparts" -}}
+  {{- $url := .Values.proxy.host }}
+  {{- $defaultScheme := .Values.proxy.protocol }}
+  {{- if contains "://" $url }}
+    {{- $parts := regexSplit "://" $url -1 }}
+    {{- $scheme := index $parts 0 }}
+    {{- $host := index $parts 1 }}
+    {{- dict "scheme" $scheme "host" $host | toYaml }}
+  {{- else }}
+    {{- dict "scheme" $defaultScheme "host" $url | toYaml }}
+  {{- end }}
 {{- end }}
-app.kubernetes.io/managed-by: {{ .Release.Service }}
-{{- end -}}
+
+{{- define "proxyParams" -}}
+{{- $urlParts := include "urlparts" . | fromYaml }}
+  {{- if .Values.proxy.upstreams }}
+    proxy_pass         {{ $urlParts.scheme }}://backend;
+    proxy_set_header   Host {{ required "A valid .Values.proxy.host required" $urlParts.host }};
+  {{- else }}
+    proxy_pass         {{ $urlParts.scheme }}://{{ required "A valid .Values.proxy.host required" $urlParts.host }};
+  {{- end }}
+  {{- if eq $urlParts.scheme "https" }}
+    proxy_ssl_server_name on;
+    proxy_ssl_name     {{ $urlParts.host }};
+  {{- end }}
+    proxy_set_header   X-API-Key {{ $.Values.proxy.apiKey }};
+    proxy_set_header   Upgrade $http_upgrade;
+    proxy_set_header   Connection keep-alive;
+    proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header   X-Forwarded-Proto $scheme;
+  {{- if .Values.proxy.cache.enabled }}
+    proxy_cache trafficcache;
+    proxy_cache_valid any {{ .Values.proxy.cache.age }};
+    proxy_cache_bypass $http_upgrade;
+  {{- end }}
+{{- end }}
+
+{{/*Location for proxy*/}}
+{{- define "locationDG" -}}
+{{/* 1. ECA endpoints*/}}
+location = /eca/traffic/moses/speeds5.json {
+  rewrite ^ /api/v1/proxy/navi/eca-index/traffic/moses/speeds5.json break;
+  {{- include "proxyParams" . }}
+}
+
+location ~ ^/eca/speeds/calculator-prod\.k8s\.m9\.2gis\.io/ {
+  rewrite ^/eca(/speeds/calculator-prod\.k8s\.m9\.2gis\.io/.*)$ /api/v1/proxy/navi/online-speeds$1 break;
+  {{- include "proxyParams" . }}
+}
+
+{{/* 2. Forecast endpoints*/}}
+location = /forecast/index.json {
+  rewrite ^ /api/v1/proxy/navi/forecast-index/index.json break;
+  {{- include "proxyParams" . }}
+}
+
+location ~ ^/forecast/([^/]+)/forecasted_speeds_v2\.zip$ {
+  rewrite ^/forecast/(.*)$ /api/v1/proxy/navi/forecasted-speeds/$1 break;
+  {{- include "proxyParams" . }}
+}
+
+{{/*3. Long forecast endpoints*/}}
+location = /long-forecast/index.json {
+  rewrite ^ /api/v1/proxy/navi/long-forecasted-speeds-index/long_forecast_data/index.json break;
+  {{- include "proxyParams" . }}
+}
+
+location ~ ^/long-forecast/([^/]+)/forecasted_speeds_v2\.zip$ {
+  rewrite ^/long-forecast/(.*)$ /api/v1/proxy/navi/long-forecasted-speeds/long_forecast_data/$1 break;
+  {{- include "proxyParams" . }}
+}
+
+{{/*4. Navi-castle endpoints*/}}
+location = /navi-castle/restrictions_index.json.zip {
+  rewrite ^ /api/v1/proxy/navi/navi-castle-index/restrictions_index.json.zip break;
+  {{- include "proxyParams" . }}
+}
+
+location ~ ^/navi-castle/restrictions/([^/]+)/.*-restriction\.json$ {
+  rewrite ^/navi-castle/restrictions/(.*)$ /api/v1/proxy/navi/restrictions/restrictions/$1 break;
+  {{- include "proxyParams" . }}
+}
+
+{{/*5. navi-castle endpoints*/}}
+location = /navi-castle/index.json.zip {
+  rewrite ^ /api/v1/proxy/navi/navi-castle-index/index.json.zip break;
+  {{- include "proxyParams" . }}
+}
+
+location ~ ^/navi-castle/eta_correction/ {
+    rewrite ^/navi-castle(/eta_correction/.*)$ /api/v1/proxy/navi$1 break;
+    proxy_pass http://localhost;
+}
+
+location ~ ^/navi-castle/smatrix/ {
+  rewrite ^/navi-castle(/smatrix/.*)$ /api/v1/proxy/navi$1 break;
+  {{- include "proxyParams" . }}
+}
+
+location ~ ^/navi-castle/probability_matrix/ {
+  rewrite ^/navi-castle(/probability_matrix/.*)$ /api/v1/proxy/navi$1 break;
+  {{- include "proxyParams" . }}
+}
+
+location ~ ^/navi-castle/turn_penalties/([^/]+)/([^/]+)\.zip$ {
+  rewrite ^/navi-castle/turn_penalties/(.*)\.zip$ /api/v1/proxy/navi/turn_penalties/$1.json break;
+  {{- include "proxyParams" . }}
+}
+
+location = /navi-castle/restricted_transport.json.zip {
+  rewrite ^ /api/v1/proxy/navi/restricted_transport-index/restricted_transport.json.zip break;
+  {{- include "proxyParams" . }}
+}
+
+location ~ ^/navi-castle/restricted_transport/([^/]+)/restricted_transport_platforms\.csv$ {
+  rewrite ^/navi-castle/restricted_transport/(.*)$ /api/v1/proxy/navi/restricted_transport/$1 break;
+  {{- include "proxyParams" . }}
+}
+
+location ~ ^/navi-castle/restricted_transport/([^/]+)/restricted_transport_routes\.csv$ {
+  rewrite ^/navi-castle/restricted_transport/(.*)$ /api/v1/proxy/navi/restricted_transport/$1 break;
+  {{- include "proxyParams" . }}
+}
+location = /eta/eta-predictions/index.json {
+  rewrite ^ /api/v1/proxy/navi/eta-predictions-index/index.json break;
+  {{- include "proxyParams" . }}
+}
+location ~ ^/eta-predictions/eta-predictor-([0-9])\.eta-predictor/([^/]+)/eta_prediction\.zip$ {
+  rewrite ^/eta-predictions/(.*)$ /api/v1/proxy/eta-predictions/$1 break;
+  {{- include "proxyParams" . }}
+}
+{{- end }}

--- a/charts/traffic-proxy/templates/_helpers.tpl
+++ b/charts/traffic-proxy/templates/_helpers.tpl
@@ -125,8 +125,8 @@ location = /eta/eta-predictions/index.json {
   rewrite ^ /api/v1/proxy/navi/eta-predictions-index/index.json break;
   {{- include "proxyParams" . }}
 }
-location ~ ^/eta-predictions/eta-predictor-([0-9])\.eta-predictor/([^/]+)/eta_prediction\.zip$ {
-  rewrite ^/eta-predictions/(.*)$ /api/v1/proxy/eta-predictions/$1 break;
+location ~ ^/eta/eta-predictions/eta-predictor-([0-9])\.eta-predictor/([^/]+)/eta_prediction\.zip$ {
+  rewrite ^/eta/eta-predictions/(.*)$ /api/v1/proxy/eta-predictions/$1 break;
   {{- include "proxyParams" . }}
 }
 {{- end }}

--- a/charts/traffic-proxy/templates/configmap.yaml
+++ b/charts/traffic-proxy/templates/configmap.yaml
@@ -3,9 +3,9 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "traffic-proxy.fullname" . }}
+  name: {{ include "generic-chart.fullname" . }}
   labels:
-    {{- include "traffic-proxy.labels" . | nindent 4 }}
+    {{- include "generic-chart.labels" . | nindent 4 }}
 data:
   nginx.conf: |
     worker_processes {{ .Values.proxy.worker.processes }};
@@ -67,27 +67,17 @@ data:
           server_name _;
 
           location / {
-            {{ if .Values.proxy.upstreams }}
-              proxy_pass         {{ .Values.proxy.protocol }}://backend;
-              proxy_set_header   Host {{ required "A valid .Values.proxy.host required" .Values.proxy.host }};
-            {{ else }}
-              proxy_pass         {{ required "A valid .Values.proxy.host required" .Values.proxy.host }};
-            {{ end }}
-              proxy_set_header   Upgrade $http_upgrade;
-              proxy_set_header   Connection keep-alive;
-              proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
-              proxy_set_header   X-Forwarded-Proto $scheme;
-            {{ if .Values.proxy.cache.enabled }}
-              proxy_cache trafficcache;
-              proxy_cache_valid any {{ .Values.proxy.cache.age }};
-              proxy_cache_bypass $http_upgrade;
-            {{ end }}
+            {{- include "proxyParams" . | nindent 8}}
           }
 
           location /health {
               default_type text/html;
               return 200 "<!DOCTYPE html><h2>OK</h2>\n";
           }
+
+      {{ if .Values.proxy.locationDG }}
+          {{- include "locationDG" . | nindent 10}}
+      {{ end }}
 
       {{ if .Values.proxy.locations }}
         {{ range .Values.proxy.locations }}

--- a/charts/traffic-proxy/templates/deployment.yaml
+++ b/charts/traffic-proxy/templates/deployment.yaml
@@ -3,13 +3,13 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "traffic-proxy.fullname" . }}
+  name: {{ include "generic-chart.fullname" . }}
   {{- if .Values.annotations }}
   annotations:
     {{- toYaml .Values.annotations | nindent 4 }}
   {{- end }}
   labels:
-    {{- include "traffic-proxy.labels" . | nindent 4 }}
+    {{- include "generic-chart.labels" . | nindent 4 }}
   {{- if .Values.labels }}
     {{- toYaml .Values.labels | nindent 4 }}
   {{- end }}
@@ -22,7 +22,7 @@ spec:
   {{- end }}
   selector:
     matchLabels:
-      {{- include "traffic-proxy.selectorLabels" . | nindent 6 }}
+      {{- include "generic-chart.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       annotations:
@@ -31,7 +31,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
-        {{- include "traffic-proxy.selectorLabels" . | nindent 8 }}
+        {{- include "generic-chart.selectorLabels" . | nindent 8 }}
       {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -44,7 +44,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http
-              containerPort: 80
+              containerPort: {{ required "A valid .Values.proxy.listen" .Values.proxy.listen }}
               protocol: TCP
           livenessProbe:
             httpGet:
@@ -71,7 +71,7 @@ spec:
               exec:
                 command: ["/bin/sh", "-c", "sleep 5"]
           volumeMounts:
-            - name: {{ include "traffic-proxy.name" $ }}-configmap
+            - name: {{ include "generic-chart.name" $ }}-configmap
               mountPath: /etc/nginx/nginx.conf
               subPath: nginx.conf
           {{- if .Values.proxy.cache.enabled }}
@@ -79,9 +79,9 @@ spec:
               mountPath: /var/cache/nginx/trafficcache
           {{- end }}
       volumes:
-        - name: {{ include "traffic-proxy.name" . }}-configmap
+        - name: {{ include "generic-chart.name" . }}-configmap
           configMap:
-            name: {{ include "traffic-proxy.fullname" . }}
+            name: {{ include "generic-chart.fullname" . }}
             items:
               - key: nginx.conf
                 path: nginx.conf

--- a/charts/traffic-proxy/templates/ingress.yaml
+++ b/charts/traffic-proxy/templates/ingress.yaml
@@ -1,12 +1,12 @@
 {{- if .Values.ingress.enabled -}}
-{{- $fullName := include "traffic-proxy.fullname" . -}}
+{{- $fullName := include "generic-chart.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
   labels:
-    {{- include "traffic-proxy.labels" . | nindent 4 }}
+    {{- include "generic-chart.labels" . | nindent 4 }}
   {{- with .Values.ingress.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/traffic-proxy/templates/pdb.yaml
+++ b/charts/traffic-proxy/templates/pdb.yaml
@@ -5,9 +5,9 @@
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
-  name: {{ include "traffic-proxy.fullname" $ }}
+  name: {{ include "generic-chart.fullname" $ }}
   labels:
-    {{- include "traffic-proxy.labels" $ | nindent 4 }}
+    {{- include "generic-chart.labels" $ | nindent 4 }}
 spec:
   {{- if .minAvailable }}
   minAvailable: {{ .minAvailable }}
@@ -17,6 +17,6 @@ spec:
   {{- end }}
   selector:
     matchLabels:
-      {{- include "traffic-proxy.selectorLabels" $ | nindent 6 }}
+      {{- include "generic-chart.selectorLabels" $ | nindent 6 }}
 {{- end }}
 {{- end }}

--- a/charts/traffic-proxy/templates/service.yaml
+++ b/charts/traffic-proxy/templates/service.yaml
@@ -3,13 +3,13 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "traffic-proxy.fullname" . }}
+  name: {{ include "generic-chart.fullname" . }}
   {{- if .Values.service.annotations }}
   annotations:
     {{- toYaml .Values.service.annotations | nindent 4 }}
   {{- end }}
   labels:
-    {{- include "traffic-proxy.labels" . | nindent 4 }}
+    {{- include "generic-chart.labels" . | nindent 4 }}
   {{- if .Values.service.labels }}
     {{- toYaml .Values.service.labels | nindent 4 }}
   {{- end }}
@@ -22,4 +22,4 @@ spec:
       name: http
       appProtocol: http
   selector:
-    {{- include "traffic-proxy.selectorLabels" . | nindent 4 }}
+    {{- include "generic-chart.selectorLabels" . | nindent 4 }}

--- a/charts/traffic-proxy/values.yaml
+++ b/charts/traffic-proxy/values.yaml
@@ -38,6 +38,8 @@ podLabels: {}
 
 # @param proxy.host URL for the proxy server to serve, ex: https://traffic0.edromaps.2gis.com. **Required**
 # @param proxy.listen Port for the proxy server to listen.
+# @param proxy.locationDG Enable location for datagateway.api.2gis.com.
+# @skip proxy.apiKey
 # @skip proxy.protocol
 # @skip proxy.upstreams
 # @param proxy.cache.enabled If caching should be enabled for the proxy server.
@@ -53,6 +55,8 @@ podLabels: {}
 proxy:
   host: ''
   listen: 8080
+  locationDG: false
+  apiKey: ''
   protocol: https  # don't document
   upstreams: []  # don't document
   cache:


### PR DESCRIPTION
# Pull Request description

## Changelog

- Миграция на `generic-chart`
- Добавлен парсинг `porxy.host` (можно использовать как Host, так и URL)
- Добавлены директивы `proxy_ssl_server_name` и `proxy_ssl_name` (проксирование на https хост)
- Формирование директив `proxy_*` вынесено в `_helpers.tpl`
- Добавлен флаг `proxy.locationDG` (добавляет `location's` для проксирования запросов в `dataGateway`)
- Добавлен параметр `proxy.apiKey` (добавление заголовка для запроса с ключом в `dataGateway`)

## Issues

- [DEVOPS-1773](https://jira.2gis.ru/browse/DEVOPS-1773)

## Breaking changes

- \-

## Check-list. Чек-лист код-ревью

- [ ] Запрос на слияние в develop.
- [ ] Есть описание к PR.
- [ ] Указаны блокирующие изменения. [Breaking-Changes](../Breaking-Changes.md)
- [ ] Соответствие кода принятому [стилю](../styleguide.md)
  - [ ] Описание настроек.
  - [ ] Именование настроек.
  - [ ] Дефолтные значения.
  - [ ] Стиль кода.
- [ ] Работоспособность. Разворачивается на своем окружении из ветки PR.
  - [ ] Тест API через тесты helmfile-хуков или коллекций Postman.
- [ ] Не осталось мусора от удаления каких-то параметров. Ищется поиском по проекту из ветки PR.
- [ ] Отработка линтера на чарт из ветки PR. Пример: `helm lint charts/search-api`
