### PR TITLE
Bump citylens-api to 1.17.9: fix routes api proxy endpoint

### DIFF
--- a/charts/citylens/Chart.yaml
+++ b/charts/citylens/Chart.yaml
@@ -4,7 +4,7 @@ type: application
 description: A Helm chart for Kubernetes to deploy Citylens service
 
 version: 1.38.0
-appVersion: 1.17.8
+appVersion: 1.17.9
 
 maintainers:
 - name: 2gis

--- a/charts/citylens/README.md
+++ b/charts/citylens/README.md
@@ -128,9 +128,9 @@ See the [documentation]() to learn about:
 
 ### Routes Planner integration
 
-| Name                   | Description                                                                                                                                                                          | Value |
-| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----- |
-| `api.routesApiBaseUrl` | Routes Planner API endpoint - if provided mobile application can access Routes Planner API via citylens-api /routes-api endpoint. Ex.: `http(s)://citylens-routes-api.ingress.host/` | `""`  |
+| Name                   | Description                                                                                                                                                           | Value |
+| ---------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----- |
+| `api.routesApiBaseUrl` | Routes Planner API endpoint - if provided mobile application can access Routes Planner API via citylens-api /routes-api endpoint. Ex.: http://citylens-routes-api.svc | `""`  |
 
 ### Citylens web service settings
 

--- a/charts/citylens/README.md
+++ b/charts/citylens/README.md
@@ -47,7 +47,7 @@ See the [documentation]() to learn about:
 | Name                   | Description  | Value                          |
 | ---------------------- | ------------ | ------------------------------ |
 | `api.image.repository` | Repository.  | `2gis-on-premise/citylens-api` |
-| `api.image.tag`        | Tag.         | `1.17.8`                       |
+| `api.image.tag`        | Tag.         | `1.17.9`                       |
 | `api.image.pullPolicy` | Pull Policy. | `IfNotPresent`                 |
 
 ### Resources settings
@@ -128,6 +128,9 @@ See the [documentation]() to learn about:
 
 ### Routes Planner integration
 
+| Name                   | Description                                                                                                                                                                          | Value |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----- |
+| `api.routesApiBaseUrl` | Routes Planner API endpoint - if provided mobile application can access Routes Planner API via citylens-api /routes-api endpoint. Ex.: `http(s)://citylens-routes-api.ingress.host/` | `""`  |
 
 ### Citylens web service settings
 

--- a/charts/citylens/values.yaml
+++ b/charts/citylens/values.yaml
@@ -98,13 +98,13 @@ dgctlStorage:
 
 # @section Routes Planner integration
 
-# @skip api.routesApiBaseUrl
+# @param api.routesApiBaseUrl Routes Planner API endpoint - if provided mobile application can access Routes Planner API via citylens-api /routes-api endpoint. Ex.: `http(s)://citylens-routes-api.ingress.host/`
 
 api:
   image:
     repository: 2gis-on-premise/citylens-api
     pullPolicy: IfNotPresent
-    tag: 1.17.8
+    tag: 1.17.9
 
   replicas: 4
 

--- a/charts/citylens/values.yaml
+++ b/charts/citylens/values.yaml
@@ -98,7 +98,7 @@ dgctlStorage:
 
 # @section Routes Planner integration
 
-# @param api.routesApiBaseUrl Routes Planner API endpoint - if provided mobile application can access Routes Planner API via citylens-api /routes-api endpoint. Ex.: `http(s)://citylens-routes-api.ingress.host/`
+# @param api.routesApiBaseUrl Routes Planner API endpoint - if provided mobile application can access Routes Planner API via citylens-api /routes-api endpoint. Ex.: http://citylens-routes-api.svc
 
 api:
   image:


### PR DESCRIPTION
# Pull Request description

## Changelog

- citylens-api:
  - Routes Planner integration: fix /routes-api proxy endpoint (used by mobile app for accessing Routes Planner API)

## Issues

- `CV-108`

## Breaking changes

- If there are breaking changes, they need to be added to the file [Breaking-Changes](../Breaking-Changes.md)

## Check-list. Чек-лист код-ревью

- [ ] Запрос на слияние в develop.
- [ ] Есть описание к PR.
- [ ] Указаны блокирующие изменения. [Breaking-Changes](../Breaking-Changes.md)
- [ ] Соответствие кода принятому [стилю](../styleguide.md)
  - [ ] Описание настроек.
  - [ ] Именование настроек.
  - [ ] Дефолтные значения.
  - [ ] Стиль кода.
- [ ] Работоспособность. Разворачивается на своем окружении из ветки PR.
  - [ ] Тест API через тесты helmfile-хуков или коллекций Postman.
- [ ] Не осталось мусора от удаления каких-то параметров. Ищется поиском по проекту из ветки PR.
- [ ] Отработка линтера на чарт из ветки PR. Пример: `helm lint charts/search-api`
