### PR TITLE
Update citylens-routes-ui to version 2.1.0

### DIFF
--- a/charts/citylens-routes-ui/README.md
+++ b/charts/citylens-routes-ui/README.md
@@ -21,27 +21,30 @@
 | Name               | Description | Value                                |
 | ------------------ | ----------- | ------------------------------------ |
 | `image.repository` | Repository  | `2gis-on-premise/citylens-routes-ui` |
-| `image.tag`        | Tag         | `1.6.2`                              |
+| `image.tag`        | Tag         | `2.1.0`                              |
 
 ### Environment
 
-| Name                           | Description                                                          | Value |
-| ------------------------------ | -------------------------------------------------------------------- | ----- |
-| `env.CATALOG_API_URL`          | Catalog API base URL **Required**                                    | `""`  |
-| `env.MAPGL_API_URL`            | Map API base URL **Required**                                        | `""`  |
-| `env.MAPGL_COPYRIGHT_VARIANT`  | Copyright variant, can be '2gis', 'urbi' or empty                    | `""`  |
-| `env.MAPGL_DEFAULT_CENTER`     | Map center in 'lon,lat' format like '46.72185,24.70996' **Required** | `""`  |
-| `env.MAPGL_KEY`                | API key for mapgl **Required**                                       | `""`  |
-| `env.MAPGL_STYLE_ID_GRAYSCALE` | Map grayscale style ID                                               | `""`  |
-| `env.MAPGL_STYLE_ID_DAY`       | Map day style ID                                                     | `""`  |
-| `env.MAPGL_STYLE_ID_NIGHT`     | Map night style ID                                                   | `""`  |
-| `env.MAPGL_STYLE_ID_PASTEL`    | Map pastel style ID                                                  | `""`  |
-| `env.METRICS_API_URL`          | Metrics service endpoint                                             | `""`  |
-| `env.ROUTES_API_URL`           | Backend (citylens-routes-api) base URL **Required**                  | `""`  |
-| `env.SSO_API_URL`              | Single sign-on API URL **Required**                                  | `""`  |
-| `env.SSO_CLIENT_ID`            | OpenID client identifier for single sign-on **Required**             | `""`  |
-| `env.SSO_CLIENT_SECRET`        | OpenID client identifier for single sign-on **Required**             | `""`  |
-| `env.SSO_SCOPE`                | OpenID scope for single sign-on **Required**                         | `""`  |
+| Name                                    | Description                                                          | Value |
+| --------------------------------------- | -------------------------------------------------------------------- | ----- |
+| `env.CATALOG_API_KEY`                   | API key for catalog **Required**                                     | `""`  |
+| `env.CATALOG_API_URL`                   | Catalog API base URL **Required**                                    | `""`  |
+| `env.MAPGL_API_URL`                     | Map API base URL **Required**                                        | `""`  |
+| `env.MAPGL_COPYRIGHT_VARIANT`           | Copyright variant, can be '2gis', 'urbi' or empty                    | `""`  |
+| `env.MAPGL_DEFAULT_CENTER`              | Map center in 'lon,lat' format like '46.72185,24.70996' **Required** | `""`  |
+| `env.MAPGL_KEY`                         | API key for mapgl **Required**                                       | `""`  |
+| `env.MAPGL_STYLE_ID_GRAYSCALE`          | Map grayscale style ID                                               | `""`  |
+| `env.MAPGL_STYLE_ID_DAY`                | Map day style ID                                                     | `""`  |
+| `env.MAPGL_STYLE_ID_NIGHT`              | Map night style ID                                                   | `""`  |
+| `env.MAPGL_STYLE_ID_PASTEL`             | Map pastel style ID                                                  | `""`  |
+| `env.METRICS_API_URL`                   | Metrics service endpoint                                             | `""`  |
+| `env.ROUTES_API_URL`                    | Backend (citylens-routes-api) base URL **Required**                  | `""`  |
+| `env.SSO_API_URL`                       | Single sign-on API URL **Required**                                  | `""`  |
+| `env.SSO_CLIENT_ID`                     | OpenID client identifier for single sign-on **Required**             | `""`  |
+| `env.SSO_CLIENT_SECRET`                 | OpenID client identifier for single sign-on **Required**             | `""`  |
+| `env.SSO_SCOPE`                         | OpenID scope for single sign-on **Required**                         | `""`  |
+| `env.SSO_SIGNUP_URL`                    | Signup URL for SSO                                                   | `""`  |
+| `env.FEATURE_FLAGS_OFFLINE_ENVIRONMENT` | Feature offline environment                                          | `""`  |
 
 ### Common deployment settings
 
@@ -61,6 +64,7 @@
 | `readinessProbe.enabled`        | Enable [readinessProbe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes) | `true`    |
 | `livenessProbe.enabled`         | Enable [livenessProbe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes)  | `true`    |
 | `containerPort`                 | Port on which application listen connection in container                                                                                        | `3000`    |
