### PR TITLE
[generic-chart] Обновление в соответствии с требованиями КБ

### DIFF
--- a/charts/generic-chart/README.md
+++ b/charts/generic-chart/README.md
@@ -56,25 +56,37 @@ Chart is tested using [pipeline](https://gitlab.2gis.ru/traffic/cicd-pipelines/-
 
 ### [Deployment](https://kubernetes.io/docs/tasks/run-application/run-stateless-application-deployment/) settings
 
-| Name                            | Description                                                                                                                                  | Value   |
-| ------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
-| `labels`                        | Custom labels to set to Deployment resource                                                                                                  | `{}`    |
-| `annotations`                   | Custom annotations to set to Deployment resource                                                                                             | `{}`    |
-| `replicaCount`                  | A replica count for the pod                                                                                                                  | `1`     |
-| `revisionHistoryLimit`          | Number of replica sets to keep for deployment rollbacks                                                                                      | `1`     |
-| `strategy`                      | Deployment [strategy](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy). Undergoes template rendering          | `{}`    |
-| `podAnnotations`                | Kubernetes [pod annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/)                                 | `{}`    |
-| `imagePullSecrets`              | Kubernetes image pull secrets                                                                                                                | `[]`    |
-| `podSecurityContext`            | Kubernetes [pod security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/)                                | `{}`    |
-| `priorityClassName`             | Kubernetes [Pod Priority](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#priorityclass) class name         | `""`    |
-| `terminationGracePeriodSeconds` | Maximum time allowed for graceful shutdown                                                                                                   | `60`    |
-| `nodeSelector`                  | Kubernetes [node selectors](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector)                           | `{}`    |
-| `affinity`                      | Kubernetes pod [affinity settings](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity)                   | `{}`    |
-| `tolerations`                   | Kubernetes [tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) settings                             | `[]`    |
-| `enableServiceLinks`            | Services injection into containers environment                                                                                               | `false` |
-| `restartPolicy`                 | Kubernetes pod [restart policy](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy)                            | `""`    |
-| `updateStrategy`                | Kubernetes StatefulSet [update strategy](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#update-strategies)           | `{}`    |
-| `volumeClaimTemplates`          | Kubernetes StatefulSet [volue claim template](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#volume-claim-templates) | `[]`    |
+| Name                                                | Description                                                                                                                                  | Value            |
+| --------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- | ---------------- |
+| `labels`                                            | Custom labels to set to Deployment resource                                                                                                  | `{}`             |
+| `annotations`                                       | Custom annotations to set to Deployment resource                                                                                             | `{}`             |
+| `replicaCount`                                      | A replica count for the pod                                                                                                                  | `1`              |
+| `revisionHistoryLimit`                              | Number of replica sets to keep for deployment rollbacks                                                                                      | `1`              |
+| `strategy`                                          | Deployment [strategy](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy). Undergoes template rendering          | `{}`             |
+| `podAnnotations`                                    | Kubernetes [pod annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/)                                 | `{}`             |
+| `imagePullSecrets`                                  | Kubernetes image pull secrets                                                                                                                | `[]`             |
+| `podSecurityContext.runAsNonRoot`                   | Indicates that the container must run as a non-root user                                                                                     | `true`           |
+| `podSecurityContext.runAsUser`                      | The User ID (UID) to run the entrypoint of the container process                                                                             | `10001`          |
+| `podSecurityContext.runAsGroup`                     | The primary Group ID (GID) for all processes in the container                                                                                | `10002`          |
+| `podSecurityContext.fsGroup`                        | A special supplemental group ID applied to all volumes mounted by the pod                                                                    | `10001`          |
+| `containerSecurityContext.privileged`               | Runs the container in privileged mode (processes are essentially equivalent to root on the host)                                             | `false`          |
+| `containerSecurityContext.runAsNonRoot`             | Forces the container to run as a non-root user                                                                                               | `true`           |
+| `containerSecurityContext.runAsUser`                | The User ID (UID) to run the container process                                                                                               | `10001`          |
+| `containerSecurityContext.runAsGroup`               | The primary Group ID (GID) for the container process                                                                                         | `10002`          |
+| `containerSecurityContext.allowPrivilegeEscalation` | Controls whether a process can gain more privileges than its parent process                                                                  | `false`          |
+| `containerSecurityContext.readOnlyRootFilesystem`   | Whether this container has a read-only root filesystem                                                                                       | `true`           |
+| `containerSecurityContext.capabilities.drop`        | The Linux capabilities to drop from the container                                                                                            | `["ALL"]`        |
+| `containerSecurityContext.seccompProfile.type`      | The type of seccomp profile to apply (e.g., RuntimeDefault)                                                                                  | `RuntimeDefault` |
+| `priorityClassName`                                 | Kubernetes [Pod Priority](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#priorityclass) class name         | `""`             |
+| `terminationGracePeriodSeconds`                     | Maximum time allowed for graceful shutdown                                                                                                   | `60`             |
+| `hostAliases`                                       | Kubernetes [host aliases](https://kubernetes.io/docs/tasks/network/customize-hosts-file-for-pods/)                                           | `[]`             |
+| `nodeSelector`                                      | Kubernetes [node selectors](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector)                           | `{}`             |
+| `affinity`                                          | Kubernetes pod [affinity settings](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity)                   | `{}`             |
+| `tolerations`                                       | Kubernetes [tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) settings                             | `[]`             |
+| `enableServiceLinks`                                | Services injection into containers environment                                                                                               | `false`          |
+| `restartPolicy`                                     | Kubernetes pod [restart policy](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy)                            | `""`             |
+| `updateStrategy`                                    | Kubernetes StatefulSet [update strategy](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#update-strategies)           | `{}`             |
+| `volumeClaimTemplates`                              | Kubernetes StatefulSet [volue claim template](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#volume-claim-templates) | `[]`             |
 
 ### Kubernetes [Horizontal Pod Autoscaling](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/) settings
 
@@ -134,11 +146,12 @@ Chart is tested using [pipeline](https://gitlab.2gis.ru/traffic/cicd-pipelines/-
 
 ### [Service account](https://kubernetes.io/docs/concepts/security/service-accounts/) settings
 
-| Name                         | Description                                                                                                             | Value  |
-| ---------------------------- | ----------------------------------------------------------------------------------------------------------------------- | ------ |
-| `serviceAccount.create`      | Specifies whether a service account should be created.                                                                  | `true` |
-| `serviceAccount.annotations` | Annotations to add to the service account.                                                                              | `{}`   |
-| `serviceAccount.name`        | The name of the service account to use. If not set and create is true, a name is generated using the fullname template. | `""`   |
+| Name                                          | Description                                                                                                             | Value   |
+| --------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- | ------- |
+| `serviceAccount.create`                       | Specifies whether a service account should be created.                                                                  | `true`  |
+| `serviceAccount.annotations`                  | Annotations to add to the service account.                                                                              | `{}`    |
+| `serviceAccount.name`                         | The name of the service account to use. If not set and create is true, a name is generated using the fullname template. | `""`    |
+| `serviceAccount.automountServiceAccountToken` | Automount service account token.                                                                                        | `false` |
 
 ### [CronJob](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/) settings
 
@@ -177,22 +190,32 @@ Chart is tested using [pipeline](https://gitlab.2gis.ru/traffic/cicd-pipelines/-
 
 ### [HTTPRoute](https://gateway-api.sigs.k8s.io/api-types/httproute/) configuration
 
-| Name                                | Description                                         | Value            |
-| ----------------------------------- | --------------------------------------------------- | ---------------- |
-| `httpRoute.enabled`                 | If HTTPRoute is enabled for the service.            | `false`          |
-| `httpRoute.hostnames`               | List of hostnames served by route                   | `[]`             |
-| `httpRoute.parentRefs`              | List of parent references (gateways) for HTTPRoute. |                  |
-| `httpRoute.parentRefs[0].name`      | Name for the first default parentRef                | `canary`         |
-| `httpRoute.parentRefs[0].namespace` | Namespace for the first default parentRef           | `istio-gateways` |
-| `httpRoute.parentRefs[1].name`      | Name for the second default parentRef               | `stable`         |
-| `httpRoute.parentRefs[1].namespace` | Namespace for the second default parentRef          | `istio-gateways` |
+| Name                                | Description                                                                                                             | Value            |
+| ----------------------------------- | ----------------------------------------------------------------------------------------------------------------------- | ---------------- |
+| `httpRoute.enabled`                 | If HTTPRoute is enabled for the service                                                                                 | `false`          |
+| `httpRoute.annotations`             | Kubernetes [annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/) for HTTPRoute. | `{}`             |
+| `httpRoute.labels`                  | Kubernetes [labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/) for HTTPRoute.           | `{}`             |
+| `httpRoute.hostnames`               | List of hostnames served by route                                                                                       | `[]`             |
+| `httpRoute.parentRefs`              | List of parent references (gateways) for HTTPRoute                                                                      |                  |
+| `httpRoute.parentRefs[0].name`      | Name for the first parentRef                                                                                            | `canary`         |
+| `httpRoute.parentRefs[0].namespace` | Namespace for the first parentRef                                                                                       | `istio-gateways` |
+| `httpRoute.parentRefs[1].name`      | Name for the second parentRef                                                                                           | `stable`         |
+| `httpRoute.parentRefs[1].namespace` | Namespace for the second parentRef                                                                                      | `istio-gateways` |
 
 ### [GRPCRoute](https://gateway-api.sigs.k8s.io/api-types/grpcroute/) configuration
 
-| Name                  | Description                                                                                        | Value |
-| --------------------- | -------------------------------------------------------------------------------------------------- | ----- |
-| `grpcRoute.hostnames` | List of hostnames served by route                                                                  | `[]`  |
-| `grpcRoute.port`      | Destination grpcroute.spec.rules.backendRefs.port number, must be set if grpcRoute.enabled is true | `nil` |
+| Name                                | Description                                                                                                             | Value            |
+| ----------------------------------- | ----------------------------------------------------------------------------------------------------------------------- | ---------------- |
+| `grpcRoute.enabled`                 | If GRPCRoute is enabled for the service.                                                                                | `false`          |
+| `grpcRoute.annotations`             | Kubernetes [annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/) for GRPCRoute. | `{}`             |
+| `grpcRoute.labels`                  | Kubernetes [labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/) for GRPCRoute.           | `{}`             |
+| `grpcRoute.hostnames`               | List of hostnames served by route                                                                                       | `[]`             |
+| `grpcRoute.port`                    | Destination grpcroute.spec.rules.backendRefs.port number, must be set if grpcRoute.enabled is true                      | `nil`            |
+| `grpcRoute.parentRefs`              | List of parent references (gateways) for GRPCRoute.                                                                     |                  |
+| `grpcRoute.parentRefs[0].name`      | Name for the first parentRef                                                                                            | `canary`         |
+| `grpcRoute.parentRefs[0].namespace` | Namespace for the first parentRef                                                                                       | `istio-gateways` |
+| `grpcRoute.parentRefs[1].name`      | Name for the second parentRef                                                                                           | `stable`         |
+| `grpcRoute.parentRefs[1].namespace` | Namespace for the second parentRef                                                                                      | `istio-gateways` |
 
 ## Maintainers
 

--- a/charts/generic-chart/templates/_container_spec.yaml
+++ b/charts/generic-chart/templates/_container_spec.yaml
@@ -1,0 +1,17 @@
+{{- define "generic-chart.container_spec.tpl" -}}
+{{- $ctx := . -}}
+{{- $container := dict -}}
+{{- if and (kindIs "map" .) (hasKey . "ctx") -}}
+  {{- $ctx = .ctx -}}
+  {{- $container = .container | default dict -}}
+{{- end -}}
+name: {{ default (include "generic-chart.containerName" $ctx) $container.name }}
+{{- $containerSecurityContext := $ctx.Values.containerSecurityContext }}
+{{- if hasKey $container "containerSecurityContext" }}
+  {{- $containerSecurityContext = $container.containerSecurityContext }}
+{{- end }}
+{{- with $containerSecurityContext }}
+securityContext:
+  {{- toYaml . | nindent 2 }}
+{{- end }}{{- /* securityContext */}}
+{{- end }} {{- /* define */}}

--- a/charts/generic-chart/templates/_grpcroute.yaml
+++ b/charts/generic-chart/templates/_grpcroute.yaml
@@ -1,23 +1,26 @@
 {{- define "generic-chart.grpcRoute.tpl" -}}
+{{- if (.Values.grpcRoute).enabled -}}
 {{- include "generic-chart.checkHostnames" $ -}}
 apiVersion: gateway.networking.k8s.io/v1
 kind: GRPCRoute
 metadata:
   name: {{ include "generic-chart.fullname" . }}
+  labels:
+    {{- include "generic-chart.labels" . | nindent 4 }}
+    {{- with .Values.grpcRoute.labels }}
+    {{- include "tplvalues.render" (dict "value" . "context" $) | nindent 4 }}
+    {{- end }}
+  {{- with .Values.grpcRoute.annotations }}
+  annotations:
+    {{- include "tplvalues.render" (dict "value" . "context" $) | nindent 4 }}
+  {{- end }}
 spec:
   {{- with .Values.grpcRoute.hostnames }}
   hostnames:
     {{- . | toYaml | nindent 4 }}
   {{- end }}
   parentRefs:
-    - group: gateway.networking.k8s.io
-      kind: Gateway
-      name: canary
-      namespace: istio-gateways
-    - group: gateway.networking.k8s.io
-      kind: Gateway
-      name: stable
-      namespace: istio-gateways
+    {{- include "generic-chart.grpcRouteParentRefs" . | nindent 4 }}
   rules:
     - backendRefs:
         - group: ""
@@ -25,4 +28,5 @@ spec:
           name: {{  include "generic-chart.fullname" . }}
           port: {{ required "grpcRoute.port is required" (.Values.grpcRoute).port }}
           weight: 1
+{{- end }}{{/* if enabled */}}
 {{- end }}{{/* define */}}

--- a/charts/generic-chart/templates/_helpers.tpl
+++ b/charts/generic-chart/templates/_helpers.tpl
@@ -116,7 +116,25 @@ This takes an array of three values:
   {{- $top := first . -}}
   {{- $overrides := fromYaml (include (index . 1) $top) | default (dict ) -}}
   {{- $tpl := fromYaml (include (index . 2) $top) | default (dict ) -}}
-  {{- toYaml (merge $overrides $tpl) -}}
+  {{- $merged := merge $overrides $tpl -}}
+  {{- include "generic-chart.applyVolumeDefaultMode" $merged -}}
+  {{- toYaml $merged -}}
+{{- end -}}
+
+{{/*
+Set defaultMode 0400 (decimal 256) for configMap and secret volumes when the
+consuming chart does not define defaultMode explicitly.
+*/}}
+{{- define "generic-chart.applyVolumeDefaultMode" -}}
+  {{- $podSpec := dig "spec" "template" "spec" (dict) . -}}
+  {{- range $volume := (get $podSpec "volumes" | default list) -}}
+    {{- range $volumeSource := list "configMap" "secret" -}}
+      {{- $source := get $volume $volumeSource -}}
+      {{- if and $source (not (hasKey $source "defaultMode")) -}}
+        {{- $_ := set $source "defaultMode" 256 -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
 {{- end -}}
 
 {{/*
@@ -235,15 +253,15 @@ Params:
 {{- end -}}
 
 {{/*
-Return parentRefs for HTTPRoute.
+Return default parentRefs for Gateway API routes.
 
-If .Values.httpRoute.parentRefs is provided by a consuming chart, use it.
+If .Values.routeParentRefs is provided by a consuming chart, use it.
 Otherwise return default canary/stable gateways.
 This keeps behavior stable for consumers that do not inherit library-chart values.
 */}}
-{{- define "generic-chart.httpRouteParentRefs" -}}
-{{- if and (hasKey .Values "httpRoute") (kindIs "map" .Values.httpRoute) (hasKey .Values.httpRoute "parentRefs") -}}
-{{- .Values.httpRoute.parentRefs | toYaml -}}
+{{- define "generic-chart.routeParentRefs" -}}
+{{- if hasKey .Values "routeParentRefs" -}}
+{{- .Values.routeParentRefs | toYaml -}}
 {{- else -}}
 - group: gateway.networking.k8s.io
   kind: Gateway
@@ -253,6 +271,34 @@ This keeps behavior stable for consumers that do not inherit library-chart value
   kind: Gateway
   name: stable
   namespace: istio-gateways
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return parentRefs for HTTPRoute.
+
+If .Values.httpRoute.parentRefs is provided by a consuming chart, use it.
+Otherwise use common routeParentRefs.
+*/}}
+{{- define "generic-chart.httpRouteParentRefs" -}}
+{{- if and (hasKey .Values "httpRoute") (kindIs "map" .Values.httpRoute) (hasKey .Values.httpRoute "parentRefs") -}}
+{{- .Values.httpRoute.parentRefs | toYaml -}}
+{{- else -}}
+{{- include "generic-chart.routeParentRefs" . -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return parentRefs for GRPCRoute.
+
+If .Values.grpcRoute.parentRefs is provided by a consuming chart, use it.
+Otherwise use common routeParentRefs.
+*/}}
+{{- define "generic-chart.grpcRouteParentRefs" -}}
+{{- if and (hasKey .Values "grpcRoute") (kindIs "map" .Values.grpcRoute) (hasKey .Values.grpcRoute "parentRefs") -}}
+{{- .Values.grpcRoute.parentRefs | toYaml -}}
+{{- else -}}
+{{- include "generic-chart.routeParentRefs" . -}}
 {{- end -}}
 {{- end -}}
 

--- a/charts/generic-chart/templates/_helpers.tpl
+++ b/charts/generic-chart/templates/_helpers.tpl
@@ -104,20 +104,29 @@ Backwards compatibility: legacy .Values.vpa.containerName is honored via generic
 {{- end -}}
 
 {{- /*
-generic-chart.merge will merge two YAML templates and output the result.
+Merges two YAML templates and output the result.
 (originates from The Common Helm Helper Chart)
 
 This takes an array of three values:
 - the top context
 - the template name of the overrides (destination)
 - the template name of the base (source)
+
+A template for specific inner purposes, use `generic-chart.merge` instead.
 */}}
-{{- define "generic-chart.merge" -}}
+{{- define "generic-chart._merge" -}}
   {{- $top := first . -}}
   {{- $overrides := fromYaml (include (index . 1) $top) | default (dict ) -}}
   {{- $tpl := fromYaml (include (index . 2) $top) | default (dict ) -}}
-  {{- $merged := merge $overrides $tpl -}}
-  {{- include "generic-chart.applyVolumeDefaultMode" $merged -}}
+  {{- toYaml (merge $overrides $tpl) -}}
+{{- end -}}
+
+{{- /*
+Merge manifests and apply default policies.
+*/}}
+{{- define "generic-chart.merge" -}}
+  {{- $merged := include "generic-chart._merge" . | fromYaml -}}
+  {{- $merged = $merged | toYaml | include "generic-chart.applyVolumeDefaultMode" | fromYaml -}}
   {{- toYaml $merged -}}
 {{- end -}}
 
@@ -126,7 +135,9 @@ Set defaultMode 0400 (decimal 256) for configMap and secret volumes when the
 consuming chart does not define defaultMode explicitly.
 */}}
 {{- define "generic-chart.applyVolumeDefaultMode" -}}
-  {{- $podSpec := dig "spec" "template" "spec" (dict) . -}}
+  {{- $manifest := fromYaml . -}}
+  {{- /* assuming Pod controller manifest like Deployment or StatefulSet */}}
+  {{- $podSpec := dig "spec" "template" "spec" (dict) $manifest -}}
   {{- range $volume := (get $podSpec "volumes" | default list) -}}
     {{- range $volumeSource := list "configMap" "secret" -}}
       {{- $source := get $volume $volumeSource -}}
@@ -135,6 +146,7 @@ consuming chart does not define defaultMode explicitly.
       {{- end -}}
     {{- end -}}
   {{- end -}}
+  {{- toYaml $manifest -}}
 {{- end -}}
 
 {{/*

--- a/charts/generic-chart/templates/_httproute.yaml
+++ b/charts/generic-chart/templates/_httproute.yaml
@@ -4,6 +4,15 @@ apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: {{ include "generic-chart.fullname" . }}
+  labels:
+    {{- include "generic-chart.labels" . | nindent 4 }}
+    {{- with .Values.httpRoute.labels }}
+    {{- include "tplvalues.render" (dict "value" . "context" $) | nindent 4 }}
+    {{- end }}
+  {{- with .Values.httpRoute.annotations }}
+  annotations:
+    {{- include "tplvalues.render" (dict "value" . "context" $) | nindent 4 }}
+  {{- end }}
 spec:
   {{- with .Values.httpRoute.hostnames }}
   hostnames:

--- a/charts/generic-chart/templates/_networkpolicy.yaml
+++ b/charts/generic-chart/templates/_networkpolicy.yaml
@@ -30,16 +30,16 @@ spec:
         {{- with .ingress.explicitNamespacesSelector }}
           # From authorized namespaces
           namespaceSelector:
-            {{ toYaml . | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
         {{- end }}{{- /* with .ingress.explicitNamespacesSelector */}}
-        {{- with .ingress.additionalRules }}
-            # Or from custom additional rules
-          {{ toYaml . | nindent 8 }}
-        {{- end }}{{- /* with .ingress.additionalRules */}}
+      {{- with .ingress.additionalRules }}
+        # Or from custom additional rules
+        {{- toYaml . | nindent 8 }}
+      {{- end }}{{- /* with .ingress.additionalRules */}}
   {{- end }}{{/* if (.ingress).enabled */}}
   {{- if (.egress).enabled }}
   egress:
-    {{ .egress.config | toYaml | nindent 4 }}
+    {{- .egress.config | toYaml | nindent 4 }}
   {{- end }}{{/* if .egress.enabled */}}
 {{- end }}{{/* with .Values.networkPolicy */}}
 {{- end }} {{- /* define */}}

--- a/charts/generic-chart/templates/_pod_spec.yaml
+++ b/charts/generic-chart/templates/_pod_spec.yaml
@@ -28,6 +28,10 @@ spec:
   terminationGracePeriodSeconds: {{ . | default 60 }}
   {{- end }}{{- /* terminationGracePeriodSeconds */}}
   enableServiceLinks: {{ .Values.enableServiceLinks | default false }}
+  {{- with .Values.hostAliases }}
+  hostAliases:
+    {{- toYaml . | nindent 8 }}
+  {{- end }}{{- /* hostAliases */}}
   {{- with .Values.nodeSelector }}
   nodeSelector:
     {{- toYaml . | nindent 8 }}

--- a/charts/generic-chart/templates/_service.yaml
+++ b/charts/generic-chart/templates/_service.yaml
@@ -23,6 +23,7 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
+      appProtocol: http
       {{- if (.Values.service).nodePort | default false }}
         {{- if contains "NodePort" ((.Values.service).type | default "ClusterIP") }}
       nodePort: {{ .Values.service.nodePort }}

--- a/charts/generic-chart/templates/_serviceaccount.yaml
+++ b/charts/generic-chart/templates/_serviceaccount.yaml
@@ -2,6 +2,11 @@
 {{- if (.Values.serviceAccount).create -}}
 apiVersion: v1
 kind: ServiceAccount
+{{- if hasKey (.Values.serviceAccount) "automountServiceAccountToken" }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- else }}
+automountServiceAccountToken: false
+{{- end }}
 metadata:
   name: {{ include "generic-chart.serviceAccountName" . }}
   labels:

--- a/charts/generic-chart/values.yaml
+++ b/charts/generic-chart/values.yaml
@@ -17,9 +17,21 @@ containerNameOverride: ''
 # @param strategy Deployment [strategy](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy). Undergoes template rendering
 # @param podAnnotations Kubernetes [pod annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/)
 # @param imagePullSecrets Kubernetes image pull secrets
-# @param podSecurityContext Kubernetes [pod security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/)
+# @param podSecurityContext.runAsNonRoot Indicates that the container must run as a non-root user
+# @param podSecurityContext.runAsUser The User ID (UID) to run the entrypoint of the container process
+# @param podSecurityContext.runAsGroup The primary Group ID (GID) for all processes in the container
+# @param podSecurityContext.fsGroup A special supplemental group ID applied to all volumes mounted by the pod
+# @param containerSecurityContext.privileged Runs the container in privileged mode (processes are essentially equivalent to root on the host)
+# @param containerSecurityContext.runAsNonRoot Forces the container to run as a non-root user
+# @param containerSecurityContext.runAsUser The User ID (UID) to run the container process
+# @param containerSecurityContext.runAsGroup The primary Group ID (GID) for the container process
+# @param containerSecurityContext.allowPrivilegeEscalation Controls whether a process can gain more privileges than its parent process
+# @param containerSecurityContext.readOnlyRootFilesystem Whether this container has a read-only root filesystem
+# @param containerSecurityContext.capabilities.drop The Linux capabilities to drop from the container
+# @param containerSecurityContext.seccompProfile.type The type of seccomp profile to apply (e.g., RuntimeDefault)
 # @param priorityClassName Kubernetes [Pod Priority](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#priorityclass) class name
 # @param terminationGracePeriodSeconds Maximum time allowed for graceful shutdown
+# @param hostAliases Kubernetes [host aliases](https://kubernetes.io/docs/tasks/network/customize-hosts-file-for-pods/)
 # @param nodeSelector Kubernetes [node selectors](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector)
 # @param affinity Kubernetes pod [affinity settings](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity)
 # @param tolerations Kubernetes [tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) settings
@@ -34,9 +46,26 @@ revisionHistoryLimit: 1
 strategy: {}
 podAnnotations: {}
 imagePullSecrets: []
-podSecurityContext: {}
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 10001
+  runAsGroup: 10002
+  fsGroup: 10001
+containerSecurityContext:
+  privileged: false
+  runAsNonRoot: true
+  runAsUser: 10001
+  runAsGroup: 10002
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop:
+      - ALL
+  seccompProfile:
+    type: RuntimeDefault
 priorityClassName: ''
 terminationGracePeriodSeconds: 60
+hostAliases: []
 nodeSelector: {}
 affinity: {}
 tolerations: []
@@ -143,11 +172,13 @@ ingress:
 # @param serviceAccount.create Specifies whether a service account should be created.
 # @param serviceAccount.annotations Annotations to add to the service account.
 # @param serviceAccount.name The name of the service account to use. If not set and create is true, a name is generated using the fullname template.
+# @param serviceAccount.automountServiceAccountToken Automount service account token.
 
 serviceAccount:
   create: true
   annotations: {}
   name: ''
+  automountServiceAccountToken: false
 
 
 # @section [CronJob](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/) settings
@@ -210,20 +241,24 @@ networkPolicy:
 
 # @section [HTTPRoute](https://gateway-api.sigs.k8s.io/api-types/httproute/) configuration
 
-# @param httpRoute.enabled If HTTPRoute is enabled for the service.
+# @param httpRoute.enabled If HTTPRoute is enabled for the service
+# @param httpRoute.annotations Kubernetes [annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/) for HTTPRoute.
+# @param httpRoute.labels Kubernetes [labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/) for HTTPRoute.
 # @param httpRoute.hostnames List of hostnames served by route
-# @extra httpRoute.parentRefs List of parent references (gateways) for HTTPRoute.
+# @extra httpRoute.parentRefs List of parent references (gateways) for HTTPRoute
 # @skip httpRoute.parentRefs[0].group
 # @skip httpRoute.parentRefs[0].kind
-# @param httpRoute.parentRefs[0].name Name for the first default parentRef
-# @param httpRoute.parentRefs[0].namespace Namespace for the first default parentRef
+# @param httpRoute.parentRefs[0].name Name for the first parentRef
+# @param httpRoute.parentRefs[0].namespace Namespace for the first parentRef
 # @skip httpRoute.parentRefs[1].group
 # @skip httpRoute.parentRefs[1].kind
-# @param httpRoute.parentRefs[1].name Name for the second default parentRef
-# @param httpRoute.parentRefs[1].namespace Namespace for the second default parentRef
+# @param httpRoute.parentRefs[1].name Name for the second parentRef
+# @param httpRoute.parentRefs[1].namespace Namespace for the second parentRef
 
 httpRoute:
   enabled: false
+  annotations: {}
+  labels: {}
   hostnames: []
   parentRefs:
     - group: gateway.networking.k8s.io
@@ -237,9 +272,33 @@ httpRoute:
 
 # @section [GRPCRoute](https://gateway-api.sigs.k8s.io/api-types/grpcroute/) configuration
 
+# @param grpcRoute.enabled If GRPCRoute is enabled for the service.
+# @param grpcRoute.annotations Kubernetes [annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/) for GRPCRoute.
+# @param grpcRoute.labels Kubernetes [labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/) for GRPCRoute.
 # @param grpcRoute.hostnames List of hostnames served by route
 # @param grpcRoute.port Destination grpcroute.spec.rules.backendRefs.port number, must be set if grpcRoute.enabled is true
+# @extra grpcRoute.parentRefs List of parent references (gateways) for GRPCRoute.
+# @skip grpcRoute.parentRefs[0].group
+# @skip grpcRoute.parentRefs[0].kind
+# @param grpcRoute.parentRefs[0].name Name for the first parentRef
+# @param grpcRoute.parentRefs[0].namespace Namespace for the first parentRef
+# @skip grpcRoute.parentRefs[1].group
+# @skip grpcRoute.parentRefs[1].kind
+# @param grpcRoute.parentRefs[1].name Name for the second parentRef
+# @param grpcRoute.parentRefs[1].namespace Namespace for the second parentRef
 
 grpcRoute:
+  enabled: false
+  annotations: {}
+  labels: {}
   hostnames: []
   port: null
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: canary
+      namespace: istio-gateways
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: stable
+      namespace: istio-gateways

--- a/charts/navi-async-matrix/README.md
+++ b/charts/navi-async-matrix/README.md
@@ -24,39 +24,42 @@ See the [documentation](https://docs.2gis.com/en/on-premise/navigation/distance-
 
 ### Common settings
 
-| Name                              | Description                                                                                                                 | Value  |
-| --------------------------------- | --------------------------------------------------------------------------------------------------------------------------- | ------ |
-| `replicaCount`                    | A replica count for the pod.                                                                                                | `1`    |
-| `imagePullSecrets`                | Kubernetes image pull secrets.                                                                                              | `[]`   |
-| `nameOverride`                    | Base name to use in all the Kubernetes entities deployed by this chart.                                                     | `""`   |
-| `fullnameOverride`                | Base fullname to use in all the Kubernetes entities deployed by this chart.                                                 | `""`   |
-| `podAnnotations`                  | Kubernetes [pod annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/).               | `{}`   |
-| `podLabels`                       | Kubernetes [pod labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/).                         | `{}`   |
-| `annotations`                     | Kubernetes [annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/).                   | `{}`   |
-| `labels`                          | Kubernetes [labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/).                             | `{}`   |
-| `podSecurityContext`              | Kubernetes [pod security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/).              | `{}`   |
-| `securityContext`                 | Kubernetes [security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/).                  | `{}`   |
-| `nodeSelector`                    | Kubernetes [node selectors](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector).         | `{}`   |
-| `tolerations`                     | Kubernetes [tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) settings.           | `[]`   |
-| `affinity`                        | Kubernetes pod [affinity settings](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity). | `{}`   |
-| `priorityClassName`               | Kubernetes [pod priority](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/).                | `""`   |
-| `terminationGracePeriodSeconds`   | Kubernetes [termination grace period](https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/).           | `60`   |
-| `prometheusEnabled`               | If Prometheus scrape is enabled.                                                                                            | `true` |
-| `livenessProbe.enabled`           | Enable livenessProbe.                                                                                                       | `true` |
-| `livenessProbe.periodSeconds`     | Period seconds for livenessProbe.                                                                                           | `15`   |
-| `livenessProbe.timeoutSeconds`    | Timeout seconds for livenessProbe.                                                                                          | `5`    |
-| `livenessProbe.failureThreshold`  | Failure threshold for livenessProbe.                                                                                        | `5`    |
-| `readinessProbe.enabled`          | Enable readinessProbe.                                                                                                      | `true` |
-| `readinessProbe.periodSeconds`    | Period seconds for readinessProbe.                                                                                          | `15`   |
-| `readinessProbe.timeoutSeconds`   | Timeout seconds for readinessProbe.                                                                                         | `5`    |
-| `readinessProbe.failureThreshold` | Failure threshold for readinessProbe.                                                                                       | `3`    |
-| `startupProbe.enabled`            | Enable startupProbe.                                                                                                        | `true` |
-| `startupProbe.periodSeconds`      | Period seconds for startupProbe.                                                                                            | `15`   |
-| `startupProbe.timeoutSeconds`     | Timeout seconds for startupProbe.                                                                                           | `5`    |
-| `startupProbe.failureThreshold`   | Failure threshold for startupProbe.                                                                                         | `60`   |
-| `customLivenessProbe`             | Override default liveness probe.                                                                                            | `{}`   |
-| `customReadinessProbe`            | Override default readiness probe.                                                                                           | `{}`   |
-| `customStartupProbe`              | Override default startup probe.                                                                                             | `{}`   |
+| Name                              | Description                                                                                                                 | Value   |
+| --------------------------------- | --------------------------------------------------------------------------------------------------------------------------- | ------- |
+| `replicaCount`                    | A replica count for the pod.                                                                                                | `1`     |
+| `imagePullSecrets`                | Kubernetes image pull secrets.                                                                                              | `[]`    |
+| `nameOverride`                    | Base name to use in all the Kubernetes entities deployed by this chart.                                                     | `""`    |
+| `fullnameOverride`                | Base fullname to use in all the Kubernetes entities deployed by this chart.                                                 | `""`    |
+| `podAnnotations`                  | Kubernetes [pod annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/).               | `{}`    |
+| `podLabels`                       | Kubernetes [pod labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/).                         | `{}`    |
+| `annotations`                     | Kubernetes [annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/).                   | `{}`    |
+| `labels`                          | Kubernetes [labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/).                             | `{}`    |
+| `podSecurityContext.runAsNonRoot` | Indicates that the container must run as a non-root user.                                                                   | `true`  |
+| `podSecurityContext.runAsUser`    | The User ID (UID) to run the entrypoint of the container process.                                                           | `10001` |
+| `podSecurityContext.runAsGroup`   | The primary Group ID (GID) for all processes in the container.                                                              | `10001` |
+| `podSecurityContext.fsGroup`      | A special supplemental group ID applied to all volumes mounted by the pod.                                                  | `10001` |
+| `securityContext`                 | Kubernetes [security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/).                  | `{}`    |
+| `nodeSelector`                    | Kubernetes [node selectors](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector).         | `{}`    |
+| `tolerations`                     | Kubernetes [tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) settings.           | `[]`    |
+| `affinity`                        | Kubernetes pod [affinity settings](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity). | `{}`    |
+| `priorityClassName`               | Kubernetes [pod priority](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/).                | `""`    |
+| `terminationGracePeriodSeconds`   | Kubernetes [termination grace period](https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/).           | `60`    |
+| `prometheusEnabled`               | If Prometheus scrape is enabled.                                                                                            | `true`  |
+| `livenessProbe.enabled`           | Enable livenessProbe.                                                                                                       | `true`  |
+| `livenessProbe.periodSeconds`     | Period seconds for livenessProbe.                                                                                           | `15`    |
+| `livenessProbe.timeoutSeconds`    | Timeout seconds for livenessProbe.                                                                                          | `5`     |
+| `livenessProbe.failureThreshold`  | Failure threshold for livenessProbe.                                                                                        | `5`     |
+| `readinessProbe.enabled`          | Enable readinessProbe.                                                                                                      | `true`  |
+| `readinessProbe.periodSeconds`    | Period seconds for readinessProbe.                                                                                          | `15`    |
+| `readinessProbe.timeoutSeconds`   | Timeout seconds for readinessProbe.                                                                                         | `5`     |
+| `readinessProbe.failureThreshold` | Failure threshold for readinessProbe.                                                                                       | `3`     |
+| `startupProbe.enabled`            | Enable startupProbe.                                                                                                        | `true`  |
+| `startupProbe.periodSeconds`      | Period seconds for startupProbe.                                                                                            | `15`    |
+| `startupProbe.timeoutSeconds`     | Timeout seconds for startupProbe.                                                                                           | `5`     |
+| `startupProbe.failureThreshold`   | Failure threshold for startupProbe.                                                                                         | `60`    |
+| `customLivenessProbe`             | Override default liveness probe.                                                                                            | `{}`    |
+| `customReadinessProbe`            | Override default readiness probe.                                                                                           | `{}`    |
+| `customStartupProbe`              | Override default startup probe.                                                                                             | `{}`    |
 
 ### Deployment settings
 

--- a/charts/navi-async-matrix/values.yaml
+++ b/charts/navi-async-matrix/values.yaml
@@ -15,7 +15,10 @@ dgctlDockerRegistry: ''
 # @param podLabels Kubernetes [pod labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/).
 # @param annotations Kubernetes [annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/).
 # @param labels Kubernetes [labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/).
-# @param podSecurityContext Kubernetes [pod security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/).
+# @param podSecurityContext.runAsNonRoot Indicates that the container must run as a non-root user.
+# @param podSecurityContext.runAsUser The User ID (UID) to run the entrypoint of the container process.
+# @param podSecurityContext.runAsGroup The primary Group ID (GID) for all processes in the container.
+# @param podSecurityContext.fsGroup A special supplemental group ID applied to all volumes mounted by the pod.
 # @param securityContext Kubernetes [security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/).
 # @param nodeSelector Kubernetes [node selectors](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector).
 # @param tolerations Kubernetes [tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) settings.
@@ -47,7 +50,11 @@ podAnnotations: {}
 podLabels: {}
 annotations: {}
 labels: {}
-podSecurityContext: {}
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 10001
+  runAsGroup: 10001
+  fsGroup: 10001
 securityContext: {}
 nodeSelector: {}
 tolerations: []

--- a/charts/navi-splitter/README.md
+++ b/charts/navi-splitter/README.md
@@ -25,23 +25,26 @@ See the [documentation](https://docs.2gis.com/en/on-premise/navigation) to learn
 
 ### Common settings
 
-| Name                            | Description                                                                                                                                  | Value |
-| ------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- | ----- |
-| `replicaCount`                  | A replica count for the pod.                                                                                                                 | `1`   |
-| `revisionHistoryLimit`          | Number of replica sets to keep for deployment rollbacks                                                                                      | `3`   |
-| `imagePullSecrets`              | Kubernetes image pull secrets.                                                                                                               | `[]`  |
-| `nameOverride`                  | Base name to use in all the Kubernetes entities deployed by this chart.                                                                      | `""`  |
-| `fullnameOverride`              | Base fullname to use in all the Kubernetes entities deployed by this chart.                                                                  | `""`  |
-| `navigroup`                     | Name of navigation deploy group.                                                                                                             | `""`  |
-| `podAnnotations`                | Kubernetes [pod annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/).                                | `{}`  |
-| `podSecurityContext`            | Kubernetes [pod security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/).                               | `{}`  |
-| `securityContext`               | Kubernetes [security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/).                                   | `{}`  |
-| `nodeSelector`                  | Kubernetes [node selectors](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector).                          | `{}`  |
-| `tolerations`                   | Kubernetes [tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) settings.                            | `[]`  |
-| `affinity`                      | Kubernetes pod [affinity settings](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity).                  | `{}`  |
-| `labels`                        | Custom labels to set to Deployment resource.                                                                                                 | `{}`  |
-| `preStopDelay`                  | Delay in seconds before terminating container.                                                                                               | `5`   |
-| `terminationGracePeriodSeconds` | Grace period for container shutdown, refer to [Pod Lifecycle](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/) for details | `60`  |
+| Name                              | Description                                                                                                                                  | Value   |
+| --------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| `replicaCount`                    | A replica count for the pod.                                                                                                                 | `1`     |
+| `revisionHistoryLimit`            | Number of replica sets to keep for deployment rollbacks                                                                                      | `3`     |
+| `imagePullSecrets`                | Kubernetes image pull secrets.                                                                                                               | `[]`    |
+| `nameOverride`                    | Base name to use in all the Kubernetes entities deployed by this chart.                                                                      | `""`    |
+| `fullnameOverride`                | Base fullname to use in all the Kubernetes entities deployed by this chart.                                                                  | `""`    |
+| `navigroup`                       | Name of navigation deploy group.                                                                                                             | `""`    |
+| `podAnnotations`                  | Kubernetes [pod annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/).                                | `{}`    |
+| `podSecurityContext.runAsNonRoot` | Indicates that the container must run as a non-root user.                                                                                    | `true`  |
+| `podSecurityContext.runAsUser`    | The User ID (UID) to run the entrypoint of the container process.                                                                            | `10001` |
+| `podSecurityContext.runAsGroup`   | The primary Group ID (GID) for all processes in the container.                                                                               | `10001` |
+| `podSecurityContext.fsGroup`      | A special supplemental group ID applied to all volumes mounted by the pod.                                                                   | `101`   |
+| `securityContext`                 | Kubernetes [security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/).                                   | `{}`    |
+| `nodeSelector`                    | Kubernetes [node selectors](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector).                          | `{}`    |
+| `tolerations`                     | Kubernetes [tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) settings.                            | `[]`    |
+| `affinity`                        | Kubernetes pod [affinity settings](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity).                  | `{}`    |
+| `labels`                          | Custom labels to set to Deployment resource.                                                                                                 | `{}`    |
+| `preStopDelay`                    | Delay in seconds before terminating container.                                                                                               | `5`     |
+| `terminationGracePeriodSeconds`   | Grace period for container shutdown, refer to [Pod Lifecycle](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/) for details | `60`    |
 
 ### Deployment settings
 

--- a/charts/navi-splitter/values.yaml
+++ b/charts/navi-splitter/values.yaml
@@ -13,7 +13,10 @@ dgctlDockerRegistry: ''
 # @param fullnameOverride Base fullname to use in all the Kubernetes entities deployed by this chart.
 # @param navigroup Name of navigation deploy group.
 # @param podAnnotations Kubernetes [pod annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/).
-# @param podSecurityContext Kubernetes [pod security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/).
+# @param podSecurityContext.runAsNonRoot Indicates that the container must run as a non-root user.
+# @param podSecurityContext.runAsUser The User ID (UID) to run the entrypoint of the container process.
+# @param podSecurityContext.runAsGroup The primary Group ID (GID) for all processes in the container.
+# @param podSecurityContext.fsGroup A special supplemental group ID applied to all volumes mounted by the pod.
 # @param securityContext Kubernetes [security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/).
 # @param nodeSelector Kubernetes [node selectors](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector).
 # @param tolerations Kubernetes [tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) settings.
@@ -29,7 +32,11 @@ nameOverride: ''
 fullnameOverride: ''
 navigroup: ''
 podAnnotations: {}
-podSecurityContext: {}
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 10001
+  runAsGroup: 10001
+  fsGroup: 101
 securityContext: {}
 nodeSelector: {}
 tolerations: []


### PR DESCRIPTION
# Pull Request description

## Changelog

- Убран хардкод grpcroute, добавлены лейблы и аннотации
- Если не определен defaultMode, то конфигмапы и секреты монтируются с defaultMode: 256
- По дефолту отключено монитирование токена в SA
- Добавлены hostAliases
- Добавлен _container_spec.yaml с containerSecurityContext
- Для сервисов добавлен appProtocol

## Issues

- https://jira.2gis.ru/browse/PLN-10386

## Breaking changes

- If there are breaking changes, they need to be added to the file [Breaking-Changes](../Breaking-Changes.md)

## Check-list. Чек-лист код-ревью

- [ ] Запрос на слияние в develop.
- [ ] Есть описание к PR.
- [ ] Указаны блокирующие изменения. [Breaking-Changes](../Breaking-Changes.md)
- [ ] Соответствие кода принятому [стилю](../styleguide.md)
  - [ ] Описание настроек.
  - [ ] Именование настроек.
  - [ ] Дефолтные значения.
  - [ ] Стиль кода.
- [ ] Работоспособность. Разворачивается на своем окружении из ветки PR.
  - [ ] Тест API через тесты helmfile-хуков или коллекций Postman.
- [ ] Не осталось мусора от удаления каких-то параметров. Ищется поиском по проекту из ветки PR.
- [ ] Отработка линтера на чарт из ветки PR. Пример: `helm lint charts/search-api`
