### PR TITLE
[PRO-8197] Релиз PRO-UI 4.19.0

### DIFF
--- a/charts/pro-ui/README.md
+++ b/charts/pro-ui/README.md
@@ -29,7 +29,7 @@ Use this Helm chart to deploy 2GIS Pro UI service, which is a part of 2GIS's [On
 | Name               | Description | Value                    |
 | ------------------ | ----------- | ------------------------ |
 | `image.repository` | Repository  | `2gis-on-premise/pro-ui` |
-| `image.tag`        | Tag         | `4.16.0`                 |
+| `image.tag`        | Tag         | `4.19.0`                 |
 
 ### Common deployment settings
 
@@ -122,12 +122,13 @@ Use this Helm chart to deploy 2GIS Pro UI service, which is a part of 2GIS's [On
 
 ### Zenith2 config settings
 
-| Name                   | Description                                                                                                                  | Value |
-| ---------------------- | ---------------------------------------------------------------------------------------------------------------------------- | ----- |
-| `ui.zenith.protocol`   | Optional. Possible values http or https.                                                                                     | `""`  |
-| `ui.zenith.host`       | Optional FQDN (domain or IP) for the Zenith service without protocol.                                                        | `""`  |
-| `ui.zenith.tileSet`    | Optional. Name of the tileSet. Please use the same name for the tileSet as in the pro-api (see userDataTileSet).             | `""`  |
-| `ui.zenith.subdomains` | Optional. variable holds a list of additional backup subdomains for the Zenith server. Please use «,» (commas) as separator. | `""`  |
+| Name                         | Description                                                                                                                         | Value   |
+| ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| `ui.zenith.protocol`         | Optional. Possible values http or https.                                                                                            | `""`    |
+| `ui.zenith.host`             | Optional FQDN (domain or IP) for the Zenith service without protocol.                                                               | `""`    |
+| `ui.zenith.tileSet`          | Optional. Name of the tileSet. Please use the same name for the tileSet as in the pro-api (see userDataTileSet).                    | `""`    |
+| `ui.zenith.subdomains`       | Optional. variable holds a list of additional backup subdomains for the Zenith server. Please use «,» (commas) as separator.        | `""`    |
+| `ui.zenith.hasAdmDivsLayers` | Optional. variable signalizes that there are adm_div layers in the Zenith server. Required for "select territories on map" feature. | `false` |
 
 ### Service settings
 

--- a/charts/pro-ui/templates/_env.tpl
+++ b/charts/pro-ui/templates/_env.tpl
@@ -95,10 +95,14 @@
   value: "{{ .Values.ui.zenith.host }}"
 - name: ZENITH_TILE_SET
   value: "{{ .Values.ui.zenith.tileSet }}"
+- name: ZENITH_HAS_ADM_DIVS_LAYERS
+  value: "{{ .Values.ui.zenith.hasAdmDivsLayers }}"
 - name: ZENITH_PROTOCOL
   value: "{{ .Values.ui.zenith.protocol }}"
 - name: ZENITH_SUBDOMAINS
   value: "{{ .Values.ui.zenith.subdomains }}"
+- name: APP_VERSION
+  value: "{{ .Values.image.tag }}"
 {{- if .Values.ui.extraEnvVars }}
 {{- range $key, $val := .Values.ui.extraEnvVars }}
 - name: {{ $key }}

--- a/charts/pro-ui/values.schema.json
+++ b/charts/pro-ui/values.schema.json
@@ -206,7 +206,8 @@
             "protocol": { "type": "string" },
             "host": { "type": "string" },
             "tileSet": { "type": "string" },
-            "subdomains": { "type": "string" }
+            "subdomains": { "type": "string" },
+            "hasAdmDivsLayers": { "type": "boolean" }
           }
         }
       }

--- a/charts/pro-ui/values.yaml
+++ b/charts/pro-ui/values.yaml
@@ -27,7 +27,7 @@ strategy:
 # @param image.tag Tag
 image:
   repository: 2gis-on-premise/pro-ui
-  tag: 4.16.0
+  tag: 4.19.0
 
 # @section Common deployment settings
 
@@ -191,11 +191,13 @@ ui:
   # @param ui.zenith.host Optional FQDN (domain or IP) for the Zenith service without protocol.
   # @param ui.zenith.tileSet Optional. Name of the tileSet. Please use the same name for the tileSet as in the pro-api (see userDataTileSet).
   # @param ui.zenith.subdomains Optional. variable holds a list of additional backup subdomains for the Zenith server. Please use «,» (commas) as separator.
