### PR TITLE
[DEVOPS-2922][DEVOPS-2123] navi-castle: split k8s resources by containers, add security context in cronjob

### DIFF
--- a/charts/navi-castle/Chart.yaml
+++ b/charts/navi-castle/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 
 
 version: 2.52.0
-appVersion: 1.9.12
+appVersion: 1.10.8
 
 maintainers:
 - name: 2gis

--- a/charts/navi-castle/README.md
+++ b/charts/navi-castle/README.md
@@ -189,6 +189,16 @@ See the [documentation](https://docs.2gis.com/en/on-premise/navigation) to learn
 | `rtr.puzzleSegments.serverUrl`            | URL puzzle segments.                                                                                                              | `""`                                            |
 | `rtr.webapi.baseDir`                      | Base dir on webapi.                                                                                                               | `/2.0/region/list?fields=*&type=segment,region` |
 | `rtr.webapi.serverUrl`                    | URL webapi.                                                                                                                       | `""`                                            |
+| `rtr.s3.enabled`                          | Enable S3 source for restriction_json.                                                                                            | `false`                                         |
+| `rtr.s3.host`                             | S3 endpoint URL, ex: http://restriction-s3.host.                                                                                  | `""`                                            |
+| `rtr.s3.bucket`                           | S3 bucket name.                                                                                                                   | `""`                                            |
+| `rtr.s3.region`                           | S3 region.                                                                                                                        | `""`                                            |
+| `rtr.s3.accessKey`                        | S3 access key for accessing the bucket.                                                                                           | `""`                                            |
+| `rtr.s3.secretKey`                        | S3 secret key for accessing the bucket.                                                                                           | `""`                                            |
+| `rtr.s3.secure`                           | Establish secure channel                                                                                                          | `true`                                          |
+| `rtr.restrictionJson.remoteDir`           | Remote directory for restriction_json. Empty for HTTP source, `restrictions` for S3.                                              | `""`                                            |
+| `rtr.restrictionJson.header`              | HTTP header used for change detection.                                                                                            | `Last-Modified`                                 |
+| `rtr.restrictionJson.timeout`             | Queries request timeout in seconds.                                                                                               | `30`                                            |
 
 ### customCAs **Custom Certificate Authority**
 

--- a/charts/navi-castle/README.md
+++ b/charts/navi-castle/README.md
@@ -83,13 +83,13 @@ See the [documentation](https://docs.2gis.com/en/on-premise/navigation) to learn
 
 ### Limits
 
-| Name                        | Description                                 | Value       |
-| --------------------------- | ------------------------------------------- | ----------- |
-| `resources`                 | Container resources requirements structure. | `{}`        |
-| `resources.requests.cpu`    | CPU request, recommended value `100m`.      | `undefined` |
-| `resources.requests.memory` | Memory request, recommended value `128Mi`.  | `undefined` |
-| `resources.limits.cpu`      | CPU limit, recommended value `1000m`.       | `undefined` |
-| `resources.limits.memory`   | Memory limit, recommended value `512Mi`.    | `undefined` |
+| Name                        | Description                                                                                                                               | Value       |
+| --------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| `resources`                 | Default container resources requirements structure. Used by `nginx.resources`, `cron.resources`, and `rtr.resources` when they are empty. | `{}`        |
+| `resources.requests.cpu`    | CPU request, recommended value `100m`.                                                                                                    | `undefined` |
+| `resources.requests.memory` | Memory request, recommended value `128Mi`.                                                                                                | `undefined` |
+| `resources.limits.cpu`      | CPU limit, recommended value `1000m`.                                                                                                     | `undefined` |
+| `resources.limits.memory`   | Memory limit, recommended value `512Mi`.                                                                                                  | `undefined` |
 
 ### Navi-Castle service settings
 
@@ -97,7 +97,7 @@ See the [documentation](https://docs.2gis.com/en/on-premise/navigation) to learn
 | -------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------- |
 | `castle.image.repository`              | Navi-Castle service image repository.                                                                                                                                                                                                          | `2gis-on-premise/navi-castle` |
 | `castle.image.pullPolicy`              | Navi-Castle service pull policy.                                                                                                                                                                                                               | `IfNotPresent`                |
-| `castle.image.tag`                     | Navi-Castle service image tag.                                                                                                                                                                                                                 | `1.9.12`                      |
+| `castle.image.tag`                     | Navi-Castle service image tag.                                                                                                                                                                                                                 | `1.10.8`                      |
 | `castle.castleDataPath`                | Path to the data directory.                                                                                                                                                                                                                    | `/opt/castle/data`            |
 | `castle.excludeProjects`               | Array of project labels to exclude                                                                                                                                                                                                             | `[]`                          |
 | `castle.restrictions`                  | Section ignored if castle.restriction.enabled=false                                                                                                                                                                                            |                               |
@@ -117,14 +117,19 @@ See the [documentation](https://docs.2gis.com/en/on-premise/navigation) to learn
 
 ### Navi-Front settings
 
-| Name                     | Description                                                               | Value                        |
-| ------------------------ | ------------------------------------------------------------------------- | ---------------------------- |
-| `nginx.port`             | HTTP port on which Navi-Front will be listening.                          | `8080`                       |
-| `nginx.image.repository` | Navi-Front image repository.                                              | `2gis-on-premise/navi-front` |
-| `nginx.image.tag`        | Navi-Front image tag.                                                     | `1.28.1`                     |
-| `nginx.nodeHeader`       | Enable header with node name (X-Node).                                    | `false`                      |
-| `nginx.locationsBlock`   | Optional nginx config block with additional locations                     | `""`                         |
-| `nginx.customConfigPath` | Path to custom nginx config file. If set, default config will be ignored. | `""`                         |
+| Name                              | Description                                                                                 | Value                        |
+| --------------------------------- | ------------------------------------------------------------------------------------------- | ---------------------------- |
+| `nginx.port`                      | HTTP port on which Navi-Front will be listening.                                            | `8080`                       |
+| `nginx.image.repository`          | Navi-Front image repository.                                                                | `2gis-on-premise/navi-front` |
+| `nginx.image.tag`                 | Navi-Front image tag.                                                                       | `1.29.1`                     |
+| `nginx.nodeHeader`                | Enable header with node name (X-Node).                                                      | `false`                      |
+| `nginx.locationsBlock`            | Optional nginx config block with additional locations                                       | `""`                         |
+| `nginx.customConfigPath`          | Path to custom nginx config file. If set, default config will be ignored.                   | `""`                         |
+| `nginx.resources`                 | Container resources requirements for `castle-nginx`. Empty value falls back to `resources`. | `{}`                         |
+| `nginx.resources.requests.cpu`    | CPU request for `castle-nginx`.                                                             | `undefined`                  |
+| `nginx.resources.requests.memory` | Memory request for `castle-nginx`.                                                          | `undefined`                  |
+| `nginx.resources.limits.cpu`      | CPU limit for `castle-nginx`.                                                               | `undefined`                  |
+| `nginx.resources.limits.memory`   | Memory limit for `castle-nginx`.                                                            | `undefined`                  |
 
 ### Cron settings
 
@@ -140,6 +145,11 @@ See the [documentation](https://docs.2gis.com/en/on-premise/navigation) to learn
 | `cron.successfulJobsHistoryLimit` | How many completed jobs should be kept. See [jobs history limits](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#jobs-history-limits). | `3`           |
 | `cron.failedJobsHistoryLimit`     | How many failed jobs should be kept. See [jobs history limits](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#jobs-history-limits).    | `3`           |
 | `cron.prometheusPort`             | Container port for supercronic prometheus                                                                                                                    | `9476`        |
+| `cron.resources`                  | Container resources requirements for `castle-cron`. Empty value falls back to `resources`.                                                                   | `{}`          |
+| `cron.resources.requests.cpu`     | CPU request for `castle-cron`.                                                                                                                               | `undefined`   |
+| `cron.resources.requests.memory`  | Memory request for `castle-cron`.                                                                                                                            | `undefined`   |
+| `cron.resources.limits.cpu`       | CPU limit for `castle-cron`.                                                                                                                                 | `undefined`   |
+| `cron.resources.limits.memory`    | Memory limit for `castle-cron`.                                                                                                                              | `undefined`   |
 
 ### Init settings
 
@@ -202,6 +212,11 @@ See the [documentation](https://docs.2gis.com/en/on-premise/navigation) to learn
 | `rtr.restrictionJson.remoteDir`           | Remote directory for restriction_json. Empty for HTTP source, `restrictions` for S3.                                              | `""`                                            |
 | `rtr.restrictionJson.header`              | HTTP header used for change detection.                                                                                            | `Last-Modified`                                 |
 | `rtr.restrictionJson.timeout`             | Queries request timeout in seconds.                                                                                               | `30`                                            |
+| `rtr.resources`                           | Container resources requirements for `castle-rtr`. Empty value falls back to `resources`.                                         | `{}`                                            |
+| `rtr.resources.requests.cpu`              | CPU request for `castle-rtr`.                                                                                                     | `undefined`                                     |
+| `rtr.resources.requests.memory`           | Memory request for `castle-rtr`.                                                                                                  | `undefined`                                     |
+| `rtr.resources.limits.cpu`                | CPU limit for `castle-rtr`.                                                                                                       | `undefined`                                     |
+| `rtr.resources.limits.memory`             | Memory limit for `castle-rtr`.                                                                                                    | `undefined`                                     |
 
 ### customCAs **Custom Certificate Authority**
 

--- a/charts/navi-castle/README.md
+++ b/charts/navi-castle/README.md
@@ -151,13 +151,16 @@ See the [documentation](https://docs.2gis.com/en/on-premise/navigation) to learn
 
 ### Kubernetes [Persistence Volumes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) settings
 
-| Name                            | Description                                                                           | Value               |
-| ------------------------------- | ------------------------------------------------------------------------------------- | ------------------- |
-| `persistentVolume.enabled`      | If Kubernetes persistence volume should be enabled for Castle.                        | `false`             |
-| `persistentVolume.accessModes`  | Volume access mode.                                                                   | `["ReadWriteOnce"]` |
-| `persistentVolume.storageClass` | Volume [storage class](https://kubernetes.io/docs/concepts/storage/storage-classes/). | `""`                |
-| `persistentVolume.size`         | Volume size.                                                                          | `5Gi`               |
-| `persistentVolume.type`         | Volume type `pvc` or `ephemeral`.                                                     | `pvc`               |
+| Name                                          | Description                                                                                                                                                                                          | Value               |
+| --------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------- |
+| `persistentVolume.enabled`                    | If Kubernetes persistence volume should be enabled for Castle.                                                                                                                                       | `false`             |
+| `persistentVolume.accessModes`                | Volume access mode.                                                                                                                                                                                  | `["ReadWriteOnce"]` |
+| `persistentVolume.storageClass`               | Volume [storage class](https://kubernetes.io/docs/concepts/storage/storage-classes/).                                                                                                                | `""`                |
+| `persistentVolume.size`                       | Volume size.                                                                                                                                                                                         | `5Gi`               |
+| `persistentVolume.type`                       | Volume type `pvc` or `ephemeral`.                                                                                                                                                                    | `pvc`               |
+| `persistentVolume.claimRetention`             | Optional [PersistentVolumeClaim retention policy](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#persistentvolumeclaim-retention) for the StatefulSet volume claim template. |                     |
+| `persistentVolume.claimRetention.whenDeleted` | What happens to PVCs created from the volume claim template when the StatefulSet is deleted (`Retain` or `Delete`).                                                                                  |                     |
+| `persistentVolume.claimRetention.whenScaled`  | What happens to PVCs when the StatefulSet replica count is scaled down (`Retain` or `Delete`).                                                                                                       |                     |
 
 ### RTR settings. Leave with defaults, FOR FUTURE RELEASE.
 

--- a/charts/navi-castle/templates/configmapbuilder.yaml
+++ b/charts/navi-castle/templates/configmapbuilder.yaml
@@ -195,12 +195,24 @@ data:
     restriction_json:
     {
         remote_name: 'restrictions-temp-%project%.json',
-        remote_dir: '',
+        remote_dir: '{{ .Values.rtr.restrictionJson.remoteDir }}',
 
         local_name: '%project%-restriction.json',
         local_dir: 'restrictions/%project%',
 
         post_processing: RestrictionFilter
+
+        {{- if .Values.rtr.s3.enabled }}
+        s3:
+        {
+            server: '{{ .Values.rtr.s3.host }}',
+            bucket: '{{ .Values.rtr.s3.bucket }}',
+            login: '{{ .Values.rtr.s3.accessKey }}',
+            pwd: 'from-env',
+            header: '{{ .Values.rtr.restrictionJson.header }}',
+            timeout: {{ .Values.rtr.restrictionJson.timeout }}
+        },
+        {{- end }}{{- /* .Values.rtr.s3.enabled */}}
 
         http:
         {

--- a/charts/navi-castle/templates/configmapnginx.yaml
+++ b/charts/navi-castle/templates/configmapnginx.yaml
@@ -24,6 +24,13 @@ data:
             autoindex_format json;
         }
 
+        location /navi-data-sync {
+            expires epoch;
+            alias  {{ .Values.castle.castleDataPath }}/backup;
+            autoindex on;
+            autoindex_format json;
+        }
+
         {{- if .Values.nginx.locationsBlock }}
           {{ .Values.nginx.locationsBlock | nindent 8 }}
         {{- end }}

--- a/charts/navi-castle/templates/cronjob.yaml
+++ b/charts/navi-castle/templates/cronjob.yaml
@@ -21,6 +21,10 @@ spec:
           labels:
         {{- include "castle.selectorLabels" $ | nindent 12 }}
         spec:
+          {{- with $.Values.podSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           affinity:
             podAffinity:
               requiredDuringSchedulingIgnoredDuringExecution:
@@ -57,6 +61,10 @@ spec:
             - name: castle-cron
               image: {{ required "A valid .Values.dgctlDockerRegistry entry required" $.Values.dgctlDockerRegistry }}/{{ $.Values.castle.image.repository }}:{{ $.Values.castle.image.tag | default $.Chart.AppVersion }}
               imagePullPolicy: {{ $.Values.castle.image.pullPolicy }}
+              {{- with $.Values.securityContext }}
+              securityContext:
+                {{- toYaml . | nindent 16 }}
+              {{- end }}
               command: [ "/opt/configuration_builder" ]
               args:
               - --config
@@ -91,7 +99,7 @@ spec:
               - name: {{ include "castle.fullname" $ }}-pvc
                 mountPath: {{ $.Values.castle.castleDataPath }}
               resources:
-                {{- toYaml $.Values.resources | nindent 16 }}
+                {{- toYaml ($.Values.cron.resources | default $.Values.resources) | nindent 16 }}
 {{- end -}} {{/* if */}}
 {{- end -}} {{/* range $flavor */}}
 {{- end -}} {{/* range $i, $e */}}

--- a/charts/navi-castle/templates/secret.yaml
+++ b/charts/navi-castle/templates/secret.yaml
@@ -17,4 +17,7 @@ data:
   {{ $prop | quote }}: {{ $val | b64enc | quote }}
   {{- end }}
   rtr.webapi.password: {{ .Values.rtr.buildFtp.password | b64enc | quote }}
+  {{- if .Values.rtr.s3.enabled }}
+  rtr.s3.secretKey: {{ .Values.rtr.s3.secretKey | b64enc | quote }}
+  {{- end }}{{- /* .Values.rtr.s3.enabled */}}
 {{- end }}{{- /* .Values.rtr.enabled and (or $consumerSensitiveProperties $consumerFileProperties) */}}

--- a/charts/navi-castle/templates/statefulset.yaml
+++ b/charts/navi-castle/templates/statefulset.yaml
@@ -307,6 +307,13 @@ spec:
                 secretKeyRef:
                   key: rtr.webapi.password
                   name: {{ print (include "castle.fullname" $) "-rtr" }}
+            {{- if .Values.rtr.s3.enabled }}
+            - name: CASTLE_RESTRICTION_JSON_S3_PWD
+              valueFrom:
+                secretKeyRef:
+                  key: rtr.s3.secretKey
+                  name: {{ print (include "castle.fullname" $) "-rtr" }}
+            {{- end }}{{- /* .Values.rtr.s3.enabled */}}
             - name: POD_NAME
               valueFrom:
                 fieldRef:

--- a/charts/navi-castle/templates/statefulset.yaml
+++ b/charts/navi-castle/templates/statefulset.yaml
@@ -376,7 +376,7 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-  {{- if and .Values.persistentVolume.enabled (eq .Values.persistentVolume.type "pvc") }}
+{{- if and .Values.persistentVolume.enabled (eq .Values.persistentVolume.type "pvc") }}
   volumeClaimTemplates:
     - metadata:
         name: {{ include "castle.fullname" . }}-pvc
@@ -389,4 +389,7 @@ spec:
         resources:
           requests:
             storage: {{ .Values.persistentVolume.size }}
-  {{- end }}
+  {{- with .Values.persistentVolume.claimRetention }}
+  persistentVolumeClaimRetentionPolicy: {{ toYaml . | nindent 4 }}
+  {{- end }}{{- /* .Values.persistentVolume.claimRetention */}}
+{{- end }}

--- a/charts/navi-castle/templates/statefulset.yaml
+++ b/charts/navi-castle/templates/statefulset.yaml
@@ -109,7 +109,7 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           resources:
-            {{- toYaml .Values.resources | nindent 12 }}
+            {{- toYaml (.Values.nginx.resources | default .Values.resources) | nindent 12 }}
           volumeMounts:
           - name: {{ include "castle.fullname" . }}-castle-nginx-config
             mountPath: {{ printf "%s/conf.d/castle.conf" ( include "nginx.customConfigPath" .) }}
@@ -178,7 +178,7 @@ spec:
               name: {{ include "castle.fullname" . }}-secret-env
           {{- end }}
           resources:
-            {{- toYaml $.Values.resources | nindent 12 }}
+            {{- toYaml (.Values.cron.resources | default .Values.resources) | nindent 12 }}
           startupProbe:
             {{- /* checks if supercronic prometheus port is open */}}
             httpGet:
@@ -241,7 +241,7 @@ spec:
             - --service=restriction_json
             - --daemon
           resources:
-            {{- toYaml $.Values.resources | nindent 12 }}
+            {{- toYaml (.Values.rtr.resources | default .Values.resources) | nindent 12 }}
           volumeMounts:
           - name: {{ include "castle.fullname" $ }}-builder-config
             mountPath: /opt/config_builder.conf

--- a/charts/navi-castle/values.yaml
+++ b/charts/navi-castle/values.yaml
@@ -272,12 +272,34 @@ persistentVolume:
 # @param rtr.puzzleSegments.serverUrl URL puzzle segments.
 # @param rtr.webapi.baseDir Base dir on webapi.
 # @param rtr.webapi.serverUrl URL webapi.
+# @param rtr.s3.enabled Enable S3 source for restriction_json.
+# @param rtr.s3.host S3 endpoint URL, ex: http://restriction-s3.host.
+# @param rtr.s3.bucket S3 bucket name.
+# @param rtr.s3.region S3 region.
+# @param rtr.s3.accessKey S3 access key for accessing the bucket.
+# @param rtr.s3.secretKey S3 secret key for accessing the bucket.
+# @param rtr.s3.secure Establish secure channel
+# @param rtr.restrictionJson.remoteDir Remote directory for restriction_json. Empty for HTTP source, `restrictions` for S3.
+# @param rtr.restrictionJson.header HTTP header used for change detection.
+# @param rtr.restrictionJson.timeout Queries request timeout in seconds.
 
 rtr:
   enabled: false
   http:
     baseDir: export-restrictions-json
     serverUrl: ''
+  s3:
+    enabled: false
+    host: ''
+    bucket: ''
+    region: ''
+    accessKey: ''
+    secretKey: ''
+    secure: true
+  restrictionJson:
+    remoteDir: ''
+    header: 'Last-Modified'
+    timeout: 30
   kafka:
     groupId: castle-rtr
     properties:

--- a/charts/navi-castle/values.yaml
+++ b/charts/navi-castle/values.yaml
@@ -109,7 +109,7 @@ ingress:
 
 # @section Limits
 
-# @param resources [nullable] Container resources requirements structure.
+# @param resources [nullable] Default container resources requirements structure. Used by `nginx.resources`, `cron.resources`, and `rtr.resources` when they are empty.
 # @param resources.requests.cpu [nullable] CPU request, recommended value `100m`.
 # @param resources.requests.memory [nullable] Memory request, recommended value `128Mi`.
 # @param resources.limits.cpu [nullable] CPU limit, recommended value `1000m`.
@@ -144,7 +144,7 @@ castle:
   image:
     repository: 2gis-on-premise/navi-castle
     pullPolicy: IfNotPresent
-    tag: 1.9.12
+    tag: 1.10.8
   castleDataPath: /opt/castle/data
   restrictions:
     url: ''
@@ -171,15 +171,21 @@ castle:
 # @param nginx.nodeHeader Enable header with node name (X-Node).
 # @param nginx.locationsBlock Optional nginx config block with additional locations
 # @param nginx.customConfigPath Path to custom nginx config file. If set, default config will be ignored.
+# @param nginx.resources [nullable] Container resources requirements for `castle-nginx`. Empty value falls back to `resources`.
+# @param nginx.resources.requests.cpu [nullable] CPU request for `castle-nginx`.
+# @param nginx.resources.requests.memory [nullable] Memory request for `castle-nginx`.
+# @param nginx.resources.limits.cpu [nullable] CPU limit for `castle-nginx`.
+# @param nginx.resources.limits.memory [nullable] Memory limit for `castle-nginx`.
 
 nginx:
   port: 8080
   image:
     repository: 2gis-on-premise/navi-front
-    tag: 1.28.1
+    tag: 1.29.1
   nodeHeader: false
   locationsBlock: ''
   customConfigPath: ''
+  resources: {}
 
 
 # @section Cron settings
@@ -194,6 +200,11 @@ nginx:
 # @param cron.successfulJobsHistoryLimit How many completed jobs should be kept. See [jobs history limits](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#jobs-history-limits).
 # @param cron.failedJobsHistoryLimit How many failed jobs should be kept. See [jobs history limits](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#jobs-history-limits).
 # @param cron.prometheusPort Container port for supercronic prometheus
+# @param cron.resources [nullable] Container resources requirements for `castle-cron`. Empty value falls back to `resources`.
+# @param cron.resources.requests.cpu [nullable] CPU request for `castle-cron`.
+# @param cron.resources.requests.memory [nullable] Memory request for `castle-cron`.
+# @param cron.resources.limits.cpu [nullable] CPU limit for `castle-cron`.
+# @param cron.resources.limits.memory [nullable] Memory limit for `castle-cron`.
 
 cron:
   enabled:
@@ -208,6 +219,7 @@ cron:
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 3
   prometheusPort: 9476
+  resources: {}
 
 
 # @section Init settings
@@ -285,9 +297,15 @@ persistentVolume:
 # @param rtr.restrictionJson.remoteDir Remote directory for restriction_json. Empty for HTTP source, `restrictions` for S3.
 # @param rtr.restrictionJson.header HTTP header used for change detection.
 # @param rtr.restrictionJson.timeout Queries request timeout in seconds.
+# @param rtr.resources [nullable] Container resources requirements for `castle-rtr`. Empty value falls back to `resources`.
+# @param rtr.resources.requests.cpu [nullable] CPU request for `castle-rtr`.
+# @param rtr.resources.requests.memory [nullable] Memory request for `castle-rtr`.
+# @param rtr.resources.limits.cpu [nullable] CPU limit for `castle-rtr`.
+# @param rtr.resources.limits.memory [nullable] Memory limit for `castle-rtr`.
 
 rtr:
   enabled: false
+  resources: {}
   http:
     baseDir: export-restrictions-json
     serverUrl: ''

--- a/charts/navi-castle/values.yaml
+++ b/charts/navi-castle/values.yaml
@@ -230,6 +230,9 @@ init:
 # @param persistentVolume.storageClass Volume [storage class](https://kubernetes.io/docs/concepts/storage/storage-classes/).
 # @param persistentVolume.size Volume size.
 # @param persistentVolume.type Volume type `pvc` or `ephemeral`.
+# @extra persistentVolume.claimRetention Optional [PersistentVolumeClaim retention policy](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#persistentvolumeclaim-retention) for the StatefulSet volume claim template.
+# @extra persistentVolume.claimRetention.whenDeleted What happens to PVCs created from the volume claim template when the StatefulSet is deleted (`Retain` or `Delete`).
+# @extra persistentVolume.claimRetention.whenScaled What happens to PVCs when the StatefulSet replica count is scaled down (`Retain` or `Delete`).
 
 persistentVolume:
   enabled: false


### PR DESCRIPTION
# Pull Request description

## Changelog

- Add resources sections for navi-nginx, navi-cron, navi-rtr containers. Keep supporting previous common parameter.
- Add security context for cronJob
- https://tsup.2gis.dev/navi/castle/1.10.8

## Issues

[DEVOPS-2922](https://jira.2gis.ru/browse/DEVOPS-2922)
[DEVOPS-2123](https://jira.2gis.ru/browse/DEVOPS-2123)


## Breaking changes

- If there are breaking changes, they need to be added to the file [Breaking-Changes](../Breaking-Changes.md)

## Check-list. Чек-лист код-ревью

- [ ] Запрос на слияние в develop.
- [ ] Есть описание к PR.
- [ ] Указаны блокирующие изменения. [Breaking-Changes](../Breaking-Changes.md)
- [ ] Соответствие кода принятому [стилю](../styleguide.md)
  - [ ] Описание настроек.
  - [ ] Именование настроек.
  - [ ] Дефолтные значения.
  - [ ] Стиль кода.
- [ ] Работоспособность. Разворачивается на своем окружении из ветки PR.
  - [ ] Тест API через тесты helmfile-хуков или коллекций Postman.
- [ ] Не осталось мусора от удаления каких-то параметров. Ищется поиском по проекту из ветки PR.
- [ ] Отработка линтера на чарт из ветки PR. Пример: `helm lint charts/search-api`
