### PR TITLE
ONPREM-3523 search-api and traffic-proxy images update

### DIFF
--- a/charts/search-api/README.md
+++ b/charts/search-api/README.md
@@ -55,7 +55,7 @@ See the [documentation](https://docs.2gis.com/en/on-premise/search) to learn abo
 | Name                   | Description                                                                                   | Value                        |
 | ---------------------- | --------------------------------------------------------------------------------------------- | ---------------------------- |
 | `api.image.repository` | Repository                                                                                    | `2gis-on-premise/search-api` |
-| `api.image.tag`        | Tag                                                                                           | `7.105.1`                    |
+| `api.image.tag`        | Tag                                                                                           | `7.107.0`                    |
 | `api.image.pullPolicy` | Image [pull policy](https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy) | `IfNotPresent`               |
 
 ### API settings
@@ -74,7 +74,7 @@ See the [documentation](https://docs.2gis.com/en/on-premise/search) to learn abo
 | Name                     | Description                                                                                   | Value                   |
 | ------------------------ | --------------------------------------------------------------------------------------------- | ----------------------- |
 | `nginx.image.repository` | Docker Repository                                                                             | `2gis-on-premise/nginx` |
-| `nginx.image.tag`        | Docker image tag                                                                              | `1.25.5`                |
+| `nginx.image.tag`        | Docker image tag                                                                              | `1.30.1`                |
 | `nginx.image.pullPolicy` | Image [pull policy](https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy) | `IfNotPresent`          |
 | `nginx.httpPort`         | HTTP port on which NGINX will be listening                                                    | `8080`                  |
 

--- a/charts/search-api/README.md
+++ b/charts/search-api/README.md
@@ -74,7 +74,7 @@ See the [documentation](https://docs.2gis.com/en/on-premise/search) to learn abo
 | Name                     | Description                                                                                   | Value                   |
 | ------------------------ | --------------------------------------------------------------------------------------------- | ----------------------- |
 | `nginx.image.repository` | Docker Repository                                                                             | `2gis-on-premise/nginx` |
-| `nginx.image.tag`        | Docker image tag                                                                              | `1.30.1`                |
+| `nginx.image.tag`        | Docker image tag                                                                              | `1.30.2`                |
 | `nginx.image.pullPolicy` | Image [pull policy](https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy) | `IfNotPresent`          |
 | `nginx.httpPort`         | HTTP port on which NGINX will be listening                                                    | `8080`                  |
 

--- a/charts/search-api/templates/configmap.yaml
+++ b/charts/search-api/templates/configmap.yaml
@@ -39,13 +39,19 @@ data:
   nginx_config: |
     daemon off;
     worker_processes 2;
-    pid /run/nginx.pid;
+    pid /tmp/nginx.pid;
 
     events {
         worker_connections 768;
     }
 
     http {
+        client_body_temp_path /tmp/client_temp;
+        proxy_temp_path       /tmp/proxy_temp_path;
+        fastcgi_temp_path     /tmp/fastcgi_temp;
+        uwsgi_temp_path       /tmp/uwsgi_temp;
+        scgi_temp_path        /tmp/scgi_temp;
+
         sendfile on;
         tcp_nopush on;
         tcp_nodelay on;

--- a/charts/search-api/values.yaml
+++ b/charts/search-api/values.yaml
@@ -61,7 +61,7 @@ api:
 
   image:
     repository: 2gis-on-premise/search-api
-    tag: 7.105.1
+    tag: 7.107.0
     pullPolicy: IfNotPresent
 
 
@@ -93,7 +93,7 @@ api:
 nginx:
   image:
     repository: 2gis-on-premise/nginx
-    tag: 1.25.5
+    tag: 1.30.1
     pullPolicy: IfNotPresent
   resources: {}
   httpPort: 8080

--- a/charts/search-api/values.yaml
+++ b/charts/search-api/values.yaml
@@ -93,7 +93,7 @@ api:
 nginx:
   image:
     repository: 2gis-on-premise/nginx
-    tag: 1.30.1
+    tag: 1.30.2
     pullPolicy: IfNotPresent
   resources: {}
   httpPort: 8080

--- a/charts/traffic-proxy/README.md
+++ b/charts/traffic-proxy/README.md
@@ -66,7 +66,7 @@ See the [documentation](https://docs.2gis.com/en/on-premise/traffic-proxy) to le
 | ------------------ | ----------- | ----------------------- |
 | `image.repository` | Repository  | `2gis-on-premise/nginx` |
 | `image.pullPolicy` | Pull Policy | `IfNotPresent`          |
-| `image.tag`        | Tag         | `1.25.5`                |
+| `image.tag`        | Tag         | `1.30.1`                |
 
 ### Strategy settings
 

--- a/charts/traffic-proxy/README.md
+++ b/charts/traffic-proxy/README.md
@@ -66,7 +66,7 @@ See the [documentation](https://docs.2gis.com/en/on-premise/traffic-proxy) to le
 | ------------------ | ----------- | ----------------------- |
 | `image.repository` | Repository  | `2gis-on-premise/nginx` |
 | `image.pullPolicy` | Pull Policy | `IfNotPresent`          |
-| `image.tag`        | Tag         | `1.30.1`                |
+| `image.tag`        | Tag         | `1.30.2`                |
 
 ### Strategy settings
 

--- a/charts/traffic-proxy/templates/configmap.yaml
+++ b/charts/traffic-proxy/templates/configmap.yaml
@@ -10,13 +10,18 @@ data:
   nginx.conf: |
     worker_processes {{ .Values.proxy.worker.processes }};
 
-    pid /run/nginx.pid;
+    pid /tmp/nginx.pid;
 
     events {
         worker_connections {{ .Values.proxy.worker.connections }};
     }
 
     http {
+        client_body_temp_path /tmp/client_temp;
+        proxy_temp_path       /tmp/proxy_temp_path;
+        fastcgi_temp_path     /tmp/fastcgi_temp;
+        uwsgi_temp_path       /tmp/uwsgi_temp;
+        scgi_temp_path        /tmp/scgi_temp;
 
         {{- if .Values.proxy.upstreams }}
         upstream backend {

--- a/charts/traffic-proxy/values.yaml
+++ b/charts/traffic-proxy/values.yaml
@@ -113,7 +113,7 @@ proxy:
 
 image:
   repository: 2gis-on-premise/nginx
-  tag: 1.30.1
+  tag: 1.30.2
   pullPolicy: IfNotPresent
 
 

--- a/charts/traffic-proxy/values.yaml
+++ b/charts/traffic-proxy/values.yaml
@@ -113,7 +113,7 @@ proxy:
 
 image:
   repository: 2gis-on-premise/nginx
-  tag: 1.25.5
+  tag: 1.30.1
   pullPolicy: IfNotPresent
 
 


### PR DESCRIPTION
# Pull Request description

## Changelog

- обновлен nginx до версии 1.30.1
- добавлены изменения в nginx.conf для работы [без привилегий](https://hub.docker.com/r/nginxinc/nginx-unprivileged)
- обновлен образ search-api до актуальной версии

## Issues

- [ONPREM-3523](https://jira.2gis.ru/browse/ONPREM-3523)

## Check-list. Чек-лист код-ревью

- [ ] Запрос на слияние в develop.
- [ ] Есть описание к PR.
- [ ] Указаны блокирующие изменения. [Breaking-Changes](../Breaking-Changes.md)
- [ ] Соответствие кода принятому [стилю](../styleguide.md)
  - [ ] Описание настроек.
  - [ ] Именование настроек.
  - [ ] Дефолтные значения.
  - [ ] Стиль кода.
- [ ] Работоспособность. Разворачивается на своем окружении из ветки PR.
  - [ ] Тест API через тесты helmfile-хуков или коллекций Postman.
- [ ] Не осталось мусора от удаления каких-то параметров. Ищется поиском по проекту из ветки PR.
- [ ] Отработка линтера на чарт из ветки PR. Пример: `helm lint charts/search-api`