+  # @param ui.zenith.hasAdmDivsLayers Optional. variable signalizes that there are adm_div layers in the Zenith server. Required for "select territories on map" feature.
   zenith:
     protocol: ''
     host: ''
     tileSet: ''
     subdomains: ''
+    hasAdmDivsLayers: false
 
 # @section Service settings
 


### PR DESCRIPTION
# Pull Request description

## Changelog

- Появилось новое поле ui.zenith.hasAdmDivsLayers. Оно опциональное, по умолчанию имеет значение false. Переменная сигнализирует о наличии слоев adm_div на сервере Zenith. Требуется для функции «выбрать территории на карте».
- Добавлены подписи для графиков (Для Столбчатых, Линейных и Гистограмм)
- Визуальные улучшения интерфейса для пользователей браузера Safari
- Была реализована поддержка нового формата для вывода диапазонов по годам в виджете-легенде.
- Виджеты без доступа к данным теперь явно сообщают об этом пользователю
- Добавлена возможность выбора двух атрибутов для группировки при построении графиков и диаграмм
- Выводим график типа "Пирамида" для ассета "Половозрастная структура населения".
- В сообщениях в логах теперь отправляется версия приложения
- Увеличили время показа всех тултипов до 1 сек.
- Отображение легенды соответствует выбранным атрибутам для группировки (основная или дополнительная) в зависимости от того, какой уровень задействован.
- Исправлен баг с кнопкой удалить в пользовательском ассете
- Исправлена логика листания фреймов для ассетов с фото-верификацией - листание теперь производится в рамках трека
- Добавлена возможность показать/скрыть все слои одной кнопкой
- Убрана устаревшую опцию bounds, чтобы фильтрация данных происходила валидно
- Добавлен выбор геофильтров через клик в карту
- Исправлены столбцы для столбчатых диаграмм. При маленькой ширине возникали артефакты.

## Issues

  - https://jira.2gis.ru/browse/PRO-7672 Ручная настройка подписи осей графиков, реализация
  - https://jira.2gis.ru/browse/PRO-8182 Едет верстка в окне настроек таймлайна Safari
  - https://jira.2gis.ru/browse/PRO-6216 В виджете слоя и виджете легенды пишем годы с пробелами
  - https://jira.2gis.ru/browse/PRO-7628 Уведомление для слоя / виджета с удалённым ассетом
  - https://jira.2gis.ru/browse/PRO-7770 Релиз двух-уровневой группировки
  - https://jira.2gis.ru/browse/PRO-7837 Проработать форматер для графика популяционной пирамиды
  - https://jira.2gis.ru/browse/PRO-7999 Клиент. При ошибке refresh'а токенов — редиректить на страницу авторизации
  - https://jira.2gis.ru/browse/PRO-8056 Рефакторинг логирования ошибок в проекте
  - https://jira.2gis.ru/browse/PRO-8230 Изменить дефолтный таймаут на появление тултипа
  - https://jira.2gis.ru/browse/PRO-7655 Изменить отображение для легенды графика при выборе двойной группировки
  - https://jira.2gis.ru/browse/PRO-7840 Баг с кнопкой "Удалить" в шаренном дашборде для пользовательских ассетов
  - https://jira.2gis.ru/browse/PRO-8054 Сломался переход между кадрами для ассета citylens
  - https://jira.2gis.ru/browse/PRO-8075 Показать/скрыть все слои сцены
  - https://jira.2gis.ru/browse/PRO-8097 Избавиться от bounds в запросе к items/org
  - https://jira.2gis.ru/browse/PRO-8161 Релиз клика в карту
  - https://jira.2gis.ru/browse/PRO-8214 Графики со столбцами в виджетах: при малой ширине столбца скругления работают некорректно

## Breaking changes

- Добавлено поле ui.zenith.hasAdmDivsLayers. `hasAdmDivsLayers` по умолчанию имеет значение true.

## Check-list. Чек-лист код-ревью

- [ ] Запрос на слияние в develop.
- [ ] Есть описание к PR.
- [ ] Указаны блокирующие изменения. [Breaking-Changes](../Breaking-Changes.md)
- [ ] Соответствие кода принятому [стилю](../styleguide.md)
  - [ ] Описание настроек.
  - [ ] Именование настроек.
  - [ ] Дефолтные значения.
  - [ ] Стиль кода.
- [ ] Работоспособность. Разворачивается на своем окружении из ветки PR.
  - [ ] Тест API через тесты helmfile-хуков или коллекций Postman.
- [ ] Не осталось мусора от удаления каких-то параметров. Ищется поиском по проекту из ветки PR.
- [ ] Отработка линтера на чарт из ветки PR. Пример: `helm lint charts/search-api`
