### PR TITLE
keys: add missing feature flags

### DIFF
--- a/charts/keys/templates/counter/statefulset.yaml
+++ b/charts/keys/templates/counter/statefulset.yaml
@@ -38,6 +38,7 @@ spec:
           resources:
             {{- toYaml .Values.counter.resources | nindent 12 }}
           env:
+            {{- include "keys.env.featureFlags" . | nindent 12 }}
             {{- include "keys.env.db.deploys" . | nindent 12 }}
             {{- include "keys.env.redis" . | nindent 12 }}
             {{- include "keys.env.counter" . | nindent 12 }}

--- a/charts/keys/templates/service-api/deployment.yaml
+++ b/charts/keys/templates/service-api/deployment.yaml
@@ -69,6 +69,7 @@ spec:
           env:
             - name: KEYS_LOG_LEVEL
               value: {{ .Values.serviceApi.logLevel | quote }}
+            {{- include "keys.env.featureFlags" . | nindent 12 }}
             {{- include "keys.env.db.deploys" . | nindent 12 }}
             {{- include "keys.env.redis" . | nindent 12 }}
             {{- include "keys.env.auditEnvMetadata" . | nindent 12 }}


### PR DESCRIPTION
# Pull Request description

## Changelog

- Добавлен пропущенный проброс фича-флагов в `counter` и в `service-api`.
   - Для `counter` это пока что ни на что не аффектило, но обязательно выстрелит в будущем.
   - Для `service-api`:
      - была поломана логика выставления уровня видимости - из-за этого каталог мог не отдавать некоторые сегменты,
      - не включалась подпись ответов Public API - флаг `featureFlags.enablePublicAPISign` не прокидывался из конфигурации в деплой.

## Issues

- Не заводили, фикс по результатам обсуждения.

## Breaking changes

- Ничего нет, просто починили поломанное в 2.4.0.

## Check-list. Чек-лист код-ревью

- [ ] Запрос на слияние в develop.
- [ ] Есть описание к PR.
- [ ] Указаны блокирующие изменения. [Breaking-Changes](../Breaking-Changes.md)
- [ ] Соответствие кода принятому [стилю](../styleguide.md)
  - [ ] Описание настроек.
  - [ ] Именование настроек.
  - [ ] Дефолтные значения.
  - [ ] Стиль кода.
- [ ] Работоспособность. Разворачивается на своем окружении из ветки PR.
  - [ ] Тест API через тесты helmfile-хуков или коллекций Postman.
- [ ] Не осталось мусора от удаления каких-то параметров. Ищется поиском по проекту из ветки PR.
- [ ] Отработка линтера на чарт из ветки PR. Пример: `helm lint charts/search-api`
