### PR TITLE
[DEVOPS-2794] Fix filename (long-)forecast data

### DIFF
--- a/charts/traffic-proxy/templates/_helpers.tpl
+++ b/charts/traffic-proxy/templates/_helpers.tpl
@@ -61,7 +61,7 @@ location = /forecast/index.json {
     {{- include "proxyParams" . }}
 }
 
-location ~ ^/forecast/([^/]+)/forecasted_speeds_v2\.zip$ {
+location ~ ^/forecast/([^/]+)/.*\.zip$ {
     rewrite ^/forecast/(.*)$ /api/v1/services/navi/proxy/forecast-speeds/$1 break;
     {{- include "proxyParams" . }}
 }
@@ -72,7 +72,7 @@ location = /long-forecast/index.json {
     {{- include "proxyParams" . }}
 }
 
-location ~ ^/long-forecast/([^/]+)/forecasted_speeds_v2\.zip$ {
+location ~ ^/long-forecast/([^/]+)/.*\.zip$ {
     rewrite ^/long-forecast/(.*)$ /api/v1/services/navi/proxy/long-forecast-speeds/long_forecast_data/$1 break;
     {{- include "proxyParams" . }}
 }


### PR DESCRIPTION
# Pull Request description

## Changelog

- In the traffic-proxy chart, we are now proxying any zip to get data from forecast and long-forecast

## Issues

- `DEVOPS-2794` 

## Breaking changes

- 

## Check-list. Чек-лист код-ревью

- [ ] Запрос на слияние в develop.
- [ ] Есть описание к PR.
- [ ] Указаны блокирующие изменения. [Breaking-Changes](../Breaking-Changes.md)
- [ ] Соответствие кода принятому [стилю](../styleguide.md)
  - [ ] Описание настроек.
  - [ ] Именование настроек.
  - [ ] Дефолтные значения.
  - [ ] Стиль кода.
- [ ] Работоспособность. Разворачивается на своем окружении из ветки PR.
  - [ ] Тест API через тесты helmfile-хуков или коллекций Postman.
- [ ] Не осталось мусора от удаления каких-то параметров. Ищется поиском по проекту из ветки PR.
- [ ] Отработка линтера на чарт из ветки PR. Пример: `helm lint charts/search-api`
