### PR TITLE
[DEVOPS-2922] navi-castle: split k8s resources by containers

### DIFF
--- a/charts/navi-castle/README.md
+++ b/charts/navi-castle/README.md
@@ -83,13 +83,13 @@ See the [documentation](https://docs.2gis.com/en/on-premise/navigation) to learn
 
 ### Limits
 
-| Name                        | Description                                 | Value       |
-| --------------------------- | ------------------------------------------- | ----------- |
-| `resources`                 | Container resources requirements structure. | `{}`        |
-| `resources.requests.cpu`    | CPU request, recommended value `100m`.      | `undefined` |
-| `resources.requests.memory` | Memory request, recommended value `128Mi`.  | `undefined` |
-| `resources.limits.cpu`      | CPU limit, recommended value `1000m`.       | `undefined` |
-| `resources.limits.memory`   | Memory limit, recommended value `512Mi`.    | `undefined` |
+| Name                        | Description                                                                                                                               | Value       |
+| --------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| `resources`                 | Default container resources requirements structure. Used by `nginx.resources`, `cron.resources`, and `rtr.resources` when they are empty. | `{}`        |
+| `resources.requests.cpu`    | CPU request, recommended value `100m`.                                                                                                    | `undefined` |
+| `resources.requests.memory` | Memory request, recommended value `128Mi`.                                                                                                | `undefined` |
+| `resources.limits.cpu`      | CPU limit, recommended value `1000m`.                                                                                                     | `undefined` |
+| `resources.limits.memory`   | Memory limit, recommended value `512Mi`.                                                                                                  | `undefined` |
 
 ### Navi-Castle service settings
 
@@ -117,14 +117,19 @@ See the [documentation](https://docs.2gis.com/en/on-premise/navigation) to learn
 
 ### Navi-Front settings
 
-| Name                     | Description                                                               | Value                        |
-| ------------------------ | ------------------------------------------------------------------------- | ---------------------------- |
-| `nginx.port`             | HTTP port on which Navi-Front will be listening.                          | `8080`                       |
-| `nginx.image.repository` | Navi-Front image repository.                                              | `2gis-on-premise/navi-front` |
-| `nginx.image.tag`        | Navi-Front image tag.                                                     | `1.29.1`                     |
-| `nginx.nodeHeader`       | Enable header with node name (X-Node).                                    | `false`                      |
-| `nginx.locationsBlock`   | Optional nginx config block with additional locations                     | `""`                         |
-| `nginx.customConfigPath` | Path to custom nginx config file. If set, default config will be ignored. | `""`                         |
+| Name                              | Description                                                                                 | Value                        |
+| --------------------------------- | ------------------------------------------------------------------------------------------- | ---------------------------- |
+| `nginx.port`                      | HTTP port on which Navi-Front will be listening.                                            | `8080`                       |
+| `nginx.image.repository`          | Navi-Front image repository.                                                                | `2gis-on-premise/navi-front` |
+| `nginx.image.tag`                 | Navi-Front image tag.                                                                       | `1.29.1`                     |
+| `nginx.nodeHeader`                | Enable header with node name (X-Node).                                                      | `false`                      |
+| `nginx.locationsBlock`            | Optional nginx config block with additional locations                                       | `""`                         |
+| `nginx.customConfigPath`          | Path to custom nginx config file. If set, default config will be ignored.                   | `""`                         |
+| `nginx.resources`                 | Container resources requirements for `castle-nginx`. Empty value falls back to `resources`. | `{}`                         |
+| `nginx.resources.requests.cpu`    | CPU request for `castle-nginx`.                                                             | `undefined`                  |
+| `nginx.resources.requests.memory` | Memory request for `castle-nginx`.                                                          | `undefined`                  |
+| `nginx.resources.limits.cpu`      | CPU limit for `castle-nginx`.                                                               | `undefined`                  |
+| `nginx.resources.limits.memory`   | Memory limit for `castle-nginx`.                                                            | `undefined`                  |
 
 ### Cron settings
 
@@ -140,6 +145,11 @@ See the [documentation](https://docs.2gis.com/en/on-premise/navigation) to learn
 | `cron.successfulJobsHistoryLimit` | How many completed jobs should be kept. See [jobs history limits](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#jobs-history-limits). | `3`           |
 | `cron.failedJobsHistoryLimit`     | How many failed jobs should be kept. See [jobs history limits](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#jobs-history-limits).    | `3`           |
 | `cron.prometheusPort`             | Container port for supercronic prometheus                                                                                                                    | `9476`        |
+| `cron.resources`                  | Container resources requirements for `castle-cron`. Empty value falls back to `resources`.                                                                   | `{}`          |
+| `cron.resources.requests.cpu`     | CPU request for `castle-cron`.                                                                                                                               | `undefined`   |
+| `cron.resources.requests.memory`  | Memory request for `castle-cron`.                                                                                                                            | `undefined`   |
+| `cron.resources.limits.cpu`       | CPU limit for `castle-cron`.                                                                                                                                 | `undefined`   |
+| `cron.resources.limits.memory`    | Memory limit for `castle-cron`.                                                                                                                              | `undefined`   |
 
 ### Init settings
 
@@ -202,6 +212,11 @@ See the [documentation](https://docs.2gis.com/en/on-premise/navigation) to learn
 | `rtr.restrictionJson.remoteDir`           | Remote directory for restriction_json. Empty for HTTP source, `restrictions` for S3.                                              | `""`                                            |
 | `rtr.restrictionJson.header`              | HTTP header used for change detection.                                                                                            | `Last-Modified`                                 |
 | `rtr.restrictionJson.timeout`             | Queries request timeout in seconds.                                                                                               | `30`                                            |
+| `rtr.resources`                           | Container resources requirements for `castle-rtr`. Empty value falls back to `resources`.                                         | `{}`                                            |
+| `rtr.resources.requests.cpu`              | CPU request for `castle-rtr`.                                                                                                     | `undefined`                                     |
+| `rtr.resources.requests.memory`           | Memory request for `castle-rtr`.                                                                                                  | `undefined`                                     |
+| `rtr.resources.limits.cpu`                | CPU limit for `castle-rtr`.                                                                                                       | `undefined`                                     |
+| `rtr.resources.limits.memory`             | Memory limit for `castle-rtr`.                                                                                                    | `undefined`                                     |
 
 ### customCAs **Custom Certificate Authority**
 

--- a/charts/navi-castle/templates/configmapnginx.yaml
+++ b/charts/navi-castle/templates/configmapnginx.yaml
@@ -24,6 +24,13 @@ data:
             autoindex_format json;
         }
 
+        location /navi-data-sync {
+            expires epoch;
+            alias  {{ .Values.castle.castleDataPath }}/backup;
+            autoindex on;
+            autoindex_format json;
+        }
+
         {{- if .Values.nginx.locationsBlock }}
           {{ .Values.nginx.locationsBlock | nindent 8 }}
         {{- end }}

--- a/charts/navi-castle/templates/cronjob.yaml
+++ b/charts/navi-castle/templates/cronjob.yaml
@@ -91,7 +91,7 @@ spec:
               - name: {{ include "castle.fullname" $ }}-pvc
                 mountPath: {{ $.Values.castle.castleDataPath }}
               resources:
-                {{- toYaml $.Values.resources | nindent 16 }}
+                {{- toYaml ($.Values.cron.resources | default $.Values.resources) | nindent 16 }}
 {{- end -}} {{/* if */}}
 {{- end -}} {{/* range $flavor */}}
 {{- end -}} {{/* range $i, $e */}}

--- a/charts/navi-castle/templates/statefulset.yaml
+++ b/charts/navi-castle/templates/statefulset.yaml
@@ -109,7 +109,7 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           resources:
-            {{- toYaml .Values.resources | nindent 12 }}
+            {{- toYaml (.Values.nginx.resources | default .Values.resources) | nindent 12 }}
           volumeMounts:
           - name: {{ include "castle.fullname" . }}-castle-nginx-config
             mountPath: {{ printf "%s/conf.d/castle.conf" ( include "nginx.customConfigPath" .) }}
@@ -178,7 +178,7 @@ spec:
               name: {{ include "castle.fullname" . }}-secret-env
           {{- end }}
           resources:
-            {{- toYaml $.Values.resources | nindent 12 }}
+            {{- toYaml (.Values.cron.resources | default .Values.resources) | nindent 12 }}
           startupProbe:
             {{- /* checks if supercronic prometheus port is open */}}
             httpGet:
@@ -241,7 +241,7 @@ spec:
             - --service=restriction_json
             - --daemon
           resources:
-            {{- toYaml $.Values.resources | nindent 12 }}
+            {{- toYaml (.Values.rtr.resources | default .Values.resources) | nindent 12 }}
           volumeMounts:
           - name: {{ include "castle.fullname" $ }}-builder-config
             mountPath: /opt/config_builder.conf

--- a/charts/navi-castle/values.yaml
+++ b/charts/navi-castle/values.yaml
@@ -109,7 +109,7 @@ ingress:
 
 # @section Limits
 
-# @param resources [nullable] Container resources requirements structure.
+# @param resources [nullable] Default container resources requirements structure. Used by `nginx.resources`, `cron.resources`, and `rtr.resources` when they are empty.
 # @param resources.requests.cpu [nullable] CPU request, recommended value `100m`.
 # @param resources.requests.memory [nullable] Memory request, recommended value `128Mi`.
 # @param resources.limits.cpu [nullable] CPU limit, recommended value `1000m`.
@@ -171,6 +171,11 @@ castle:
 # @param nginx.nodeHeader Enable header with node name (X-Node).
 # @param nginx.locationsBlock Optional nginx config block with additional locations
 # @param nginx.customConfigPath Path to custom nginx config file. If set, default config will be ignored.
+# @param nginx.resources [nullable] Container resources requirements for `castle-nginx`. Empty value falls back to `resources`.
+# @param nginx.resources.requests.cpu [nullable] CPU request for `castle-nginx`.
+# @param nginx.resources.requests.memory [nullable] Memory request for `castle-nginx`.
+# @param nginx.resources.limits.cpu [nullable] CPU limit for `castle-nginx`.
+# @param nginx.resources.limits.memory [nullable] Memory limit for `castle-nginx`.
 
 nginx:
   port: 8080
@@ -180,6 +185,7 @@ nginx:
   nodeHeader: false
   locationsBlock: ''
   customConfigPath: ''
+  resources: {}
 
 
 # @section Cron settings
@@ -194,6 +200,11 @@ nginx:
 # @param cron.successfulJobsHistoryLimit How many completed jobs should be kept. See [jobs history limits](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#jobs-history-limits).
 # @param cron.failedJobsHistoryLimit How many failed jobs should be kept. See [jobs history limits](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#jobs-history-limits).
 # @param cron.prometheusPort Container port for supercronic prometheus
+# @param cron.resources [nullable] Container resources requirements for `castle-cron`. Empty value falls back to `resources`.
+# @param cron.resources.requests.cpu [nullable] CPU request for `castle-cron`.
+# @param cron.resources.requests.memory [nullable] Memory request for `castle-cron`.
+# @param cron.resources.limits.cpu [nullable] CPU limit for `castle-cron`.
+# @param cron.resources.limits.memory [nullable] Memory limit for `castle-cron`.
 
 cron:
   enabled:
@@ -208,6 +219,7 @@ cron:
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 3
   prometheusPort: 9476
+  resources: {}
 
 
 # @section Init settings
@@ -285,9 +297,15 @@ persistentVolume:
 # @param rtr.restrictionJson.remoteDir Remote directory for restriction_json. Empty for HTTP source, `restrictions` for S3.
 # @param rtr.restrictionJson.header HTTP header used for change detection.
 # @param rtr.restrictionJson.timeout Queries request timeout in seconds.
+# @param rtr.resources [nullable] Container resources requirements for `castle-rtr`. Empty value falls back to `resources`.
+# @param rtr.resources.requests.cpu [nullable] CPU request for `castle-rtr`.
+# @param rtr.resources.requests.memory [nullable] Memory request for `castle-rtr`.
+# @param rtr.resources.limits.cpu [nullable] CPU limit for `castle-rtr`.
+# @param rtr.resources.limits.memory [nullable] Memory limit for `castle-rtr`.
 
 rtr:
   enabled: false
+  resources: {}
   http:
     baseDir: export-restrictions-json
     serverUrl: ''


### PR DESCRIPTION
# Pull Request description

## Changelog

- Add `resources` sections for navi-nginx, navi-cron, navi-rtr containers. Keep supporting previous common parameter.

## Issues

- [DEVOPS-2922](https://jira.2gis.ru/browse/DEVOPS-2922)

## Breaking changes

- n/a

## Check-list. Чек-лист код-ревью

- [ ] Запрос на слияние в develop.
- [ ] Есть описание к PR.
- [ ] Указаны блокирующие изменения. [Breaking-Changes](../Breaking-Changes.md)
- [ ] Соответствие кода принятому [стилю](../styleguide.md)
  - [ ] Описание настроек.
  - [ ] Именование настроек.
  - [ ] Дефолтные значения.
  - [ ] Стиль кода.
- [ ] Работоспособность. Разворачивается на своем окружении из ветки PR.
  - [ ] Тест API через тесты helmfile-хуков или коллекций Postman.
- [ ] Не осталось мусора от удаления каких-то параметров. Ищется поиском по проекту из ветки PR.
- [ ] Отработка линтера на чарт из ветки PR. Пример: `helm lint charts/search-api`