+| `progressDeadlineSeconds`       | Deadline                                                                                                                                        | `60`      |
 
 ### Logs
 

--- a/charts/citylens-routes-ui/templates/configmap.yaml
+++ b/charts/citylens-routes-ui/templates/configmap.yaml
@@ -29,14 +29,15 @@ data:
 
       sendfile on;
       tcp_nopush on;
-      keepalive_timeout 65;
+      keepalive_timeout 10;
+      send_timeout 10;
 
       include /etc/nginx/conf.d/*.conf;
     }
 
   default.conf.template: |
     server {
-      listen 3000;
+      listen {{ required "A valid .Values.containerPort required" .Values.containerPort }};
       root /usr/share/nginx/html;
       error_page 500 502 503 504 /50x.html;
       gzip_static on;

--- a/charts/citylens-routes-ui/templates/deployment.yaml
+++ b/charts/citylens-routes-ui/templates/deployment.yaml
@@ -13,6 +13,7 @@ metadata:
 spec:
   replicas: {{ .Values.replicas }}
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  progressDeadlineSeconds: {{ .Values.progressDeadlineSeconds | int }}
   {{- if .Values.strategy }}
   strategy:
     {{- toYaml .Values.strategy | nindent 4 }}
@@ -74,10 +75,21 @@ spec:
               value: {{ required "A valid .Values.env.SSO_CLIENT_ID entry required" .Values.env.SSO_CLIENT_ID | quote }}
             - name: SSO_SCOPE
               value: {{ required "A valid .Values.env.SSO_SCOPE entry required" .Values.env.SSO_SCOPE | quote }}
+            - name: SSO_SIGNUP_URL
+              value: {{ .Values.env.SSO_SIGNUP_URL | quote }}
             - name: ROUTES_API_URL
               value: {{ required "A valid .Values.env.ROUTES_API_URL entry required" .Values.env.ROUTES_API_URL | quote }}
-            - name: ENV_FLAGS_ENABLE_Q1_FEATURES
-              value: {{ .Values.env.ENV_FLAGS_ENABLE_Q1_FEATURES | quote }}
+            - name: FEATURE_FLAGS_OFFLINE_ENVIRONMENT
+              value: {{ .Values.env.FEATURE_FLAGS_OFFLINE_ENVIRONMENT | quote }}
+            - name: FEATBIT_SDK_KEY
+              value: {{ .Values.env.FEATBIT_SDK_KEY | quote }}
+            - name: FEATBIT_SERVER_URL
+              value: {{ .Values.env.FEATBIT_SERVER_URL | quote }}
+            - name: CATALOG_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: CATALOG_API_KEY
+                  name: {{ include "citylens-ui.name" . }}-secret
             - name: MAPGL_KEY
               valueFrom:
                 secretKeyRef:

--- a/charts/citylens-routes-ui/templates/secrets.yaml
+++ b/charts/citylens-routes-ui/templates/secrets.yaml
@@ -4,5 +4,6 @@ metadata:
   name: {{ include "citylens-ui.name" . }}-secret
 type: Opaque
 data:
+  CATALOG_API_KEY: {{ required "Valid .Values.env.CATALOG_API_KEY required!" .Values.env.CATALOG_API_KEY | b64enc }}
   MAPGL_KEY: {{ required "Valid .Values.env.MAPGL_KEY required!" .Values.env.MAPGL_KEY | b64enc }}
   SSO_CLIENT_SECRET: {{ required "Valid .Values.env.SSO_CLIENT_SECRET required!" .Values.env.SSO_CLIENT_SECRET | b64enc }}

--- a/charts/citylens-routes-ui/values.yaml
+++ b/charts/citylens-routes-ui/values.yaml
@@ -25,10 +25,11 @@ strategy:
 # @param image.tag Tag
 image:
   repository: 2gis-on-premise/citylens-routes-ui
-  tag: 1.6.2
+  tag: 2.1.0
 
 # @section Environment
 
+# @param env.CATALOG_API_KEY API key for catalog **Required**
 # @param env.CATALOG_API_URL Catalog API base URL **Required**
 # @param env.MAPGL_API_URL Map API base URL **Required**
 # @param env.MAPGL_COPYRIGHT_VARIANT Copyright variant, can be '2gis', 'urbi' or empty
@@ -44,7 +45,10 @@ image:
 # @param env.SSO_CLIENT_ID OpenID client identifier for single sign-on **Required**
 # @param env.SSO_CLIENT_SECRET OpenID client identifier for single sign-on **Required**
 # @param env.SSO_SCOPE OpenID scope for single sign-on **Required**
+# @param env.SSO_SIGNUP_URL Signup URL for SSO
+# @param env.FEATURE_FLAGS_OFFLINE_ENVIRONMENT Feature offline environment
 env:
+  CATALOG_API_KEY: ''
   CATALOG_API_URL: ''
   MAPGL_API_URL: ''
   MAPGL_COPYRIGHT_VARIANT: ''
@@ -60,6 +64,8 @@ env:
   SSO_CLIENT_ID: ''
   SSO_CLIENT_SECRET: ''
   SSO_SCOPE: ''
+  SSO_SIGNUP_URL: ''
+  FEATURE_FLAGS_OFFLINE_ENVIRONMENT: ''
 
 # @section Common deployment settings
 
@@ -77,6 +83,7 @@ env:
 # @param readinessProbe.enabled Enable [readinessProbe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes)
 # @param livenessProbe.enabled Enable [livenessProbe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes)
 # @param containerPort Port on which application listen connection in container
+# @param progressDeadlineSeconds Deadline
 replicas: 1
 revisionHistoryLimit: 3
 terminationGracePeriodSeconds: 60
@@ -93,6 +100,7 @@ readinessProbe:
 livenessProbe:
   enabled: true
 containerPort: 3000
+progressDeadlineSeconds: 60
 
 # @section Logs
 
@@ -140,10 +148,10 @@ ingress:
   annotations: {}
   className: nginx
   hosts:
-  - host: citylens-routes-ui.example.com
-    paths:
-    - path: /
-      pathType: Prefix
+    - host: citylens-routes-ui.example.com
+      paths:
+        - path: /
+          pathType: Prefix
   tls: []
   # - hosts:
   #   - citylens-routes-ui.example.com


### PR DESCRIPTION
# Pull Request description

## Changelog

- Добавилась обязательная переменная `CATALOG_API_KEY`, как правило дублирует по значению `MAPGL_KEY`
- Изменены таймауты на nginx
- Обновлена версия до 2.1.0
- Добавлена переменная SSO_SIGNUP_URL (если указать - пользователей при отсутствии компании в Platform Manager будет редиректить на создание компании)
- Добавлена переменная `FEATURE_FLAGS_OFFLINE_ENVIRONMENT`, для онпрема её значение - `on-premise`

---

## Issues

###### [CITYLENS-2040](https://jira.2gis.ru/browse/CITYLENS-2040) FE: Доработки по риал-тайм трекам
Поддержка обновленного апи реалтайм треков и автоматический фоллбек в завершенные треки
###### [CITYLENS-2056](https://jira.2gis.ru/browse/CITYLENS-2056) FE: Улучшение сортировки задач
Улучшена фильтрация списка задач
###### [CITYLENS-2106](https://jira.2gis.ru/browse/CITYLENS-2106) FE: Не указывается выбор проезда в одну сторону при автонарезке
Добавлен выбор проезда в одном направлении при нарезке полигона на странице планирования задач
###### [CITYLENS-2111](https://jira.2gis.ru/browse/CITYLENS-2111) BE: Отображение навигации работает через раз
Исправлена ошибка расчёта навигации при изменении задачи
###### [CITYLENS-2124](https://jira.2gis.ru/browse/CITYLENS-2124) Перейти с /v1/polygons на /v1/view_box (обсудить)
Добавлено отображение всей геометрии на карте (лингео, точек, полигонов)
###### [CITYLENS-2160](https://jira.2gis.ru/browse/CITYLENS-2160) Performance issues на экране задачи для лингео
Улучшена производительность на экране редактирования задачи
###### [CITYLENS-2170](https://jira.2gis.ru/browse/CITYLENS-2170) Не снимается ховер с улиц если быстро водить курсором по ним
Исправлен баг с непропадающим ховером на выделенных улицах на карте
###### [CITYLENS-2192](https://jira.2gis.ru/browse/CITYLENS-2192) Назначать на пользователя все проекты территории при выборе территории
Автоназначение проектов при выборе территорий
###### [CITYLENS-2199](https://jira.2gis.ru/browse/CITYLENS-2199) Не подставлять в лингео туристические маршруты
При выборе улицы больше не выбираются тур. маршруты
###### [CITYLENS-2240](https://jira.2gis.ru/browse/CITYLENS-2240) Не снимается и не добавляется территория у водителя, на странице водителей
Исправление queryKey на странице drivers

## Breaking changes

Добавилась обязательная переменная `CATALOG_API_KEY`, как правило дублирует по значению `MAPGL_KEY`

## Check-list. Чек-лист код-ревью

- [x] Запрос на слияние в develop.
- [x] Есть описание к PR.
- [x] Указаны блокирующие изменения. [Breaking-Changes](../Breaking-Changes.md)
- [ ] Соответствие кода принятому [стилю](../styleguide.md)
  - [ ] Описание настроек.
  - [ ] Именование настроек.
  - [ ] Дефолтные значения.
  - [ ] Стиль кода.
- [ ] Работоспособность. Разворачивается на своем окружении из ветки PR.
  - [ ] Тест API через тесты helmfile-хуков или коллекций Postman.
- [ ] Не осталось мусора от удаления каких-то параметров. Ищется поиском по проекту из ветки PR.
- [ ] Отработка линтера на чарт из ветки PR. Пример: `helm lint charts/search-api`
