### PR TITLE
navi-front: chart syncup

### DIFF
--- a/charts/navi-front/README.md
+++ b/charts/navi-front/README.md
@@ -54,21 +54,33 @@ See the [documentation](https://docs.2gis.com/en/on-premise/navigation) to learn
 
 ### Navi-Front service settings
 
-| Name                           | Description                                                                      | Value       |
-| ------------------------------ | -------------------------------------------------------------------------------- | ----------- |
-| `front.port`                   | Navi-Front service HTTP port                                                     | `8080`      |
-| `front.router.discover`        | Enable/disable router autodiscovery                                              | `true`      |
-| `front.router.host`            | Set router address if autodiscovery is disabled                                  | `localhost` |
-| `front.tsp_carrouting.enabled` | Enable/disable carrouting TSP                                                    | `false`     |
-| `front.tsp_carrouting.host`    | Set carrouting TSP hostname                                                      | `""`        |
-| `front.multimod.enabled`       | Add multimodal routing service location                                          | `false`     |
-| `front.multimod.host`          | Multimodal routing service hostname                                              | `""`        |
-| `front.keepalive.enabled`      | Enable keepalive (for upstreams)                                                 | `false`     |
-| `front.keepalive.connections`  | Maximum number of idle keepalive connections (per upstream)                      | `50`        |
-| `front.keepalive.requests`     | Maximum number of requests that can be served through one keepalive connection   | `100`       |
-| `front.keepalive.time`         | Maximum time for one keepalive connection                                        | `1h`        |
-| `front.keepalive.timeout`      | Timeout for idle keepalive connection                                            | `60s`       |
-| `navigroup`                    | Service group identifier, allows multiple stacks deployed to the same namespace. | `""`        |
+| Name                                     | Description                                                                                                                            | Value                                            |
+| ---------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| `front.port`                             | Navi-Front service HTTP port                                                                                                           | `8080`                                           |
+| `front.router.discover`                  | Enable/disable router autodiscovery                                                                                                    | `true`                                           |
+| `front.router.host`                      | Set router address if autodiscovery is disabled                                                                                        | `localhost`                                      |
+| `front.router.backupPorts`               | Support for backup ports on router                                                                                                     |                                                  |
+| `front.router.backupPorts.base`          | Backup router ports start with `base` and assignd sequentially up                                                                      | `50000`                                          |
+| `front.router.backupPorts.number`        | Number of backup router ports                                                                                                          | `0`                                              |
+| `front.router.keepalive`                 | Allows router upstream overrides to front.keepalive settings                                                                           | `{}`                                             |
+| `front.router.proxy`                     | Settings for router proxy rule                                                                                                         |                                                  |
+| `front.router.proxy.nextUpstreamTimeout` | nginx [proxy_next_upstream_timeout](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_next_upstream_timeout)             | `750ms`                                          |
+| `front.router.proxy.connectTimeout`      | nginx [proxy_connect_timeout](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_connect_timeout)                         | `100ms`                                          |
+| `front.router.proxy.readTimeout`         | nginx [proxy_read_timeout](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_read_timeout)                               | `500ms`                                          |
+| `front.router.proxy.sendTimeout`         | nginx [proxy_send_timeout](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_send_timeout)                               | `500ms`                                          |
+| `front.router.proxy.nextUpstream`        | nginx [proxy_next_upstream](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_next_upstream)                             | `error timeout non_idempotent http_502 http_504` |
+| `front.tsp_carrouting.enabled`           | Enable/disable carrouting TSP                                                                                                          | `false`                                          |
+| `front.tsp_carrouting.host`              | Set carrouting TSP hostname                                                                                                            | `""`                                             |
+| `front.multimod.enabled`                 | Add multimodal routing service location                                                                                                | `false`                                          |
+| `front.multimod.host`                    | Multimodal routing service hostname                                                                                                    | `""`                                             |
+| `front.keepalive.enabled`                | Enable keepalive (for upstreams)                                                                                                       | `false`                                          |
+| `front.keepalive.connections`            | Maximum number of idle keepalive connections (per upstream)                                                                            | `50`                                             |
+| `front.keepalive.requests`               | Maximum number of requests that can be served through one keepalive connection                                                         | `100`                                            |
+| `front.keepalive.time`                   | Maximum time for one keepalive connection                                                                                              | `1h`                                             |
+| `front.keepalive.timeout`                | Timeout for idle keepalive connection                                                                                                  | `60s`                                            |
+| `front.locationExtraProxyHeaders`        | Additional headers to pass to backend `locationExtraProxyHeaders: { header1: value1, header2: 'value 2'}`                              | `{}`                                             |
+| `front.queryTimeouts`                    | Per-query timeout in seconds. If back service supports multiple queries then use max `queryTimeouts: {route_planner: 60, routing: 20}` | `{}`                                             |
+| `navigroup`                              | Service group identifier, allows multiple stacks deployed to the same namespace.                                                       | `""`                                             |
 
 ### Service account settings
 
@@ -141,7 +153,6 @@ See the [documentation](https://docs.2gis.com/en/on-premise/navigation) to learn
 | `nginx.hideBackendHostname`                      | Do not pass X-Back-Hostname header from navi-back to client                                                                                     | `true`       |
 | `nginx.protectInternalLocations`                 |                                                                                                                                                 |              |
 | `nginx.protectInternalLocations.allowedNetworks` | CIDR blocks to allow access to internal locations from. For debug purposes only                                                                 | `[]`         |
-| `nginx.connectTimeout.geocoding`                 | Timeout for connections to navi-router, nginx [time](http://nginx.org/en/docs/syntax.html#time) string                                          | `""`         |
 
 ### Location overrides
 
@@ -152,7 +163,6 @@ See the [documentation](https://docs.2gis.com/en/on-premise/navigation) to learn
 | `distMatrixCtxLocation` | Override for default /get_dist_matrix_ctx                                                        | `""`  |
 | `hullLocation`          | Override for default /get_hull                                                                   | `""`  |
 | `multimodLocation`      | Override for default /ctx_multi_mod and /find_platforms if enabled with `front.multimod.enabled` | `""`  |
-
 
 ## Maintainers
 

--- a/charts/navi-front/templates/configmap-base.yaml
+++ b/charts/navi-front/templates/configmap-base.yaml
@@ -31,6 +31,16 @@ data:
     js_var $multi_mod_ctx "none";
     js_var $multi_mod_taxi "none";
 
+    # map router's rule name to the actual CTX upstream
+    map $multi_mod_ctx $multi_mod_ctx_upstream {
+        {{- include "front.mapUpstreams" . | nindent 8 }}
+    }
+
+    # map router's rule name to the actual TAXI upstream
+    map $multi_mod_taxi $multi_mod_taxi_upstream {
+        {{- include "front.mapUpstreams" . | nindent 8 }}
+    }
+
     upstream {{ .Values.front.multimod.host }} {
         server {{ .Values.front.multimod.host }};
         {{- if .Values.front.keepalive.enabled }}
@@ -45,12 +55,16 @@ data:
     {{ include "front.createUpstreams" . | nindent 4 }}
 
     upstream router_{{ ternary (include "front.createRouterUpstream" .) .Values.front.router.host .Values.front.router.discover }} {
-        server {{ ternary (include "front.createRouterUpstream" .) .Values.front.router.host .Values.front.router.discover }};
-        {{- if .Values.front.keepalive.enabled }}
-        keepalive {{ .Values.front.keepalive.connections }};
-        keepalive_requests {{ .Values.front.keepalive.requests }};
-        keepalive_time {{ .Values.front.keepalive.time }};
-        keepalive_timeout {{ .Values.front.keepalive.timeout }};
+        server {{ ternary (include "front.createRouterUpstream" .) .Values.front.router.host .Values.front.router.discover }} max_fails=0;
+        {{- range (.Values.front.router.backupPorts.number | int | until) }}
+        server {{ ternary (include "front.createRouterUpstream" $) $.Values.front.router.host $.Values.front.router.discover }}:{{ . | add $.Values.front.router.backupPorts.base }} max_fails=0;
+        {{- end }}{{- /* range */}}
+        {{- $routerKeepalive := deepCopy .Values.front.keepalive | merge .Values.front.router.keepalive }}
+        {{- if $routerKeepalive.enabled }}
+        keepalive {{ $routerKeepalive.connections }};
+        keepalive_requests {{ $routerKeepalive.requests }};
+        keepalive_time {{ $routerKeepalive.time }};
+        keepalive_timeout {{ $routerKeepalive.timeout }};
         {{- end }}
     }
 
@@ -154,6 +168,9 @@ data:
             add_header X-Region {{ .Values.front.multimod.host }} always;
             proxy_set_header X-Multi-Mod-Taxi $multi_mod_taxi;
             proxy_set_header X-Multi-Mod-Ctx $multi_mod_ctx;
+            # replace those with the below lines once multimod supports that
+            # proxy_set_header X-Multi-Mod-Taxi $multi_mod_taxi_upstream;
+            # proxy_set_header X-Multi-Mod-Ctx $multi_mod_ctx_upstream;
             proxy_set_header X-Region-Id $multi_region_id;
             {{- if .Values.front.keepalive.enabled }}
             proxy_set_header Connection "";
@@ -162,7 +179,6 @@ data:
             proxy_pass http://{{ .Values.front.multimod.host }}$uri$is_args$args;
         }
         location /find_platforms {
-            {{ include "front.getInternalACL" . | nindent 12 }}
             js_content bundle.geo_coding;
         }
         {{- end }}
@@ -172,16 +188,34 @@ data:
             js_content bundle.geo_coding;
         }
 
+        location ~* ^/isochrone  {
+            js_content bundle.geo_coding;
+        }
+
+        location ~* ^/area_clustering {
+            js_content bundle.geo_coding;
+        }
+
         location /geocoding {
             {{ include "front.getInternalACL" . | nindent 12 }}
-            {{- if .Values.nginx.connectTimeout.geocoding }}
-            proxy_connect_timeout {{ .Values.nginx.connectTimeout.geocoding }};
-            {{- end }}
+            proxy_next_upstream_timeout {{ .Values.front.router.proxy.nextUpstreamTimeout }};
+            {{- with .Values.front.router.proxy.connectTimeout }}
+            proxy_connect_timeout {{ . }};
+            {{- end }}{{- /* with .Values.front.router.proxy.connectTimeout */}}
+            {{- with .Values.front.router.proxy.readTimeout }}
+            proxy_read_timeout {{ . }};
+            {{- end }}{{- /* with .Values.front.router.proxy.readTimeout */}}
+            {{- with .Values.front.router.proxy.sendTimeout }}
+            proxy_send_timeout {{ . }};
+            {{- end }}{{- /* with .Values.front.router.proxy.sendTimeout */}}
             rewrite ^/geocoding(.*)$ $1 break;
             {{- if .Values.front.keepalive.enabled }}
             proxy_set_header Connection "";
             proxy_http_version 1.1;
             {{- end }}
+            # retries limited by request timeout
+            proxy_next_upstream_tries 1024;
+            proxy_next_upstream {{ .Values.front.router.proxy.nextUpstream }};
             proxy_pass http://router_{{ ternary (include "front.createRouterUpstream" .) .Values.front.router.host .Values.front.router.discover }};
         }
 

--- a/charts/navi-front/values.yaml
+++ b/charts/navi-front/values.yaml
@@ -59,6 +59,16 @@ image:
 # @param front.port Navi-Front service HTTP port
 # @param front.router.discover Enable/disable router autodiscovery
 # @param front.router.host Set router address if autodiscovery is disabled
+# @extra front.router.backupPorts [nullable] Support for backup ports on router
+# @param front.router.backupPorts.base Backup router ports start with `base` and assignd sequentially up
+# @param front.router.backupPorts.number Number of backup router ports
+# @param front.router.keepalive Allows router upstream overrides to front.keepalive settings
+# @extra front.router.proxy [nullable] Settings for router proxy rule
+# @param front.router.proxy.nextUpstreamTimeout nginx [proxy_next_upstream_timeout](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_next_upstream_timeout)
+# @param front.router.proxy.connectTimeout nginx [proxy_connect_timeout](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_connect_timeout)
+# @param front.router.proxy.readTimeout nginx [proxy_read_timeout](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_read_timeout)
+# @param front.router.proxy.sendTimeout nginx [proxy_send_timeout](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_send_timeout)
+# @param front.router.proxy.nextUpstream nginx [proxy_next_upstream](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_next_upstream)
 # @param front.tsp_carrouting.enabled Enable/disable carrouting TSP
 # @param front.tsp_carrouting.host Set carrouting TSP hostname
 # @param front.multimod.enabled Add multimodal routing service location
@@ -68,6 +78,8 @@ image:
 # @param front.keepalive.requests Maximum number of requests that can be served through one keepalive connection
 # @param front.keepalive.time Maximum time for one keepalive connection
 # @param front.keepalive.timeout Timeout for idle keepalive connection
+# @param front.locationExtraProxyHeaders Additional headers to pass to backend `locationExtraProxyHeaders: { header1: value1, header2: 'value 2'}`
+# @param front.queryTimeouts Per-query timeout in seconds. If back service supports multiple queries then use max `queryTimeouts: {route_planner: 60, routing: 20}`
 # @param navigroup Service group identifier, allows multiple stacks deployed to the same namespace.
 
 front:
@@ -75,6 +87,16 @@ front:
   router:
     discover: true
     host: localhost
+    backupPorts:
+      base: 50000
+      number: 0
+    keepalive: {}
+    proxy:
+      nextUpstreamTimeout: 750ms
+      connectTimeout: 100ms
+      readTimeout: 500ms
+      sendTimeout: 500ms
+      nextUpstream: error timeout non_idempotent http_502 http_504
   tsp_carrouting:
     enabled: false
     host: ''
@@ -87,6 +109,8 @@ front:
     requests: 100
     time: 1h
     timeout: 60s
+  locationExtraProxyHeaders: {}
+  queryTimeouts: {}
 
 navigroup: ''
 
@@ -193,7 +217,6 @@ pdb:
 # @param nginx.hideBackendHostname Do not pass X-Back-Hostname header from navi-back to client
 # @extra nginx.protectInternalLocations
 # @param nginx.protectInternalLocations.allowedNetworks CIDR blocks to allow access to internal locations from. For debug purposes only
-# @param nginx.connectTimeout.geocoding Timeout for connections to navi-router, nginx [time](http://nginx.org/en/docs/syntax.html#time) string
 
 nginx:
   setRealIpFrom: 127.0.0.1
@@ -209,8 +232,6 @@ nginx:
   hideBackendHostname: true
   protectInternalLocations:
     allowedNetworks: []
-  connectTimeout:
-    geocoding: ''
 
 
 # @section Location overrides


### PR DESCRIPTION
# Pull Request description

## Changelog

- Автоматическое выставление таймаута по аннотациям из бэка (https://github.com/2gis/on-premise-helm-charts/pull/702)

- Добавлена возможность добавлять произвольные заголовки в проксируемый запрос для автоматически сгенерирванных локейшенов:
```
front:
  locationExtraProxyHeaders:
    header1: value1
```

- Локейшен для запросов `/isochrone`
- Локейшен для запросов `/area_clustering` (поддержка в следующем релизе роутера/бэка)


## Issues

- DEVOPS-1872
- DEVOPS-1874

## Breaking changes

n/a

## Check-list. Чек-лист код-ревью

- [ ] Запрос на слияние в develop.
- [ ] Есть описание к PR.
- [ ] Указаны блокирующие изменения. [Breaking-Changes](../Breaking-Changes.md)
- [ ] Соответствие кода принятому [стилю](../styleguide.md)
  - [ ] Описание настроек.
  - [ ] Именование настроек.
  - [ ] Дефолтные значения.
  - [ ] Стиль кода.
- [ ] Работоспособность. Разворачивается на своем окружении из ветки PR.
  - [ ] Тест API через тесты helmfile-хуков или коллекций Postman.
- [ ] Не осталось мусора от удаления каких-то параметров. Ищется поиском по проекту из ветки PR.
- [ ] Отработка линтера на чарт из ветки PR. Пример: `helm lint charts/search-api`
