### PR TITLE
BASIS-281, BASIS-326 - фикс секретов и фолбэков

### DIFF
--- a/charts/tiles-api/configs/proxy.yaml
+++ b/charts/tiles-api/configs/proxy.yaml
@@ -8,9 +8,7 @@ log-format: {{ .logFormatOverride | default $.Values.logFormat | default "json" 
 proxy:
   timeout: {{ .timeout }}
   heartbeat: 1m
-  target-hosts:
-    - host: http://127.0.0.1:{{ $.Values.api.containerPort }}
-      weight: 100
+  target-host: http://127.0.0.1:{{ $.Values.api.containerPort }}
 
 access:
   enabled: {{ .access.enabled }}
@@ -21,13 +19,6 @@ access:
     {{- if .access.stat.enabled }}
     host: {{ required "Valid .Values.proxy.access.stat.url required!" .access.stat.url }}
     {{- end }}
-
-  vector:
-    token: {{ .access.vector.token }}
-  mapbox:
-    token: {{ .access.vector.token }}
-  raster:
-    token: {{ .access.raster.token }}
 
 storage:
   enabled: false

--- a/charts/tiles-api/templates/api.secret.yaml
+++ b/charts/tiles-api/templates/api.secret.yaml
@@ -9,3 +9,6 @@ type: Opaque
 data:
   cassandraUser:  {{ required "Valid .Values.cassandra.credentials.user required!" .Values.cassandra.credentials.user | b64enc }}
   cassandraPassword:  {{ required "Valid .Values.cassandra.credentials.password required!" .Values.cassandra.credentials.password | b64enc }}
+  raster_token:  {{ required "Valid .Values.proxy.access.raster.token required!" .Values.proxy.access.raster.token | b64enc }}
+  vector_token:  {{ required "Valid .Values.proxy.access.vector.token required!" .Values.proxy.access.vector.token | b64enc }}
+  mapbox_token:  {{ required "Valid .Values.proxy.access.vector.token required!" .Values.proxy.access.vector.token | b64enc }}

--- a/charts/tiles-api/templates/deployment.yaml
+++ b/charts/tiles-api/templates/deployment.yaml
@@ -134,6 +134,21 @@ spec:
             - name: SSL_CERT_DIR
               value: {{ include "tiles.customCA.mountPath" $ }}
             {{- end }}
+            - name: ACCESS_VECTOR_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "tiles.fullname" $ }}-api
+                  key: vector_token
+            - name: ACCESS_RASTER_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "tiles.fullname" $ }}-api
+                  key: raster_token
+            - name: ACCESS_MAPBOX_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "tiles.fullname" $ }}-api
+                  key: mapbox_token
         {{- end }}
 
         - name: tiles-api


### PR DESCRIPTION
BASIS-281 - перенесли токены в секреты; BASIS-326 - удалили компонент который пытался делать фолбэк в другой дц

# Pull Request description

## Changelog

- `Some changes` (A description of the changes proposed in the pull request.)

## Issues

- `Issue-123` (Link to related issue)

## Breaking changes

- If there are breaking changes, they need to be added to the file [Breaking-Changes](../Breaking-Changes.md)

## Check-list. Чек-лист код-ревью

- [ ] Запрос на слияние в develop.
- [ ] Есть описание к PR.
- [ ] Указаны блокирующие изменения. [Breaking-Changes](../Breaking-Changes.md)
- [ ] Соответствие кода принятому [стилю](../styleguide.md)
  - [ ] Описание настроек.
  - [ ] Именование настроек.
  - [ ] Дефолтные значения.
  - [ ] Стиль кода.
- [ ] Работоспособность. Разворачивается на своем окружении из ветки PR.
  - [ ] Тест API через тесты helmfile-хуков или коллекций Postman.
- [ ] Не осталось мусора от удаления каких-то параметров. Ищется поиском по проекту из ветки PR.
- [ ] Отработка линтера на чарт из ветки PR. Пример: `helm lint charts/search-api`
