### PR TITLE
[DEVOPS-2738] [charts/navi-async-matrix] remove navigroup label

### DIFF
--- a/charts/navi-async-matrix/templates/deployment.yaml
+++ b/charts/navi-async-matrix/templates/deployment.yaml
@@ -1,8 +1,6 @@
 {{- define "merger.deployment" }}
 metadata:
   name: {{ include "generic-chart.fullname" . }}-merger
-  labels:
-    navigroup: {{ .Values.navigroup | default "" | quote }}
 spec:
   replicas: {{ .Values.dm.merger.replicaCount | default 1 }}
   selector:


### PR DESCRIPTION
# Pull Request description

## Changelog

- Удалили неиспльзуемый лейбл navigroup

## Issues

- [DEVOPS-2738](https://jira.2gis.ru/browse/DEVOPS-2738)

## Breaking changes

- отсутствуют

## Check-list. Чек-лист код-ревью

- [ ] Запрос на слияние в develop.
- [ ] Есть описание к PR.
- [ ] Указаны блокирующие изменения. [Breaking-Changes](../Breaking-Changes.md)
- [ ] Соответствие кода принятому [стилю](../styleguide.md)
  - [ ] Описание настроек.
  - [ ] Именование настроек.
  - [ ] Дефолтные значения.
  - [ ] Стиль кода.
- [ ] Работоспособность. Разворачивается на своем окружении из ветки PR.
  - [ ] Тест API через тесты helmfile-хуков или коллекций Postman.
- [ ] Не осталось мусора от удаления каких-то параметров. Ищется поиском по проекту из ветки PR.
- [ ] Отработка линтера на чарт из ветки PR. Пример: `helm lint charts/search-api`
